### PR TITLE
API(points): support for array inputs

### DIFF
--- a/glass/points.py
+++ b/glass/points.py
@@ -87,41 +87,55 @@ def positions_from_delta(ngal, delta, bias=None, vis=None, *,
                          bias_model='linear', remove_monopole=False, rng=None):
     '''Generate positions tracing a density contrast.
 
-    The map of expected number counts is constructed from the number density,
-    density contrast, an optional bias model, and an optional visibility map.
+    The map of expected number counts is constructed from the number
+    density, density contrast, an optional bias model, and an optional
+    visibility map.
 
-    If ``remove_monopole`` is set, the monopole of the computed density contrast
-    is removed.  Over the full sky, the mean number density of the map will then
-    match the given number density exactly.  This, however, means that an
-    effectively different bias model is being used, unless the monopole is
-    already zero in the first place.
+    If ``remove_monopole`` is set, the monopole of the computed density
+    contrast is removed.  Over the full sky, the mean number density of
+    the map will then match the given number density exactly.  This,
+    however, means that an effectively different bias model is being
+    used, unless the monopole is already zero in the first place.
+
+    The function supports multi-dimensional input for the ``ngal``,
+    ``delta``, ``bias``, and ``vis`` parameters.  Leading axes are
+    broadcast to the same shape, and treated as separate populations of
+    points, which are sampled independently.
 
     Parameters
     ----------
-    ngal : float
+    ngal : float or array_like
         Number density, expected number of points per arcmin2.
     delta : array_like
-        Map of the input density contrast.  This is fed into the bias model to
-        produce the density contrast for sampling.
-    bias : float, optional
+        Map of the input density contrast.  This is fed into the bias
+        model to produce the density contrast for sampling.
+    bias : float or array_like, optional
         Bias parameter, is passed as an argument to the bias model.
     vis : array_like, optional
-        Visibility map for the observed points.  This is multiplied with the
-        full sky number count map, and must hence be of compatible shape.
+        Visibility map for the observed points.  This is multiplied with
+        the full sky number count map, and must hence be of compatible
+        shape.
     bias_model : str or callable, optional
-        The bias model to apply.  If a string, refers to a function in the
-        points module, e.g. ``'linear'`` for ``glass.points.linear_bias`` or
-        ``'loglinear'`` for ``glass.points.loglinear_bias``.
+        The bias model to apply.  If a string, refers to a function in
+        the :mod:`~glass.points` module, e.g. ``'linear'`` for
+        :func:`linear_bias()` or ``'loglinear'`` for
+        :func:`loglinear_bias`.
     remove_monopole : bool, optional
-        If true, the monopole of the density contrast after biasing is fixed to
-        zero.
+        If true, the monopole of the density contrast after biasing is
+        fixed to zero.
     rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be used.
+        Random number generator.  If not given, a default RNG is used.
 
     Returns
     -------
-    lon, lat : array_like
-        Columns of longitudes and latitudes for the sampled points.
+    lon, lat : array_like or list of array_like
+        Columns of longitudes and latitudes for the sampled points.  For
+        multi-dimensional inputs, 1-D lists of points corresponding to
+        the flattened leading dimensions are returned.
+    count : int or list of ints
+        The number of sampled points.  For multi-dimensional inputs, a
+        1-D list of counts corresponding to the flattened leading
+        dimensions is returned.
 
     '''
 
