### PR TITLE
API(galaxies): change handling of array inputs and populations

### DIFF
--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -18,37 +18,46 @@ Functions
 
 '''
 
+from __future__ import annotations
+
 import numpy as np
 import healpix
 
-from typing import Optional, Tuple
+from typing import Optional
+from numpy.typing import ArrayLike
 
-from .math import cumtrapz
+from .math import broadcast_leading_axes, cumtrapz
 
 
-def redshifts_from_nz(size: int, z: np.ndarray, nz: np.ndarray, *,
-                      rng: Optional[np.random.Generator] = None
-                      ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+def redshifts_from_nz(count: int | ArrayLike, z: ArrayLike, nz: ArrayLike, *,
+                      rng: np.random.Generator | None = None
+                      ) -> np.ndarray | list[np.ndarray]:
     '''Generate galaxy redshifts from a source distribution.
+
+    The function supports multi-dimensional input if ``count`` is an
+    array or there are multiple axes in the ``z`` or ``nz`` arrays.  In
+    this case, the shape of ``count`` and the leading dimensions of
+    ``z`` and ``nz`` are broadcast into a common shape, and redshifts
+    are sampled independently for each dimension.  The return value is
+    then a list of redshift samples.
 
     Parameters
     ----------
-    size : int
-        Number of redshifts to sample.
+    count : int or array_like
+        Number of redshifts to sample.  If an array is given, its shape
+        is broadcast against the leading dimensions of ``z`` and ``nz``.
     z, nz : array_like
-        Source distribution.  Leading axes are treated as different
-        galaxy populations.
+        Source distribution.  Leading dimensions are broadcast against
+        the shape of ``count``.
     rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be
-        used.
+        Random number generator.  If not given, a default RNG is used.
 
     Returns
     -------
-    z : array_like
-        Redshifts sampled from the given source distribution.
-    pop : array_like or None
-        Index of the galaxy population from the leading axes of ``nz``;
-        or ``None`` if there are no galaxy populations.
+    redshifts : array_like or list of array_like
+        Redshifts sampled from the given source distribution.  If the input
+        was multi-dimensional, returns a 1-D list of samples corresponding
+        to the flattened input dimensions.
 
     '''
 
@@ -56,34 +65,29 @@ def redshifts_from_nz(size: int, z: np.ndarray, nz: np.ndarray, *,
     if rng is None:
         rng = np.random.default_rng()
 
-    # get galaxy populations
-    if np.ndim(nz) > 1:
-        pop = list(np.ndindex(np.shape(nz)[:-1]))
-    else:
-        pop = None
+    # bring inputs' leading axes into common shape
+    dims, count, z, nz = broadcast_leading_axes((count, 0), (z, 1), (nz, 1))
 
-    # compute the as-yet unnormalised CDF of each galaxy population
-    cdf = cumtrapz(nz, z)
+    # list of results for all dimensions
+    redshifts = np.empty(count.sum())
 
-    # compute probability to be in each galaxy population
-    p = cdf[..., -1]/cdf[..., -1].sum(axis=None, keepdims=True)
+    # keep track of the number of sampled redshifts
+    total = 0
 
-    # now normalise the CDFs
-    cdf /= cdf[..., -1:]
+    # go through extra dimensions; also works if dims is empty
+    for k in np.ndindex(dims):
 
-    # sample redshifts and populations
-    if pop is not None:
-        x = rng.choice(len(pop), p=p, size=size)
-        gal_z = rng.uniform(0, 1, size=size)
-        for i, j in enumerate(pop):
-            s = (x == i)
-            gal_z[s] = np.interp(gal_z[s], cdf[j], z)
-        gal_pop = np.take(pop, x)
-    else:
-        gal_z = np.interp(rng.uniform(0, 1, size=size), cdf, z)
-        gal_pop = None
+        # compute the CDF of each galaxy population
+        cdf = cumtrapz(nz[k], z[k], dtype=float)
+        cdf /= cdf[-1]
 
-    return gal_z, gal_pop
+        # sample redshifts and store result
+        redshifts[total:total+count[k]] = np.interp(rng.uniform(0, 1, size=count[k]), cdf, z[k])
+        total += count[k]
+
+    assert total == redshifts.size
+
+    return redshifts
 
 
 def galaxy_shear(lon: np.ndarray, lat: np.ndarray, eps: np.ndarray,

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -33,30 +33,30 @@ def redshifts_from_nz(count: int | ArrayLike, z: ArrayLike, nz: ArrayLike, *,
                       ) -> np.ndarray:
     '''Generate galaxy redshifts from a source distribution.
 
