### PR TITLE
ENH: specify bounds for Gaussian photometric redshifts

### DIFF
--- a/glass/test/test_galaxies.py
+++ b/glass/test/test_galaxies.py
@@ -97,6 +97,17 @@ def test_gaussian_phz():
     assert phz.shape == (100,)
     assert np.all(phz >= 0)
 
+    # case: upper and lower bound
+
+    z = 1.
+    sigma_0 = np.ones(100)
+
+    phz = gaussian_phz(z, sigma_0, lower=0.5, upper=1.5)
+
+    assert phz.shape == (100,)
+    assert np.all(phz >= 0.5)
+    assert np.all(phz <= 1.5)
+
     # test interface
 
     # case: scalar redshift, scalar sigma_0


### PR DESCRIPTION
Adds `lower=` and `upper=` keyword parameters to the `gaussian_phz()` function to sample Gaussian photometric redshifts within the given limits.

This currently uses a trivial rejection sampler from the full normal distribution, so it can easily become very inefficient if the bounds don't contain significant probability mass.  Needs to be improved for serious use.

Closes: #114
Changed: The `gaussian_phz()` function now accepts bounds using `lower=` and `upper=` keyword parameters.