### PR TITLE
API(points): return flat lists of points

### DIFF
--- a/glass/math.py
+++ b/glass/math.py
@@ -11,6 +11,43 @@ ARCMIN2_SPHERE = 60**6//100/np.pi
 ARCSEC2_SPHERE = 60**8//100/np.pi
 
 
+def broadcast_leading_axes(*args):
+    '''Broadcast all but the last N axes.
+
+    Returns the shape of the broadcast dimensions, and all input arrays
+    with leading axes matching that shape.
+
+    Example
+    -------
+    Broadcast all dimensions of ``a``, all except the last dimension of
+    ``b``, and all except the last two dimensions of ``c``.
+
+    >>> a = 0
+    >>> b = np.zeros((4, 10))
+    >>> c = np.zeros((3, 1, 5, 6))
+    >>> dims, a, b, c = broadcast_leading_axes((a, 0), (b, 1), (c, 2))
+    >>> dims
+    (3, 4)
+    >>> a.shape
+    (3, 4)
+    >>> b.shape
+    (3, 4, 10)
+    >>> c.shape
+    (3, 4, 5, 6)
+
+    '''
+
+    shapes, trails = [], []
+    for a, n in args:
+        s = np.shape(a)
+        i = len(s) - n
+        shapes.append(s[:i])
+        trails.append(s[i:])
+    dims = np.broadcast_shapes(*shapes)
+    arrs = (np.broadcast_to(a, dims + t) for (a, _), t in zip(args, trails))
+    return (dims, *arrs)
+
+
 def ndinterp(x, xp, fp, axis=-1, left=None, right=None, period=None):
     '''interpolate multi-dimensional array over axis'''
     return np.apply_along_axis(partial(np.interp, x, xp), axis, fp,

--- a/glass/test/test_math.py
+++ b/glass/test/test_math.py
@@ -2,6 +2,21 @@ import numpy as np
 import numpy.testing as npt
 
 
+def test_broadcast_leading_axes():
+    from glass.math import broadcast_leading_axes
+
+    a = 0
+    b = np.zeros((4, 10))
+    c = np.zeros((3, 1, 5, 6))
+
+    dims, a, b, c = broadcast_leading_axes((a, 0), (b, 1), (c, 2))
+
+    assert dims == (3, 4)
+    assert a.shape == (3, 4)
+    assert b.shape == (3, 4, 10)
+    assert c.shape == (3, 4, 5, 6)
+
+
 def test_ndinterp():
     from glass.math import ndinterp
 

--- a/glass/test/test_points.py
+++ b/glass/test/test_points.py
@@ -2,7 +2,7 @@ def test_positions_from_delta():
     import numpy as np
     from glass.points import positions_from_delta
 
-    # case 1: test single-dimensional input
+    # case: single-dimensional input
 
     ngal = 1e-3
     delta = np.zeros(12)
@@ -11,10 +11,10 @@ def test_positions_from_delta():
 
     lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
 
-    assert isinstance(cnt, np.integer)
+    assert isinstance(cnt, int)
     assert lon.shape == lat.shape == (cnt,)
 
-    # case 2: test multi-dimensional ngal
+    # case: multi-dimensional ngal
 
     ngal = [1e-3, 2e-3]
     delta = np.zeros(12)
@@ -23,32 +23,22 @@ def test_positions_from_delta():
 
     lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
 
-    assert isinstance(cnt, list)
-    assert isinstance(lon, list)
-    assert isinstance(lat, list)
-    assert len(cnt) == len(lon) == len(lat) == 2
-    for i, c in enumerate(cnt):
-        assert isinstance(c, np.integer)
-        assert lon[i].shape == lat[i].shape == (c,)
+    assert cnt.shape == (2,)
+    assert lon.shape == lat.shape == (cnt.sum(),)
 
-    # case 3: test multi-dimensional delta
+    # case: multi-dimensional delta
 
     ngal = 1e-3
-    delta = np.zeros((2, 12))
+    delta = np.zeros((3, 2, 12))
     bias = 0.8
     vis = np.ones(12)
 
     lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
 
-    assert isinstance(cnt, list)
-    assert isinstance(lon, list)
-    assert isinstance(lat, list)
-    assert len(cnt) == len(lon) == len(lat) == 2
-    for i, c in enumerate(cnt):
-        assert isinstance(c, np.integer)
-        assert lon[i].shape == lat[i].shape == (c,)
+    assert cnt.shape == (3, 2)
+    assert lon.shape == lat.shape == (cnt.sum(),)
 
-    # case 4: test multi-dimensional broadcasting
+    # case: multi-dimensional broadcasting
 
     ngal = [1e-3, 2e-3]
     delta = np.zeros((3, 1, 12))
@@ -57,52 +47,36 @@ def test_positions_from_delta():
 
     lon, lat, cnt = positions_from_delta(ngal, delta, bias, vis)
 
-    assert isinstance(cnt, list)
-    assert isinstance(lon, list)
-    assert isinstance(lat, list)
-    assert len(cnt) == len(lon) == len(lat) == 6
-    for i, c in enumerate(cnt):
-        assert isinstance(c, np.integer)
-        assert lon[i].shape == lat[i].shape == (c,)
+    assert cnt.shape == (3, 2)
+    assert lon.shape == lat.shape == (cnt.sum(),)
 
 
 def test_uniform_positions():
-    import numpy as np
     from glass.points import uniform_positions
 
-    # case 1: test scalar input
+    # case: scalar input
 
     ngal = 1e-3
 
     lon, lat, cnt = uniform_positions(ngal)
 
-    assert isinstance(cnt, np.integer)
+    assert isinstance(cnt, int)
     assert lon.shape == lat.shape == (cnt,)
 
-    # case 2: test 1-D array input
+    # case: 1-D array input
 
     ngal = [1e-3, 2e-3, 3e-3]
 
     lon, lat, cnt = uniform_positions(ngal)
 
-    assert isinstance(cnt, list)
-    assert isinstance(lon, list)
-    assert isinstance(lat, list)
-    assert len(cnt) == len(lon) == len(lat) == 3
-    for i, c in enumerate(cnt):
-        assert isinstance(c, np.integer)
-        assert lon[i].shape == lat[i].shape == (c,)
+    assert cnt.shape == (3,)
+    assert lon.shape == lat.shape == (cnt.sum(),)
 
-    # case 3: test 2-D array input
+    # case: 2-D array input
 
-    ngal = [[1e-3, 2e-3], [3e-3, 4e-3]]
+    ngal = [[1e-3, 2e-3], [3e-3, 4e-3], [5e-3, 6e-3]]
 
     lon, lat, cnt = uniform_positions(ngal)
 
-    assert isinstance(cnt, list)
-    assert isinstance(lon, list)
-    assert isinstance(lat, list)
-    assert len(cnt) == len(lon) == len(lat) == 4
-    for i, c in enumerate(cnt):
-        assert isinstance(c, np.integer)
-        assert lon[i].shape == lat[i].shape == (c,)
+    assert cnt.shape == (3, 2)
+    assert lon.shape == lat.shape == (cnt.sum(),)


### PR DESCRIPTION
Amend the changes #80 to return only flat, 1-D columns of longitudes and latitudes from the `glass.points` sampling functions, even for inputs with extra dimensions. This makes it easier to pass the results to other functions, which might not accept ragged lists of arrays.

If extra dimensions are present in the inputs, the output `count` is an array of counts with the shape of the extra dimensions. This is convenient, because it can be passed directly e.g. as the `size=` argument in random sampling functions.

A `count` array also makes it easy to create a column of labels for the sampled populations of points:

    label_col = np.repeat(labels, count.flat)

The change also introduces a `broadcast_leading_axes()` utility function that broadcasts a varying number leading axes for given arrays.

BREAKING CHANGE: Point sampling functions return flat arrays.

Fixes: #85