### PR TITLE
ENH(lensing): deflections from weak lensing

### DIFF
--- a/docs/user/definitions.rst
+++ b/docs/user/definitions.rst
@@ -7,10 +7,14 @@ The *GLASS* code uses the following mathematical definitions.
 .. glossary::
 
    deflection
-      The deflection :math:`\alpha` due to weak gravitational lensing is either
-      a spin-1 complex number or a real vector with two components.  It
-      describes the displacement of a position by an angle :math:`|\alpha|`
-      in the direction of the tangent vector :math:`\vec{\alpha}`.
+      The deflection :math:`\alpha` is a complex value with spin weight
+      :math:`1`.  It describes the displacement of a position along a geodesic
+      (i.e. great circle).  The angular distance of the displacement is the
+      absolute value :math:`|\alpha|`.  The direction of the displacement is
+      the angle given by the complex argument :math:`\arg\alpha`, such that
+      :math:`\arg\alpha = 0^\circ` is north, :math:`\arg\alpha = 90^\circ` is
+      east, :math:`\arg\alpha = 180^\circ` is south, and :math:`\arg\alpha =
+      -90^\circ` is west.
 
    ellipticity
       If :math:`q = b/a` is the axis ratio of an elliptical isophote with

--- a/docs/user/definitions.rst
+++ b/docs/user/definitions.rst
@@ -6,6 +6,12 @@ The *GLASS* code uses the following mathematical definitions.
 
 .. glossary::
 
+   deflection
+      The deflection :math:`\alpha` due to weak gravitational lensing is either
+      a spin-1 complex number or a real vector with two components.  It
+      describes the displacement of a position by an angle :math:`|\alpha|`
+      in the direction of the tangent vector :math:`\vec{\alpha}`.
+
    ellipticity
       If :math:`q = b/a` is the axis ratio of an elliptical isophote with
       semi-major axis :math:`a` and semi-minor axis :math:`b`, and :math:`\phi`

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -77,7 +77,7 @@ def from_convergence(kappa: NDArray, lmax: Optional[int] = None, *,
     Notes
     -----
     The weak lensing fields are computed from the convergence or
-    deflection potential in the following way.[1]_
+    deflection potential in the following way. [1]_
 
     Define the spin-raising and spin-lowering operators of the
     spin-weighted spherical harmonics as

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -114,10 +114,10 @@ def from_convergence(kappa: NDArray, lmax: Optional[int] = None, *,
         \alpha
         = \eth \, \psi \;.
 
-    The deflection field is given the spin weight :math:`1` in the
-    HEALPix convention, so that points are deflected towards regions of
+    The deflection field has spin weight :math:`1` in the HEALPix
+    convention, in order for points to be deflected towards regions of
     positive convergence.  The modes :math:`\alpha_{lm}` of the
-    deflection field are
+    deflection field are hence
 
     .. math::
 

--- a/glass/test/test_lensing.py
+++ b/glass/test/test_lensing.py
@@ -1,0 +1,55 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+@pytest.mark.parametrize("usecomplex", [True, False])
+def test_deflect_nsew(usecomplex):
+    from glass.lensing import deflect
+
+    d = 5.
+    r = np.radians(d)
+
+    if usecomplex:
+        def alpha(re, im):
+            return re + 1j*im
+    else:
+        def alpha(re, im):
+            return [re, im]
+
+    # north
+    lon, lat = deflect(0., 0., alpha(r, 0))
+    assert np.allclose([lon, lat], [0., d])
+
+    # south
+    lon, lat = deflect(0., 0., alpha(-r, 0))
+    assert np.allclose([lon, lat], [0., -d])
+
+    # east
+    lon, lat = deflect(0., 0., alpha(0, r))
+    assert np.allclose([lon, lat], [-d, 0.])
+
+    # west
+    lon, lat = deflect(0., 0., alpha(0, -r))
+    assert np.allclose([lon, lat], [d, 0.])
+
+
+def test_deflect_many():
+    import healpix
+    from glass.lensing import deflect
+
+    n = 1000
+    abs_alpha = np.random.uniform(0, 2*np.pi, size=n)
+    arg_alpha = np.random.uniform(-np.pi, np.pi, size=n)
+
+    lon_ = np.degrees(np.random.uniform(-np.pi, np.pi, size=n))
+    lat_ = np.degrees(np.arcsin(np.random.uniform(-1, 1, size=n)))
+
+    lon, lat = deflect(lon_, lat_, abs_alpha*np.exp(1j*arg_alpha))
+
+    x_, y_, z_ = healpix.ang2vec(lon_, lat_, lonlat=True)
+    x, y, z = healpix.ang2vec(lon, lat, lonlat=True)
+
+    dotp = x*x_ + y*y_ + z*z_
+
+    npt.assert_allclose(dotp, np.cos(abs_alpha))


### PR DESCRIPTION
Adds functions to simulate deflections due to weak gravitational lensing:

* `from_convergence()` computes other weak lensing fields from the convergence
* `deflect()` applies deflections to a set of positions

An exact definition of what "deflection" means in GLASS is added to the glossary.

This functionality so far only covers the raw physical process of deflecting a point.  To compute the observed positions of a set of sources under weak lensing, we will need a new high-level function `lensed_positions()`, say, that solves the lensing equation by repeatedly calling `deflect()`.

Closes: #106
Added: `deflect()` applies deflections to positions
Added: `from_convergence()` returns other lensing fields given the convergence
Deprecated: `shear_from_convergence()` is deprecated in favour of `from_convergence()`