### PR TITLE
ENH: User functions to save and load Cls

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -114,7 +114,7 @@ def transform_cls(cls, tfm, pars=()):
     '''Transform Cls to Gaussian Cls.'''
     gls = []
     for cl in cls:
-        if cl is not None:
+        if cl is not None and len(cl) > 0:
             if cl[0] == 0:
                 monopole = 0.
             else:
@@ -123,7 +123,7 @@ def transform_cls(cls, tfm, pars=()):
             if info == 0:
                 warnings.warn('Gaussian cl did not converge, inexact transform')
         else:
-            gl = None
+            gl = []
         gls.append(gl)
     return gls
 
@@ -142,14 +142,14 @@ def gaussian_gls(cls, *, lmax=None, ncorr=None, nside=None):
         n = int((2*len(cls))**0.5)
         if n*(n+1)//2 != len(cls):
             raise ValueError('length of cls array is not a triangle number')
-        cls = [cls[i*(i+1)//2+j] if j <= ncorr else None for i in range(n) for j in range(i+1)]
+        cls = [cls[i*(i+1)//2+j] if j <= ncorr else [] for i in range(n) for j in range(i+1)]
 
     if nside is not None:
         pw = hp.pixwin(nside, lmax=lmax)
 
     gls = []
     for cl in cls:
-        if cl is not None:
+        if cl is not None and len(cl) > 0:
             if lmax is not None:
                 cl = cl[:lmax+1]
             if nside is not None:

--- a/glass/user.py
+++ b/glass/user.py
@@ -9,13 +9,27 @@ User utilities (:mod:`glass.user`)
 The :mod:`glass.user` module contains convenience functions for users of the
 library.
 
+
+Input and output
+----------------
+
 .. autosummary::
-   :template: generator.rst
    :toctree: generated/
    :nosignatures:
 
-    Profiler
-    profile
+   save_cls
+   load_cls
+
+
+Profiling
+---------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   Profiler
+   profile
 
 '''
 
@@ -24,8 +38,35 @@ import time
 import tracemalloc
 from datetime import timedelta
 from contextlib import contextmanager
+import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+def save_cls(filename, cls):
+    '''Save a list of Cls to file.
+
+    Uses :func:`numpy.savez` internally. The filename should therefore have a
+    ``.npz`` suffix, or it will be given one.
+
+    '''
+
+    split = np.cumsum([len(cl) if cl is not None else 0 for cl in cls[:-1]])
+    values = np.concatenate([cl for cl in cls if cl is not None])
+    np.savez(filename, values=values, split=split)
+
+
+def load_cls(filename):
+    '''Load a list of Cls from file.
+
+    Uses :func:`numpy.load` internally.
+
+    '''
+
+    with np.load(filename) as npz:
+        values = npz['values']
+        split = npz['split']
+    return np.split(values, split)
 
 
 def _memf(n: int):


### PR DESCRIPTION
Adds two functions `save_cls` and `load_cls` to `glass.user` that can save and load the GLASS cls format as numpy arrays.  They do so by concatenating all cls into a single array of values, and keeping track of the necessary splits to return the concatenated array to the original list. Both are stored in a npz file.

Also changes some functions to use an empty list instead of `None` for missing Cls.