### PR TITLE
ENH: do not integrate matter fields

### DIFF
--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -62,7 +62,7 @@ import numpy as np
 import healpy as hp
 
 from .generator import receives, yields
-from .util import ARCMIN2_SPHERE, restrict_interval, cumtrapz, triaxial_axis_ratio
+from .util import ARCMIN2_SPHERE, restrict_interval, cumtrapz, triaxial_axis_ratio, hp_integrate
 
 
 log = logging.getLogger(__name__)
@@ -310,7 +310,7 @@ def gal_dist_fullsky(z, dndz, bz=None, *, bias='log-linear', rng=None):
             log.info('no galaxies, skipping...')
             continue
 
-        # normalise the number densities to get propability densities
+        # normalise the number densities to get probability densities
         dndz_ /= np.where(p > 0, p, 1)[..., np.newaxis]
 
         # normalise to get probability to find galaxy in each population
@@ -326,8 +326,10 @@ def gal_dist_fullsky(z, dndz, bz=None, *, bias='log-linear', rng=None):
 
         # compute the distribution of the galaxies
         # first, compute the galaxy overdensity using the bias function
-        # then, modifying the array in place, turn into number count
+        # second, average overdensity over HEALPix pixels
+        # third, modifying the array in place, turn into number count
         dist = bf(delta, zbar)
+        dist = hp_integrate(dist)
         dist += 1
         dist *= ARCMIN2_SPHERE/np.shape(dist)[-1]*ntot
 

--- a/glass/random.py
+++ b/glass/random.py
@@ -78,19 +78,8 @@ def multalm(alm, bl, inplace=False):
 def transform_cls(cls, tfm, nside=None):
     '''transform Cls to Gaussian Cls for simulation'''
 
-    # maximum l in input cls
-    lmax = max(len(cl)-1 for cl in cls if cl is not None)
-
     # bandlimit if nside is provided
     llim = 3*nside - 1 if nside is not None else None
-
-    # get pixel window function if nside is given, or set to unity
-    if nside is not None:
-        log.info('using pixel window function for NSIDE=%d', nside)
-        pw = hp.pixwin(nside, pol=False, lmax=llim)
-        pw *= pw
-    else:
-        pw = np.ones(lmax+1)
 
     # transform input cls to cls for the Gaussian random fields
     gaussian_cls = []
@@ -102,12 +91,7 @@ def transform_cls(cls, tfm, nside=None):
                 log.info('exponentially decaying cl from %d to %d', len(cl)-1, llim)
                 cl = _exp_decay_cl(llim, cl)
 
-            # simulating integrated maps by multiplying cls and pw
-            # shorter array determines length
-            n = min(len(cl), len(pw))
-            cl = cl[:n]*pw[:n]
-
-            log.info('transforming cl with LMAX=%d', n-1)
+            log.info('transforming cl with LMAX=%d', len(cl)-1)
 
             # transform the cl
             cl = tfm(cl)

--- a/glass/util.py
+++ b/glass/util.py
@@ -3,6 +3,7 @@
 '''module for implementation utilities'''
 
 import numpy as np
+import healpy as hp
 
 # constants
 DEGREE2_SPHERE = 60**4//100/np.pi
@@ -111,3 +112,11 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
     q = np.sqrt((A+C-np.sqrt((A-C)**2+B2))/(A+C+np.sqrt((A-C)**2+B2)))
 
     return q
+
+
+def hp_integrate(m, nside=None, lmax=None):
+    '''integrate pixels of a HEALPix map in harmonic space'''
+    if nside is None:
+        nside = hp.get_nside(m)
+    alm = hp.map2alm(m, lmax=lmax, pol=False, use_pixel_weights=True)
+    return hp.alm2map(alm, nside, lmax=lmax, pixwin=True, inplace=True)


### PR DESCRIPTION
Closes #26 by removing the pixel window function from the random generation of the matter fields.  This fixes the spurious integration in the weak lensing fields.  Instead, the galaxy density is integrated after the galaxy bias has been applied to the matter field.