-    The function supports multi-dimensional input if ``count`` is an
-    array or there are multiple axes in the ``z`` or ``nz`` arrays.  In
-    this case, the shape of ``count`` and the leading dimensions of
-    ``z`` and ``nz`` are broadcast into a common shape, and redshifts
-    are sampled independently for each dimension.  The return value is
-    then a list of redshift samples.
+    The function supports sampling from multiple populations of
+    redshifts if ``count`` is an array or if there are additional axes
+    in the ``z`` or ``nz`` arrays.  In this case, the shape of ``count``
+    and the leading dimensions of ``z`` and ``nz`` are broadcast to a
+    common shape, and redshifts are sampled independently for each extra
+    dimension.  The results are concatenated into a flat array.
 
     Parameters
     ----------
     count : int or array_like
         Number of redshifts to sample.  If an array is given, its shape
-        is broadcast against the leading dimensions of ``z`` and ``nz``.
+        is broadcast against the leading axes of ``z`` and ``nz``.
     z, nz : array_like
-        Source distribution.  Leading dimensions are broadcast against
-        the shape of ``count``.
+        Source distribution.  Leading axes are broadcast against the
+        shape of ``count``.
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
     Returns
     -------
-    redshifts : array_like or list of array_like
-        Redshifts sampled from the given source distribution.  If the input
-        was multi-dimensional, returns a 1-D list of samples corresponding
-        to the flattened input dimensions.
+    redshifts : array_like
+        Redshifts sampled from the given source distribution.  For
+        inputs with extra dimensions, returns a flattened 1-D array of
+        samples from all populations.
 
     '''
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -34,20 +34,20 @@ def redshifts_from_nz(count: int | ArrayLike, z: ArrayLike, nz: ArrayLike, *,
     '''Generate galaxy redshifts from a source distribution.
 
     The function supports sampling from multiple populations of
-    redshifts if ``count`` is an array or if there are additional axes
-    in the ``z`` or ``nz`` arrays.  In this case, the shape of ``count``
-    and the leading dimensions of ``z`` and ``nz`` are broadcast to a
-    common shape, and redshifts are sampled independently for each extra
-    dimension.  The results are concatenated into a flat array.
+    redshifts if *count* is an array or if there are additional axes in
+    the *z* or *nz* arrays.  In this case, the shape of *count* and the
+    leading dimensions of *z* and *nz* are broadcast to a common shape,
+    and redshifts are sampled independently for each extra dimension.
+    The results are concatenated into a flat array.
 
     Parameters
     ----------
     count : int or array_like
         Number of redshifts to sample.  If an array is given, its shape
-        is broadcast against the leading axes of ``z`` and ``nz``.
+        is broadcast against the leading axes of *z* and *nz*.
     z, nz : array_like
         Source distribution.  Leading axes are broadcast against the
