### PR TITLE
REL: glass 2023.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the project are documented in this file.  The format is
 based on [Keep a Changelog](https://keepachangelog.com).
 
 
+[2023.6]  (30 Jun 2023)
+-----------------------
+
+### Added
+
+- `deflect()` applies deflections to positions
+- `from_convergence()` returns other lensing fields given the convergence
+- A new `glass.ext` namespace, reserved for extensions
+
+### Changed
+
+- The `glass` module is no longer a namespace package
+- The point sampling functions `positions_from_delta()` and
+  `uniform_positions()` now return an iterator
+- `ellipticity_gaussian()` and `ellipticity_intnorm()` accept array inputs
+- Use pyproject.toml for packaging
+
+### Deprecated
+
+- `shear_from_convergence()` is deprecated in favour of `from_convergence()`
+
+### Removed
+
+- The `glass.all` meta-module is no longer necessary
+
+### Fixed
+
+- Incorrect extrapolation in `glass.core.array.trapz_product()`, causing a bug
+  in `glass.points.effective_bias()`
+
+
 [2023.5]  (31 May 2023)
 -----------------------
 
@@ -74,6 +105,7 @@ based on [Keep a Changelog](https://keepachangelog.com).
 - Initial wide release for GLASS paper
 
 
+[2023.6]: https://github.com/glass-dev/glass/compare/v2023.5...v2023.6
 [2023.5]: https://github.com/glass-dev/glass/compare/v2023.2...v2023.5
 [2023.2]: https://github.com/glass-dev/glass/compare/v2023.1...v2023.2
 [2023.1]: https://github.com/glass-dev/glass/releases/tag/v2023.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,17 @@ one or more GitHub issue numbers:
 To indicate that the pull request shall close an open issue, use `Closes` and
 a single GitHub issue number:
 
-    Fixes: #17
+    Closes: #17
+
+Changelog entries are collected using the following trailers, and later parsed
+into the [changelog](CHANGELOG.md) for the next release:
+
+    Added: Some new feature
+    Changed: Some change in existing functionality
+    Deprecated: Some soon-to-be removed feature
+    Removed: Some now removed feature
+    Fixed: Some bug fix
+    Security: Some vulnerability was fixed
 
 You can use any of the other common git trailers.  In particular, you can use
 `Cc` to notify others of your pull request via their GitHub user names:
@@ -87,9 +97,9 @@ Releasing
 To release a new version of *GLASS*, there should be a commit titled
 `REL: glass yyyy.mm` that includes the following changes:
 
-* The current `Unreleased` section in the [changelog](CHANGELOG.md) is renamed
-  to `yyyy.mm (DD Mon YYYY)` and a new "Unreleased" section is started.  The
-  links to changesets at the bottom of the file have to be updated accordingly.
+* The changelog trailers since the last release are parsed into the
+  [changelog](CHANGELOG.md) under a section titled `[yyyy.mm]  (DD Mon YYYY)`.
+  A new link to the changeset is added at the bottom of the file.
 * The [release notes](docs/manual/releases.rst) are updated with the new
   version.  The release notes should translate the changelog entries into
   prose that can be understood by non-developer users of the code.  If there

--- a/docs/manual/releases.rst
+++ b/docs/manual/releases.rst
@@ -4,6 +4,39 @@ Release notes
 
 These notes document the changes between individual *GLASS* releases.
 
+
+2023.6 (30 Jun 2023)
+--------------------
+
+- There is some support for simulating the deflections due to weak
+  gravitational lensing:
+
+  - The :func:`~glass.lensing.deflect` function applies deflections to
+    positions.
+
+  - The :func:`~glass.lensing.from_convergence` function returns one or more
+    other lensing fields given the convergence.
+
+  - The ``shear_from_convergence()`` function is deprecated in favour of
+    ``from_convergence()``.
+
+- The ``glass`` module is no longer a namespace package.  The new ``glass.ext``
+  namespace is reserved for extensions instead.  This is done to follow best
+  practices, so that a bad extension can no longer break all of *GLASS* by
+  mistake.  The ``glass.all`` meta-module is no longer necessary.
+
+- The point sampling functions :func:`~glass.points.positions_from_delta` and
+  :func:`~glass.points.uniform_positions` now return an iterator over points.
+  This has lead to orders-of-magnitude improvements in memory use and
+  performance when simulating galaxies at Euclid/LSST densities.
+
+- The ellipticity sampling functions :func:`~glass.shapes.ellipticity_gaussian`
+  and :func:`~glass.shapes.ellipticity_intnorm` accept array inputs.
+
+- A bug causing incorrect results from :func:`~glass.points.effective_bias` has
+  been fixed.
+
+
 2023.5 (31 May 2023)
 --------------------
 


### PR DESCRIPTION
glass 2023.6 (30 Jun 2023)
--------------------------

- There is some support for simulating the deflections due to weak gravitational lensing:

  - The `deflect()` function applies deflections to positions.

  - The `from_convergence()` function returns one or more other lensing fields given the convergence.

  - The `shear_from_convergence()` function is deprecated in favour of `from_convergence()`.

- The `glass` module is no longer a namespace package.  The new `glass.ext` namespace is reserved for extensions instead.  This is done to follow best practices, so that a bad extension can no longer break all of *GLASS* by mistake.  The `glass.all` meta-module is no longer necessary.

- The point sampling functions `positions_from_delta()` and `uniform_positions()` now return an iterator over points. This has lead to orders-of-magnitude improvements in memory use and performance when simulating galaxies at Euclid/LSST densities.

- The ellipticity sampling functions `ellipticity_gaussian()` and `ellipticity_intnorm()` accept array inputs.

- A bug causing incorrect results from `effective_bias()` has been fixed.