### PR TITLE
BUG: remove stray print statement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,5 @@ repos:
   rev: 4.0.1
   hooks:
   - id: flake8
+    additional_dependencies:
+    - flake8-print

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -204,8 +204,6 @@ def gaussian_phz(z: ArrayLike, sigma_0: float | ArrayLike, *,
 
     zphot = rng.normal(z, sigma)
 
-    print(zphot)
-
     if lower is None:
         lower = 0.
     if upper is None:


### PR DESCRIPTION
Fixes a print statement left in #115.

Also makes sure this doesn't happen again by adding the `flake8-print` plugin to the pre-commit config.