@@ -135,71 +149,114 @@ def positions_from_delta(ngal, delta, bias=None, vis=None, *,
     elif not callable(bias_model):
         raise ValueError('bias_model must be string or callable')
 
-    # compute density contrast from bias model, or copy
-    if bias is None:
-        n = np.copy(delta)
-    else:
-        n = bias_model(delta, bias)
-
-    # remove monopole if asked to
-    if remove_monopole:
-        n -= np.mean(n, keepdims=True)
-
-    # turn into number count, modifying the array in place
-    n += 1
-    n *= ARCMIN2_SPHERE/n.size*ngal
-
-    # apply visibility if given
+    # figure out a common shape for inputs' leading dimensions
+    *delta_dims, delta_npix = np.shape(delta)
+    input_dims = [np.shape(ngal), delta_dims]
+    if bias is not None:
+        input_dims += [np.shape(bias)]
     if vis is not None:
-        n *= vis
+        *vis_dims, vis_npix = np.shape(vis)
+        input_dims += [vis_dims]
+    dims = np.broadcast_shapes(*input_dims)
 
-    # clip number density at zero
-    np.clip(n, 0, None, out=n)
+    # broadcast inputs to common shape of leading dimensions
+    ngal = np.broadcast_to(ngal, dims)
+    delta = np.broadcast_to(delta, dims + (delta_npix,))
+    if bias is not None:
+        bias = np.broadcast_to(bias, dims)
+    if vis is not None:
+        vis = np.broadcast_to(vis, dims + (vis_npix,))
 
-    # sample actual number in each pixel
-    n = rng.poisson(n)
+    # keep track of results for each leading dimensions
+    lons, lats, counts = [], [], []
 
-    # total number of sampled points
-    ntot = n.sum()
+    # iterate the leading dimensions
+    for k in np.ndindex(dims):
 
-    # for converting randomly sampled positions to HEALPix indices
-    npix = n.shape[-1]
-    nside = healpix.npix2nside(npix)
+        # compute density contrast from bias model, or copy
+        if bias is None:
+            n = np.copy(delta[k])
+        else:
+            n = bias_model(delta[k], bias[k])
 
-    # these will hold the results
-    lon = np.empty(ntot)
-    lat = np.empty(ntot)
+        # remove monopole if asked to
+        if remove_monopole:
+            n -= np.mean(n, keepdims=True)
 
-    # sample batches of 10000 pixels
-    batch = 10_000
-    ncur = 0
-    for i in range(0, npix, batch):
-        k = n[i:i+batch]
-        bpix = np.repeat(np.arange(i, i+k.size), k)
-        blon, blat = healpix.randang(nside, bpix, lonlat=True, rng=rng)
-        lon[ncur:ncur+blon.size] = blon
-        lat[ncur:ncur+blat.size] = blat
-        ncur += bpix.size
+        # turn into number count, modifying the array in place
+        n += 1
+        n *= ARCMIN2_SPHERE/n.size*ngal[k]
 
-    assert ncur == ntot, 'internal error in sampling'
+        # apply visibility if given
+        if vis is not None:
+            n *= vis[k]
 
-    return lon, lat
+        # clip number density at zero
+        np.clip(n, 0, None, out=n)
+
+        # sample actual number in each pixel
+        n = rng.poisson(n)
+
+        # total number of sampled points
+        ntot = n.sum()
+
+        # for converting randomly sampled positions to HEALPix indices
+        npix = n.shape[-1]
+        nside = healpix.npix2nside(npix)
+
+        # these will hold the results
+        lon = np.empty(ntot)
+        lat = np.empty(ntot)
+
+        # sample batches of 10000 pixels
+        batch = 10_000
+        ncur = 0
+        for i in range(0, npix, batch):
+            k = n[i:i+batch]
+            bpix = np.repeat(np.arange(i, i+k.size), k)
+            blon, blat = healpix.randang(nside, bpix, lonlat=True, rng=rng)
+            lon[ncur:ncur+blon.size] = blon
+            lat[ncur:ncur+blat.size] = blat
+            ncur += bpix.size
+
+        assert ncur == ntot, 'internal error in sampling'
+
+        # store results
+        lons.append(lon)
+        lats.append(lat)
+        counts.append(ntot)
+
+    # do not return lists if there were no leading dimensions
+    if dims:
+        result = lons, lats, counts
+    else:
+        result = lons[0], lats[0], counts[0]
+
+    return result
 
 
 def uniform_positions(ngal, *, rng=None):
     '''Generate positions uniformly over the sphere.
 
+    The function supports array input for the ``ngal`` parameter.
+
     Parameters
     ----------
-    ngal : float
+    ngal : float or array_like
         Number density, expected number of positions per arcmin2.
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG will be used.
 
     Returns
     -------
-    lon, lat : array_like
-        Columns of longitudes and latitudes for the sampled points.
+    lon, lat : array_like or list of array_like
+        Columns of longitudes and latitudes for the sampled points.  For
+        array inputs, 1-D lists of points corresponding to the
+        flattened array dimensions are returned.
+    count : int or list of ints
+        The number of sampled points.  For array inputs, a 1-D list of
+        counts corresponding to the flattened array dimensions is
+        returned.
 
     '''
 
@@ -208,10 +265,33 @@ def uniform_positions(ngal, *, rng=None):
         rng = np.random.default_rng()
 
     # sample number of galaxies
-    ntot = rng.poisson(ARCMIN2_SPHERE*ngal)
+    ntot = rng.poisson(np.multiply(ARCMIN2_SPHERE, ngal))
 
-    # sample uniformly over the sphere
-    lon = rng.uniform(-180, 180, size=ntot)
-    lat = np.rad2deg(np.arcsin(rng.uniform(-1, 1, size=ntot)))
+    # extra dimensions of the output
+    dims = np.shape(ntot)
 
-    return lon, lat
+    # make sure ntot is an array even if scalar
+    ntot = np.broadcast_to(ntot, dims)
+
+    # arrays for results
+    lons, lats, counts = [], [], []
+
+    # sample each set of points
+    for k in np.ndindex(dims):
+
+        # sample uniformly over the sphere
+        lon = rng.uniform(-180, 180, size=ntot[k])
+        lat = np.rad2deg(np.arcsin(rng.uniform(-1, 1, size=ntot[k])))
+
+        # store results
+        lons.append(lon)
+        lats.append(lat)
+        counts.append(ntot[k])
+
+    # do not return lists if there were no leading dimensions
+    if dims:
+        result = lons, lats, counts
+    else:
+        result = lons[0], lats[0], counts[0]
+
+    return result

--- a/glass/test/test_points.py
+++ b/glass/test/test_points.py
@@ -1,0 +1,108 @@
+def test_positions_from_delta():
+    import numpy as np
+    from glass.points import positions_from_delta
+
+    # case 1: test single-dimensional input
+
+    ngal = 1e-3
+    delta = np.zeros(12)
+    bias = 0.8
+    vis = np.ones(12)
+
+    lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
+
+    assert isinstance(cnt, np.integer)
+    assert lon.shape == lat.shape == (cnt,)
+
+    # case 2: test multi-dimensional ngal
+
+    ngal = [1e-3, 2e-3]
+    delta = np.zeros(12)
+    bias = 0.8
+    vis = np.ones(12)
+
+    lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
+
+    assert isinstance(cnt, list)
+    assert isinstance(lon, list)
+    assert isinstance(lat, list)
+    assert len(cnt) == len(lon) == len(lat) == 2
+    for i, c in enumerate(cnt):
+        assert isinstance(c, np.integer)
+        assert lon[i].shape == lat[i].shape == (c,)
+
+    # case 3: test multi-dimensional delta
+
+    ngal = 1e-3
+    delta = np.zeros((2, 12))
+    bias = 0.8
+    vis = np.ones(12)
+
+    lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
+
+    assert isinstance(cnt, list)
+    assert isinstance(lon, list)
+    assert isinstance(lat, list)
+    assert len(cnt) == len(lon) == len(lat) == 2
+    for i, c in enumerate(cnt):
+        assert isinstance(c, np.integer)
+        assert lon[i].shape == lat[i].shape == (c,)
+
+    # case 4: test multi-dimensional broadcasting
+
+    ngal = [1e-3, 2e-3]
+    delta = np.zeros((3, 1, 12))
+    bias = 0.8
+    vis = np.ones(12)
+
+    lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
+
+    assert isinstance(cnt, list)
+    assert isinstance(lon, list)
+    assert isinstance(lat, list)
+    assert len(cnt) == len(lon) == len(lat) == 6
+    for i, c in enumerate(cnt):
+        assert isinstance(c, np.integer)
+        assert lon[i].shape == lat[i].shape == (c,)
+
+
+def test_uniform_positions():
+    import numpy as np
+    from glass.points import uniform_positions
+
+    # case 1: test scalar input
+
+    ngal = 1e-3
+
+    lon, lat, cnt = uniform_positions(ngal)
+
+    assert isinstance(cnt, np.integer)
+    assert lon.shape == lat.shape == (cnt,)
+
+    # case 2: test 1-D array input
+
+    ngal = [1e-3, 2e-3, 3e-3]
+
+    lon, lat, cnt = uniform_positions(ngal)
+
+    assert isinstance(cnt, list)
+    assert isinstance(lon, list)
+    assert isinstance(lat, list)
+    assert len(cnt) == len(lon) == len(lat) == 3
+    for i, c in enumerate(cnt):
+        assert isinstance(c, np.integer)
+        assert lon[i].shape == lat[i].shape == (c,)
+
+    # case 3: test 2-D array input
+
+    ngal = [[1e-3, 2e-3], [3e-3, 4e-3]]
+
+    lon, lat, cnt = uniform_positions(ngal)
+
+    assert isinstance(cnt, list)
+    assert isinstance(lon, list)
+    assert isinstance(lat, list)
+    assert len(cnt) == len(lon) == len(lat) == 4
+    for i, c in enumerate(cnt):
+        assert isinstance(c, np.integer)
+        assert lon[i].shape == lat[i].shape == (c,)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 [options]
 python_requires = >=3.6
 install_requires =
-    numpy
+    numpy>=1.20.0
     healpix>=2022.11.1
     healpy>=1.15.0
     cosmology>=2022.10.9


### PR DESCRIPTION
Allow dimensional input to the sampling functions in `glass.points`. In the language of the `glass.galaxies` module, leading dimensions would correspond to separate galaxy populations.

Numpy broadcasting rules are applied to the leading dimensions.

Since the sampling returns a potentially different number of points for each extra dimension, the return value for dimensional input is a 1-D list of points, corresponding to the flattened leading dimensions.

To simplify working with dimensional output, the sampling functions now always return a third value `counts` along with longitudes and latitudes, which is either an int or a list of ints.  Because the return values are different, this is a breaking change.

BREAKING CHANGE: Position sampling returns counts alongside points.

Fixes: #77