### PR TITLE
DOC: remove Gitter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2302.01942-red)](https://arxiv.org/abs/2302.01942)
 [![adsabs](https://img.shields.io/badge/ads-2023arXiv230201942T-blueviolet)](https://ui.adsabs.harvard.edu/abs/2023arXiv230201942T)
 [![doi](https://img.shields.io/badge/doi-10.48550/arXiv.2302.01942-blue)](https://dx.doi.org/10.48550/arXiv.2302.01942)
-[![Gitter](https://badges.gitter.im/glass-dev/glass.svg)](https://gitter.im/glass-dev/glass)
 [![Slack](https://img.shields.io/badge/join-Slack-4A154B)](https://glass-dev.github.io/slack)
 
 This is the core library for GLASS, the Generator for Large Scale Structure.
@@ -43,16 +42,10 @@ The best way to get help about the code is currently to get in touch.
 If you would like to start a discussion with the wider GLASS community about
 e.g. a design decision or API change, you can use our [Discussions] page.
 
-If you are running into problems, suspect a bug, or have a quick question, you
-can chat on our [Gitter channel].
-
-If you are looking for a longer, asynchronous discussion, e.g. about
-implementing new models or creating extensions, you can join our [Slack
-workspace].
+We also have a public [Slack workspace] for discussions about the project.
 
 
 [documentation]: https://glass.readthedocs.io/
 [examples]: https://glass.readthedocs.io/projects/examples/
 [Discussions]: https://github.com/orgs/glass-dev/discussions
-[Gitter channel]: https://gitter.im/glass-dev/glass
 [Slack workspace]: https://glass-dev.github.io/slack

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -46,13 +46,6 @@ e.g. a design decision or API change, you can use our Discussions__ page.
 
 __ https://github.com/orgs/glass-dev/discussions
 
-If you are running into problems, suspect a bug, or have a quick question, you
-can chat on our `Gitter channel`__.
-
-__ https://gitter.im/glass-dev/glass
-
-If you are looking for a longer, asynchronous discussion, e.g. about
-implementing new models or creating extensions, you can join our `Slack
-workspace`__.
+We also have a public `Slack workspace`__ for discussions about the project.
 
 __ https://glass-dev.github.io/slack


### PR DESCRIPTION
Remove links to Gitter due to its recent migration to a service that isn't as easy to use as before.

We can add an alternative at some point in the future, if one emerges.