### PR TITLE
DOC: update citation info

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -4,23 +4,26 @@ Citation
 If you use GLASS simulations or the GLASS library in your research, please cite
 the GLASS paper in your publications.
 
-Here is the bibliography entry from [NASA/ADS](https://ui.adsabs.harvard.edu/abs/2023arXiv230201942T):
+Here is the bibliography entry from [NASA/ADS]:
 
 ```bib
-@ARTICLE{2023arXiv230201942T,
-       author = {{Tessore}, Nicolas and {Loureiro}, Arthur and {Joachimi}, Benjamin and {von Wietersheim-Kramsta}, Maximilian},
+@ARTICLE{2023OJAp....6E..11T,
+       author = {{Tessore}, Nicolas and {Loureiro}, Arthur and {Joachimi}, Benjamin and {von Wietersheim-Kramsta}, Maximilian and {Jeffrey}, Niall},
         title = "{GLASS: Generator for Large Scale Structure}",
-      journal = {arXiv e-prints},
+      journal = {The Open Journal of Astrophysics},
      keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
          year = 2023,
-        month = feb,
-          eid = {arXiv:2302.01942},
-        pages = {arXiv:2302.01942},
-          doi = {10.48550/arXiv.2302.01942},
+        month = mar,
+       volume = {6},
+          eid = {11},
+        pages = {11},
+          doi = {10.21105/astro.2302.01942},
 archivePrefix = {arXiv},
        eprint = {2302.01942},
  primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230201942T},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 ```
+
+[NASA/ADS]: https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Documentation](https://readthedocs.org/projects/glass/badge/?version=latest)](https://glass.readthedocs.io/en/latest/)
 [![PyPI](https://img.shields.io/pypi/v/glass)](https://pypi.org/project/glass)
 [![arXiv](https://img.shields.io/badge/arXiv-2302.01942-red)](https://arxiv.org/abs/2302.01942)
-[![adsabs](https://img.shields.io/badge/ads-2023arXiv230201942T-blueviolet)](https://ui.adsabs.harvard.edu/abs/2023arXiv230201942T)
-[![doi](https://img.shields.io/badge/doi-10.48550/arXiv.2302.01942-blue)](https://dx.doi.org/10.48550/arXiv.2302.01942)
+[![adsabs](https://img.shields.io/badge/ads-2023OJAp....6E..11T-blueviolet)](https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T)
+[![doi](https://img.shields.io/badge/doi-10.21105/astro.2302.01942-blue)](https://dx.doi.org/10.21105/astro.2302.01942)
 [![Slack](https://img.shields.io/badge/join-Slack-4A154B)](https://glass-dev.github.io/slack)
 
 This is the core library for GLASS, the Generator for Large Scale Structure.

--- a/docs/user/publications.rst
+++ b/docs/user/publications.rst
@@ -4,7 +4,7 @@ Publications
 The following publications about *GLASS* exist.
 
 * | *GLASS: Generator for Large Scale Structure*
-  | Tessore N., Loureiro A., Joachimi B., von Wietersheim-Kramsta M.
-  | arXiv e-prints, 2023
+  | Tessore N., Loureiro A., Joachimi B., von Wietersheim-Kramsta M., Jeffrey N.
+  | The Open Journal of Astrophysics 6, 11 (2023)
     (`arXiv <https://arxiv.org/abs/2302.01942>`_,
-     `ADS <https://ui.adsabs.harvard.edu/abs/2023arXiv230201942T>`_)
+     `ADS <https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T>`_)


### PR DESCRIPTION
Updates the citations in the README and the docs to the accepted version of the GLASS paper.

Does not fix the docstrings which refer to the paper.

Fixes: #74