### PR TITLE
ENH(shapes): shape sampling accepts array input

### DIFF
--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -169,10 +169,11 @@ def ellipticity_gaussian(count: int | ArrayLike, sigma: ArrayLike, *,
                          ) -> NDArray:
     r'''Sample Gaussian galaxy ellipticities.
 
-    The ellipticities are sampled from a normal distribution with standard
-    deviation ``sigma`` for each component.  Samples where the ellipticity is
-    larger than unity are discarded.  Hence, do not use this function with too
-    large values of ``sigma``, or the sampling will become inefficient.
+    The ellipticities are sampled from a normal distribution with
+    standard deviation ``sigma`` for each component.  Samples where the
+    ellipticity is larger than unity are discarded.  Hence, do not use
+    this function with too large values of ``sigma``, or the sampling
+    will become inefficient.
 
     Parameters
     ----------
@@ -181,7 +182,7 @@ def ellipticity_gaussian(count: int | ArrayLike, sigma: ArrayLike, *,
     sigma : array_like
         Standard deviation in each component.
     rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be used.
+        Random number generator.  If not given, a default RNG is used.
 
     Returns
     -------

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -24,8 +24,10 @@ Utilities
 
 '''
 
+from __future__ import annotations
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 
 def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
@@ -162,7 +164,9 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None):
     return e
 
 
-def ellipticity_gaussian(size, sigma, *, rng=None):
+def ellipticity_gaussian(count: int | ArrayLike, sigma: ArrayLike, *,
+                         rng: np.random.Generator | None = None
+                         ) -> NDArray:
     r'''Sample Gaussian galaxy ellipticities.
 
     The ellipticities are sampled from a normal distribution with standard
@@ -172,7 +176,7 @@ def ellipticity_gaussian(size, sigma, *, rng=None):
 
     Parameters
     ----------
-    size : int
+    count : int or array_like
         Number of ellipticities to be sampled.
     sigma : array_like
         Standard deviation in each component.
@@ -190,33 +194,45 @@ def ellipticity_gaussian(size, sigma, *, rng=None):
     if rng is None:
         rng = np.random.default_rng()
 
+    # bring inputs into common shape
+    count, sigma = np.broadcast_arrays(count, sigma)
+
+    # allocate flattened output array
+    eps = np.empty(count.sum(), dtype=np.complex128)
+
     # sample complex ellipticities
     # reject those where abs(e) > 0
-    e = rng.standard_normal(2*size, np.float64).view(np.complex128)
-    e *= sigma
-    i = np.where(np.abs(e) > 1)[0]
-    while len(i) > 0:
-        rng.standard_normal(2*len(i), np.float64, e[i].view(np.float64))
-        e[i] *= sigma
-        i = i[np.abs(e[i]) > 1]
+    i = 0
+    for k in np.ndindex(count.shape):
+        e = rng.standard_normal(2*count[k], np.float64).view(np.complex128)
+        e *= sigma[k]
+        r = np.where(np.abs(e) > 1)[0]
+        while len(r) > 0:
+            rng.standard_normal(2*len(r), np.float64, e[r].view(np.float64))
+            e[r] *= sigma[k]
+            r = r[np.abs(e[r]) > 1]
+        eps[i:i+count[k]] = e
+        i += count[k]
 
-    return e
+    return eps
 
 
-def ellipticity_intnorm(size, sigma, *, rng=None):
+def ellipticity_intnorm(count: int | ArrayLike, sigma: ArrayLike, *,
+                        rng: np.random.Generator | None = None
+                        ) -> NDArray:
     r'''Sample galaxy ellipticities with intrinsic normal distribution.
 
-    The ellipticities are sampled from an intrinsic normal distribution with
-    standard deviation ``sigma`` for each component.
+    The ellipticities are sampled from an intrinsic normal distribution
+    with standard deviation ``sigma`` for each component.
 
     Parameters
     ----------
