### PR TITLE
API(shells): partition() to fit windows to function

### DIFF
--- a/glass/test/test_shells.py
+++ b/glass/test/test_shells.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.testing as npt
 
 
 def test_tophat_windows():
@@ -47,40 +46,3 @@ def test_restrict():
             i = np.searchsorted(zr, zi)
             assert zr[i] == zi
             assert fr[i] == fi*np.interp(zi, w.za, w.wa)
-
-
-def test_partition():
-    from glass.shells import partition, RadialWindow
-
-    # Gaussian test function
-    z = np.linspace(0., 5., 1000)
-    f = np.exp(-((z - 2.)/0.5)**2/2)
-
-    # overlapping triangular weight functions
-    ws = [RadialWindow(za=[0., 1., 2.], wa=[0., 1., 0.], zeff=None),
-          RadialWindow(za=[1., 2., 3.], wa=[0., 1., 0.], zeff=None),
-          RadialWindow(za=[2., 3., 4.], wa=[0., 1., 0.], zeff=None),
-          RadialWindow(za=[3., 4., 5.], wa=[0., 1., 0.], zeff=None)]
-
-    zp, fp = partition(z, f, ws)
-
-    assert len(zp) == len(fp) == len(ws)
-
-    for zr, w in zip(zp, ws):
-        assert np.all((zr >= w.za[0]) & (zr <= w.za[-1]))
-
-    for zr, fr, w in zip(zp, fp, ws):
-        f_ = np.interp(zr, z, f, left=0., right=0.)
-        w_ = np.interp(zr, w.za, w.wa, left=0., right=0.)
-        npt.assert_allclose(fr, f_*w_)
-
-    f_ = sum(np.interp(z, zr, fr, left=0., right=0.)
-             for zr, fr in zip(zp, fp))
-
-    # first and last points have zero total weight
-    assert f_[0] == f_[-1] == 0.
-
-    # find first and last index where total weight becomes unity
-    i, j = np.searchsorted(z, [ws[0].za[1], ws[-1].za[1]])
-
-    npt.assert_allclose(f_[i:j], f[i:j], atol=1e-15)


### PR DESCRIPTION
Change the `partition()` function to return an array of weights such that the weighted sum of window functions approximates the given input function.  This can be used to directly obtain e.g. the galaxy densities in each shell to match a target distribution $dN/dz$:

```py
# the galaxy density in each shell to match dndz
ngal = partition(z, dndz, shells)
```

For overlapping window functions, there are in general many ways to combine shells to match a given function. The `partition()` function currently implements least-squares (`method="lstsq"`) and the restriction of the target function to the shell, followed by integration (`method="restrict"`). The latter was previously the default procedure for tophat windows.

Closes: #121
Changed: The `partition()` function now returns an array of weights to approximate the given function by the windows.