### PR TITLE
BUG(shells): fix and improve partition() with NNLS

### DIFF
--- a/glass/core/algorithm.py
+++ b/glass/core/algorithm.py
@@ -12,7 +12,7 @@ def nnls(
     a: ArrayLike,
     b: ArrayLike,
     *,
-    tol: float = 1e-10,
+    tol: float = 0.0,
     maxiter: int | None = None,
 ) -> ArrayLike:
     """Compute a non-negative least squares solution.
@@ -39,7 +39,7 @@ def nnls(
     if a.shape[0] != b.shape[0]:
         raise ValueError("the shapes of `a` and `b` do not match")
 
-    m, n = a.shape
+    _, n = a.shape
 
     if maxiter is None:
         maxiter = 3 * n

--- a/glass/test/test_shells.py
+++ b/glass/test/test_shells.py
@@ -72,3 +72,5 @@ def test_partition(method):
     part = partition(z, fz, shells, method=method)
 
     assert part.shape == (len(shells), 3, 2)
+
+    assert np.allclose(part.sum(axis=0), np.trapz(fz, z))


### PR DESCRIPTION
Most importantly, fixes a bug in `partition_nnls()` which rendered that function useless.

Secondly, optimises `partition_nnls()` by using a QR factorisation of the problem before calling `nnls()` on an equivalent but much smaller problem.

Finally, adds a new integral constraint for both `nnls` and `lstsq` which ensures that the sum of the partition recovers the integral of the input function.

Fixes: #144
Fixed: A bug in `partition()` with the default method.
Changed: Both `partition(method="nnls")` and `partition(method="lstsq")` now have an additional integral constraint so that the sum of the partition recovers the integral of the input function.