-    size : int
+    count : int | array_like
         Number of ellipticities to sample.
     sigma : array_like
         Standard deviation of the ellipticity in each component.
     rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be used.
+        Random number generator.  If not given, a default RNG is used.
 
     Returns
     -------
@@ -225,21 +241,31 @@ def ellipticity_intnorm(size, sigma, *, rng=None):
 
     '''
 
-    # make sure sigma is admissible
-    if not 0 <= sigma < 0.5**0.5:
-        raise ValueError('sigma must be between 0 and sqrt(0.5)')
-
     # default RNG if not provided
     if rng is None:
         rng = np.random.default_rng()
 
+    # bring inputs into common shape
+    count, sigma = np.broadcast_arrays(count, sigma)
+
+    # make sure sigma is admissible
+    if not np.all((0 <= sigma) & (sigma < 0.5**0.5)):
+        raise ValueError('sigma must be between 0 and sqrt(0.5)')
+
     # convert to sigma_eta using fit
     sigma_eta = sigma*((8 + 5*sigma**2)/(2 - 4*sigma**2))**0.5
 
-    # sample complex ellipticities
-    e = rng.standard_normal(2*size, np.float64).view(np.complex128)
-    e *= sigma_eta
-    r = np.hypot(e.real, e.imag)
-    e *= np.divide(np.tanh(r/2), r, where=(r > 0), out=r)
+    # allocate flattened output array
+    eps = np.empty(count.sum(), dtype=np.complex128)
 
-    return e
+    # sample complex ellipticities
+    i = 0
+    for k in np.ndindex(count.shape):
+        e = rng.standard_normal(2*count[k], np.float64).view(np.complex128)
+        e *= sigma_eta[k]
+        r = np.hypot(e.real, e.imag)
+        e *= np.divide(np.tanh(r/2), r, where=(r > 0), out=r)
+        eps[i:i+count[k]] = e
+        i += count[k]
+
+    return eps

--- a/glass/test/test_shapes.py
+++ b/glass/test/test_shapes.py
@@ -1,4 +1,32 @@
 import numpy as np
+import pytest
+
+
+def test_ellipticity_gaussian():
+
+    from glass.shapes import ellipticity_gaussian
+
+    n = 1_000_000
+
+    eps = ellipticity_gaussian(n, 0.256)
+
+    assert eps.shape == (n,)
+
+    assert np.all(np.abs(eps) < 1)
+
+    assert np.isclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
+
+    eps = ellipticity_gaussian([n, n], [0.128, 0.256])
+
+    assert eps.shape == (2*n,)
+
+    assert np.all(np.abs(eps) < 1)
+
+    assert np.isclose(np.std(eps.real[:n]), 0.128, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.imag[:n]), 0.128, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.real[n:]), 0.256, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
 
 
 def test_ellipticity_intnorm():
@@ -9,9 +37,23 @@ def test_ellipticity_intnorm():
 
     eps = ellipticity_intnorm(n, 0.256)
 
-    assert eps.size == n
+    assert eps.shape == (n,)
 
     assert np.all(np.abs(eps) < 1)
 
     assert np.isclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
     assert np.isclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
+
+    eps = ellipticity_intnorm([n, n], [0.128, 0.256])
+
+    assert eps.shape == (2*n,)
+
+    assert np.all(np.abs(eps) < 1)
+
+    assert np.isclose(np.std(eps.real[:n]), 0.128, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.imag[:n]), 0.128, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.real[n:]), 0.256, atol=1e-3, rtol=0)
+    assert np.isclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
+
+    with pytest.raises(ValueError):
+        ellipticity_intnorm(1, 0.71)


### PR DESCRIPTION
Change the `ellipticity_gaussian()` and `ellipticity_intnorm()` functions in `glass.shapes` to support array inputs for the `count` and `sigma` parameters.  The outputs are a flat list of concatenates samples for each input axis.

Closes: #100
Changes: `ellipticity_gaussian()` and `ellipticity_intnorm()` accept array inputs