### PR TITLE
DOC: Changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+Changelog
+=========
+
+All notable changes to the project are documented in this file.  The format is
+based on [Keep a Changelog](https://keepachangelog.com).
+
+
+[Unreleased]
+------------
+
+### Added
+
+- User functions to save and load Cls
+- This changelog added to keep track of changes between versions
+
+
+### Changed
+
+- Some type hints added to library functions
+
+
+[2023.1] - 2023-01-31
+---------------------
+
+### Added
+
+- Initial wide release for GLASS paper
+
+
+[Unreleased]: https://github.com/glass-dev/glass/compare/v2023.1...HEAD
+[2023.1]: https://github.com/glass-dev/glass/releases/tag/v2023.1

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -6,5 +6,6 @@ User guide
    :maxdepth: 2
 
    getting_started
+   releases
    extensions
    definitions

--- a/docs/user/releases.rst
+++ b/docs/user/releases.rst
@@ -1,0 +1,20 @@
+
+=============
+Release notes
+=============
+
+These notes document the changes between individual *GLASS* releases.
+
+
+2023.1 (31 Jan 2023)
+====================
+
+Added
+-----
+
+- **Initial wide release for GLASS paper**
+
+  This was the initial full release of *GLASS*, coinciding with the release of
+  preprint `arXiv:2302.01942`__.
+
+  __ https://arxiv.org/abs/2302.01942


### PR DESCRIPTION
To keep track of the changes between GLASS releases, this PR adds a [changelog](https://keepachangelog.com) to the repository, and a "release notes" page to the documentation.