### PR TITLE
API: make glass.ext the namespace for extensions

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from ._version import __version__, __version_tuple__  # noqa: F401
+except ModuleNotFoundError:
+    pass

--- a/glass/all.py
+++ b/glass/all.py
@@ -1,6 +1,0 @@
-# author: Nicolas Tessore <n.tessore@ucl.ac.uk>
-# license: MIT
-'''meta-module that imports all modules from the GLASS namespace'''
-
-
-(lambda: [__import__(_.name) for _ in __import__('pkgutil').iter_modules(__import__(__package__).__path__, __package__ + '.')])()  # noqa

--- a/glass/ext/__init__.py
+++ b/glass/ext/__init__.py
@@ -1,0 +1,20 @@
+'''Namespace loader for GLASS extension packages.
+
+Uses the pkgutil namespace mechanism to find "ext" submodules of
+packages that provide a "glass" module.
+
+'''
+
+
+def _extend_path(path, name):
+    import os.path
+    from pkgutil import extend_path
+
+    _pkg, _, _mod = name.partition('.')
+
+    return list(filter(os.path.isdir,
+                       (os.path.join(p, _mod)
+                        for p in extend_path(path, _pkg))))
+
+
+__path__ = _extend_path(__path__, __name__)


### PR DESCRIPTION
Introduces two related changes:

* Create a `glass.ext` namespace package for extensions.
* Make `glass` no longer a namespace package, by adding an `__init__.py`.

To be able to load namespace packages under non-namespace packages, a pkgutil-type namespace loader is used that looks for extensions having a `glass` module with a `glass.ext` submodule.

This is a breaking change for the `glass.camb` package and the examples, but we want to follow the best practices for plugins, and prevent further breakages of the entire `glass` module further down the line.

No symbols are added to `glass/__init__.py` yet (apart from the version), and everything continues to be imported via the submodules for the time being. Making all imports through the `glass` module itself will require a larger restructuring of the docs in the future.

Closes: #97
Added: A new `glass.ext` namespace, reserved for extensions
Changed: The `glass` module is no longer a namespace package
Removed: The `glass.all` meta-module is no longer necessary