### PR TITLE
API: universal support for array types

### DIFF
--- a/glass/_array_api/cupy.py
+++ b/glass/_array_api/cupy.py
@@ -1,0 +1,3 @@
+'''cupy array namespace for GLASS'''
+
+from array_api_compat.cupy import *  # noqa

--- a/glass/_array_api/numpy.py
+++ b/glass/_array_api/numpy.py
@@ -1,0 +1,3 @@
+'''numpy array namespace for GLASS'''
+
+from array_api_compat.numpy import *  # noqa

--- a/glass/_array_api/torch.py
+++ b/glass/_array_api/torch.py
@@ -1,0 +1,3 @@
+'''torch array namespace for GLASS'''
+
+from array_api_compat.torch import *  # noqa

--- a/glass/array.py
+++ b/glass/array.py
@@ -1,0 +1,79 @@
+# author: Nicolas Tessore <n.tessore@ucl.ac.uk>
+# license: MIT
+'''
+Universal array support (:mod:`glass.array`)
+============================================
+
+.. currentmodule:: glass.array
+
+The :mod:`glass.array` module provides support to write *GLASS* code that
+supports a variety of compatible array types.
+
+
+
+'''
+
+from contextlib import contextmanager
+from importlib import import_module
+from typing import Any, Union
+
+# these are underscored symbols which are to be exported from the namespace
+_EXPORT = ['__array_api_version__', '__array_namespace__']
+
+# placeholder type for an array namespace
+ArrayNamespace = Any
+
+# the currently used array namespace
+_NS: Union[ArrayNamespace, None] = None
+
+
+@contextmanager
+def _restore(ns: Union[ArrayNamespace, None]) -> Any:
+    '''context manager to restore a previous array namespace'''
+    try:
+        yield
+    finally:
+        use(ns)
+
+
+def use(ns: Union[str, ArrayNamespace]) -> Any:
+    '''Use the given array namespace.'''
+
+    global _NS
+
+    # store the previous namespace before it gets overwritten
+    old_ns = _NS
+
+    # set the new array namespace
+    if isinstance(ns, str):
+        # if the name of an array namespace was given, import it
+        try:
+            _NS = import_module(f'glass._array_api.{ns}')
+        except ModuleNotFoundError as exc:
+            raise ValueError(f'unknown array namespace "{ns}"') from exc
+    else:
+        # use the array namespace as given; could check type here
+        _NS = ns
+
+    # should check here that _NS really implements the protocol
+
+    # we will modify the globals directly to change available symbols
+    g = globals()
+
+    # unload the current array namespace from module
+    if old_ns is not None:
+        for name in old_ns.__dict__:
+            if name in _EXPORT or not name.startswith('_'):
+                g.pop(name, None)
+
+    # load the new array namespace into module
+    for name, obj in _NS.__dict__.items():
+        if name in _EXPORT or not name.startswith('_'):
+            g[name] = obj
+
+    # for use as a context manager
+    return _restore(old_ns)
+
+
+# use the numpy array namespace by default
+use('numpy')

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 [options]
 python_requires = >=3.6
 install_requires =
+    array_api_compat>=1.1
     numpy
     healpix>=2022.11.1
     healpy>=1.15.0


### PR DESCRIPTION
This change introduces a `glass.array` module which can be imported as the array namespace:

    import glass.array as xp

By default, that loads the numpy array namespace, so that `xp` is mostly equivalent to the usual `np`.

However, the `glass.array` module has a function `use` for switching to a different array namespace internally:

    xp.use('numpy')  # default
    xp.use('cupy')
    xp.use('torch')

This can also be done locally using the context manager-form of the same command:

    with xp.use('torch'):
        ...

Internally, the `array-api-compat` package is used to load the various array namespaces into modules `glass._array_api.<name>`.  These modules can be extended with functionality for GLASS, such as e.g. a spherical harmonic transform that supports the array type.

The `glass._array_api` module should also be a namespace package, so that we can have extensions which add support for other array types, e.g. `glass-jax`.