### PR TITLE
MNT(core): create module for core functionality

### DIFF
--- a/.commitlint.rules.js
+++ b/.commitlint.rules.js
@@ -2,9 +2,9 @@ module.exports = {
   rules: {
     "header-max-length": [2, "always", 65],
     "subject-case": [0, "always", "sentence-case"],
-    "scope-enum": [2, "always", ["all", "fields", "galaxies", "lensing",
-                                 "math", "observations", "points", "shapes",
-                                 "shells", "user"]],
+    "scope-enum": [2, "always", ["all", "core", "fields", "galaxies",
+                                 "lensing", "math", "observations", "points",
+                                 "shapes", "shells", "user"]],
     "scope-case": [0, "always", "lower-case"],
     "type-enum": [2, "always", ["API", "BUG", "DEP", "DEV", "DOC", "ENH",
                                 "MNT", "REV", "STY", "TST", "TYP", "REL"]],

--- a/glass/core/__init__.py
+++ b/glass/core/__init__.py
@@ -1,0 +1,12 @@
+# author: Nicolas Tessore <n.tessore@ucl.ac.uk>
+# license: MIT
+'''
+Core functions (:mod:`glass.core`)
+==================================
+
+.. currentmodule:: glass.core
+
+The :mod:`glass.core` module contains core functionality for developing
+GLASS modules.
+
+'''

--- a/glass/core/array.py
+++ b/glass/core/array.py
@@ -1,14 +1,9 @@
 # author: Nicolas Tessore <n.tessore@ucl.ac.uk>
 # license: MIT
-'''module for mathematical utilities'''
+'''module for array utilities'''
 
 import numpy as np
 from functools import partial
-
-# constants
-DEGREE2_SPHERE = 60**4//100/np.pi
-ARCMIN2_SPHERE = 60**6//100/np.pi
-ARCSEC2_SPHERE = 60**8//100/np.pi
 
 
 def broadcast_leading_axes(*args):

--- a/glass/core/constants.py
+++ b/glass/core/constants.py
@@ -1,0 +1,9 @@
+# author: Nicolas Tessore <n.tessore@ucl.ac.uk>
+# license: MIT
+'''module for constants'''
+
+PI = 3.1415926535897932384626433832795028841971693993751
+
+DEGREE2_SPHERE = 60**4//100/PI
+ARCMIN2_SPHERE = 60**6//100/PI
+ARCSEC2_SPHERE = 60**8//100/PI

--- a/glass/core/test/test_array.py
+++ b/glass/core/test/test_array.py
@@ -3,7 +3,7 @@ import numpy.testing as npt
 
 
 def test_broadcast_leading_axes():
-    from glass.math import broadcast_leading_axes
+    from glass.core.array import broadcast_leading_axes
 
     a = 0
     b = np.zeros((4, 10))
@@ -18,7 +18,7 @@ def test_broadcast_leading_axes():
 
 
 def test_ndinterp():
-    from glass.math import ndinterp
+    from glass.core.array import ndinterp
 
     # test 1d interpolation
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -25,7 +25,7 @@ import healpix
 
 from numpy.typing import ArrayLike
 
-from .math import broadcast_leading_axes, cumtrapz
+from .core.array import broadcast_leading_axes, cumtrapz
 
 
 def redshifts_from_nz(count: int | ArrayLike, z: ArrayLike, nz: ArrayLike, *,

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -35,7 +35,7 @@ import math
 from typing import Optional, Tuple, List
 from numpy.typing import ArrayLike
 
-from .math import cumtrapz
+from .core.array import cumtrapz
 
 
 def vmap_galactic_ecliptic(nside: int, galactic: Tuple[float, float] = (30, 90),

--- a/glass/points.py
+++ b/glass/points.py
@@ -33,7 +33,8 @@ Bias models
 import numpy as np
 import healpix
 
-from .math import ARCMIN2_SPHERE, broadcast_leading_axes, trapz_product
+from .core.array import broadcast_leading_axes, trapz_product
+from .core.constants import ARCMIN2_SPHERE
 
 
 def effective_bias(z, bz, w):

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -44,8 +44,7 @@ import warnings
 from collections import namedtuple
 import numpy as np
 
-from .math import ndinterp
-
+from .core.array import ndinterp
 
 # type checking
 from typing import (Union, Sequence, List, Tuple, Optional, Callable,

--- a/glass/test/test_dummy.py
+++ b/glass/test/test_dummy.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    pass


### PR DESCRIPTION
Moves core functionality that is used by other, user-facing modules into the `glass.core` module.

Currently provides submodules `glass.core.array` and `glass.core.constants`, which contain the respective array functionality and constants from the ex-`glass.math` module.

The `glass.math` module, which was not documented and meant to be internal to other modules, has been removed.

In the future, the `glass.core` module is expected to serve as a namespace for further implementation helpers.

Fixes: #87