### PR TITLE
ENH: extrapolate cls to smooth transforms

### DIFF
--- a/glass/random.py
+++ b/glass/random.py
@@ -58,33 +58,35 @@ def transform_cls(cls, tfm, nside=None):
     '''transform Cls to Gaussian Cls for simulation'''
 
     # maximum l in input cls
-    lmax = np.max([len(cl)-1 for cl in cls if cl is not None])
+    lmax = max(len(cl)-1 for cl in cls if cl is not None)
 
-    # map limit if nside is provided
+    # bandlimit if nside is provided
     llim = 3*nside - 1 if nside is not None else None
 
     # get pixel window function if nside is given, or set to unity
     if nside is not None:
+        log.info('using pixel window function for NSIDE=%d', nside)
         pw = hp.pixwin(nside, pol=False, lmax=llim)
+        pw *= pw
     else:
         pw = np.ones(lmax+1)
-
-    # the actual lmax is constrained by what the pixwin function can provide
-    lmax = len(pw) - 1
 
     # transform input cls to cls for the Gaussian random fields
     gaussian_cls = []
     for cl in cls:
         # only work on available cls
         if cl is not None:
-            # extrapolate the cl if possible
+            # extrapolate the cl if necessary
             if llim and llim >= len(cl):
+                log.info('exponentially decaying cl from %d to %d', len(cl)-1, llim)
                 cl = _exp_decay_cl(llim, cl)
 
             # simulating integrated maps by multiplying cls and pw
             # shorter array determines length
-            cl_len = min(len(cl), lmax+1)
-            cl = cl[:cl_len]*pw[:cl_len]
+            n = min(len(cl), len(pw))
+            cl = cl[:n]*pw[:n]
+
+            log.info('transforming cl with LMAX=%d', n-1)
 
             # transform the cl
             cl = tfm(cl)

--- a/glass/random.py
+++ b/glass/random.py
@@ -61,7 +61,7 @@ def transform_cls(cls, tfm, nside=None):
     lmax = np.max([len(cl)-1 for cl in cls if cl is not None])
 
     # map limit if nside is provided
-    llim = int(12**0.5*nside - 1) if nside is not None else None
+    llim = 3*nside - 1 if nside is not None else None
 
     # get pixel window function if nside is given, or set to unity
     if nside is not None:

--- a/glass/random.py
+++ b/glass/random.py
@@ -65,7 +65,7 @@ def transform_cls(cls, tfm, nside=None):
 
     # get pixel window function if nside is given, or set to unity
     if nside is not None:
-        pw = hp.pixwin(nside, pol=False, lmax=(llim or lmax))
+        pw = hp.pixwin(nside, pol=False, lmax=llim)
     else:
         pw = np.ones(lmax+1)
 

--- a/glass/random.py
+++ b/glass/random.py
@@ -61,7 +61,7 @@ def transform_cls(cls, tfm, nside=None):
     lmax = np.max([len(cl)-1 for cl in cls if cl is not None])
 
     # map limit if nside is provided
-    llim = 12**0.5*nside - 1 if nside is not None else None
+    llim = int(12**0.5*nside - 1) if nside is not None else None
 
     # get pixel window function if nside is given, or set to unity
     if nside is not None:

--- a/glass/random.py
+++ b/glass/random.py
@@ -61,6 +61,9 @@ def transform_cls(cls, tfm, nside=None):
     # the actual lmax is constrained by what the pixwin function can provide
     lmax = len(pw) - 1
 
+    # band limit if nside is provided
+    llim = 3*nside - 1 if nside is not None else None
+
     # transform input cls to cls for the Gaussian random fields
     gaussian_cls = []
     for cl in cls:
@@ -70,6 +73,10 @@ def transform_cls(cls, tfm, nside=None):
             # shorter array determines length
             cl_len = min(len(cl), lmax+1)
             cl = cl[:cl_len]*pw[:cl_len]
+
+            # pad the cls up to bandlimit if provided
+            if llim and llim > cl_len:
+                cl = np.pad(cl, (0, llim-cl_len))
 
             # transform the cl
             cl = tfm(cl)


### PR DESCRIPTION
This PR add extrapolates cls to the bandlimit with an exponential decay. This smoothes the transforms when the lmax of the input is below the bandlimit. For lmax below ~2nside or so, the lognormal realisations should realise the input cls more or less exactly.

This PR also fixes the pixel window function.