-        shape of ``count``.
+        shape of *count*.
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
@@ -166,7 +166,7 @@ def gaussian_phz(z: ArrayLike, sigma_0: float | ArrayLike,
     -------
     phz : array_like
         Photometric redshifts assuming Gaussian errors, of the same
-        shape as ``z``.
+        shape as *z*.
 
     See Also
     --------

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -31,7 +31,7 @@ from .math import broadcast_leading_axes, cumtrapz
 
 def redshifts_from_nz(count: int | ArrayLike, z: ArrayLike, nz: ArrayLike, *,
                       rng: np.random.Generator | None = None
-                      ) -> np.ndarray | list[np.ndarray]:
+                      ) -> np.ndarray:
     '''Generate galaxy redshifts from a source distribution.
 
     The function supports multi-dimensional input if ``count`` is an

--- a/glass/math.py
+++ b/glass/math.py
@@ -65,11 +65,11 @@ def trapz_product(f, *ff, axis=-1):
     return np.trapz(y, x, axis=axis)
 
 
-def cumtrapz(f, x, out=None):
+def cumtrapz(f, x, dtype=None, out=None):
     '''cumulative trapezoidal rule along last axis'''
 
     if out is None:
-        out = np.empty_like(f)
+        out = np.empty_like(f, dtype=dtype)
 
     np.cumsum((f[..., 1:] + f[..., :-1])/2*np.diff(x), axis=-1, out=out[..., 1:])
     out[..., 0] = 0

--- a/glass/test/test_galaxies.py
+++ b/glass/test/test_galaxies.py
@@ -70,3 +70,71 @@ def test_redshifts_from_nz():
 
     with pytest.raises(ValueError):
         redshifts_from_nz(count, z, nz)
+
+
+def test_gaussian_phz():
+    import numpy as np
+    from glass.galaxies import gaussian_phz
+
+    # test sampling
+
+    # case: zero variance
+
+    z = np.linspace(0, 1, 100)
+    sigma_0 = 0.
+
+    phz = gaussian_phz(z, sigma_0)
+
+    np.testing.assert_array_equal(z, phz)
+
+    # case: truncated normal
+
+    z = 0.
+    sigma_0 = np.ones(100)
+
+    phz = gaussian_phz(z, sigma_0)
+
+    assert phz.shape == (100,)
+    assert np.all(phz >= 0)
+
+    # test interface
+
+    # case: scalar redshift, scalar sigma_0
+
+    z = 1.
+    sigma_0 = 0.
+
+    phz = gaussian_phz(z, sigma_0)
+
+    assert np.ndim(phz) == 0
+    assert phz == z
+
+    # case: array redshift, scalar sigma_0
+
+    z = np.linspace(0, 1, 10)
+    sigma_0 = 0.
+
+    phz = gaussian_phz(z, sigma_0)
+
+    assert phz.shape == (10,)
+    np.testing.assert_array_equal(z, phz)
+
+    # case: scalar redshift, array sigma_0
+
+    z = 1.
+    sigma_0 = np.zeros(10)
+
+    phz = gaussian_phz(z, sigma_0)
+
+    assert phz.shape == (10,)
+    np.testing.assert_array_equal(z, phz)
+
+    # case: array redshift, array sigma_0
+
+    z = np.linspace(0, 1, 10)
+    sigma_0 = np.zeros((11, 1))
+
+    phz = gaussian_phz(z, sigma_0)
+
+    assert phz.shape == (11, 10)
+    np.testing.assert_array_equal(np.broadcast_to(z, (11, 10)), phz)

--- a/glass/test/test_galaxies.py
+++ b/glass/test/test_galaxies.py
@@ -1,0 +1,72 @@
+import pytest
+
+
+def test_redshifts_from_nz():
+    import numpy as np
+    from glass.galaxies import redshifts_from_nz
+
+    # test sampling
+
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0])
+    assert np.all((0 <= redshifts) & (redshifts <= 1))
+
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 0, 0])
+    assert np.all((1 <= redshifts) & (redshifts <= 3))
+
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 0, 0, 1])
+    assert np.all((3 <= redshifts) & (redshifts <= 4))
+
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 1, 1])
+    assert not np.any(redshifts <= 1)
+
+    # test interface
+
+    # case: no extra dimensions
+
+    count = 10
+    z = np.linspace(0, 1, 100)
+    nz = z*(1-z)
+
+    redshifts = redshifts_from_nz(count, z, nz)
+
+    assert redshifts.shape == (count,)
+    assert np.all((0 <= redshifts) & (redshifts <= 1))
+
+    # case: extra dimensions from count
+
+    count = [10, 20, 30]
+    z = np.linspace(0, 1, 100)
+    nz = z*(1-z)
+
+    redshifts = redshifts_from_nz(count, z, nz)
+
+    assert np.shape(redshifts) == (60,)
+
+    # case: extra dimensions from nz
+
+    count = 10
+    z = np.linspace(0, 1, 100)
+    nz = [z*(1-z), (z-0.5)**2]
+
+    redshifts = redshifts_from_nz(count, z, nz)
+
+    assert redshifts.shape == (20,)
+
+    # case: extra dimensions from count and nz
+
+    count = [[10], [20], [30]]
+    z = np.linspace(0, 1, 100)
+    nz = [z*(1-z), (z-0.5)**2]
+
+    redshifts = redshifts_from_nz(count, z, nz)
+
+    assert redshifts.shape == (120,)
+
+    # case: incompatible input shapes
+
+    count = [10, 20, 30]
+    z = np.linspace(0, 1, 100)
+    nz = [z*(1-z), (z-0.5)**2]
+
+    with pytest.raises(ValueError):
+        redshifts_from_nz(count, z, nz)


### PR DESCRIPTION
This change brings the inputs of the `glass.galaxies` module in line with the outputs of the `glass.points` sampling functions after changes #80 and #86.

The `redshifts_from_nz()` function now supports arrays for the `count` parameter (e.g. as returned by the `glass.points` functions) as well as multi-dimensional distributions. If multiple populations are being sampled, the resulting output from each population (i.e. extra input dimension) is concatenated and returned as a flat 1-D column.

The old `gal_pop` return value no longer exists; the population information is already decided by the points sampling and encoded in the `count` array.  As mentioned in #85, it is now easy to generate a column of arbitrary population labels using `np.repeat(labels, count.flat)`.

Also changed is that `gaussian_phz()` accepts array input for the `sigma_0` parameter. This can be used to sample photometric redshifts with different uncertainties for different populations, using `np.repeat(sigma_0_for_each_pop, count.flat)` to create a column of `sigma_0` values for all sampled galaxies.

BREAKING CHANGE: `redshifts_from_nz()` no longer returns `gal_pop`

Fixes: #82