### PR TITLE
ENH(fields): compute effective spectra of a simulation

### DIFF
--- a/glass/core/array.py
+++ b/glass/core/array.py
@@ -6,6 +6,14 @@ import numpy as np
 from functools import partial
 
 
+def broadcast_first(*arrays):
+    """Broadcast arrays, treating the first axis as common."""
+    arrays = tuple(np.moveaxis(a, 0, -1) if np.ndim(a) else a for a in arrays)
+    arrays = np.broadcast_arrays(*arrays)
+    arrays = tuple(np.moveaxis(a, -1, 0) if np.ndim(a) else a for a in arrays)
+    return arrays
+
+
 def broadcast_leading_axes(*args):
     '''Broadcast all but the last N axes.
 

--- a/glass/test/test_lensing.py
+++ b/glass/test/test_lensing.py
@@ -3,6 +3,41 @@ import numpy.testing as npt
 import pytest
 
 
+@pytest.fixture
+def shells():
+    from glass.shells import RadialWindow
+
+    shells = [
+        RadialWindow([0., 1., 2.], [0., 1., 0.], 1.),
+        RadialWindow([1., 2., 3.], [0., 1., 0.], 2.),
+        RadialWindow([2., 3., 4.], [0., 1., 0.], 3.),
+        RadialWindow([3., 4., 5.], [0., 1., 0.], 4.),
+        RadialWindow([4., 5., 6.], [0., 1., 0.], 5.),
+    ]
+
+    return shells
+
+
+@pytest.fixture
+def cosmo():
+    class MockCosmology:
+
+        @property
+        def omega_m(self):
+            return 0.3
+
+        def ef(self, z):
+            return (self.omega_m * (1 + z)**3 + 1 - self.omega_m) ** 0.5
+
+        def xm(self, z, z2=None):
+            if z2 is None:
+                return np.array(z) * 1000
+            else:
+                return (np.array(z2) - np.array(z)) * 1000
+
+    return MockCosmology()
+
+
 @pytest.mark.parametrize("usecomplex", [True, False])
 def test_deflect_nsew(usecomplex):
     from glass.lensing import deflect
@@ -53,3 +88,22 @@ def test_deflect_many():
     dotp = x*x_ + y*y_ + z*z_
 
     npt.assert_allclose(dotp, np.cos(abs_alpha))
+
+
+def test_multi_plane_matrix(shells, cosmo):
+    from glass.lensing import multi_plane_matrix
+
+    mat = multi_plane_matrix(shells, cosmo)
+
+    npt.assert_array_equal(mat, np.tril(mat))
+    npt.assert_array_equal(np.triu(mat, 1), 0)
+
+
+def test_multi_plane_weights(shells, cosmo):
+    from glass.lensing import multi_plane_weights
+
+    w_in = np.eye(len(shells))
+    w_out = multi_plane_weights(w_in, shells, cosmo)
+
+    npt.assert_array_equal(w_out, np.triu(w_out, 1))
+    npt.assert_array_equal(np.tril(w_out), 0)

--- a/glass/test/test_points.py
+++ b/glass/test/test_points.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.testing as npt
 
 
 def catpos(pos):
@@ -94,3 +95,21 @@ def test_uniform_positions():
 
     assert cnt.shape == (3, 2)
     assert lon.shape == lat.shape == (cnt.sum(),)
+
+
+def test_position_weights():
+    from glass.points import position_weights
+
+    for bshape in None, (), (100,), (1, 100):
+        for cshape in (100,), (1, 100), (3, 2, 100):
+
+            counts = np.random.rand(*cshape)
+            bias = None if bshape is None else np.random.rand(*bshape)
+
+            weights = position_weights(counts, bias)
+
+            expected = counts / counts.sum(axis=-1, keepdims=True)
+            if bias is not None:
+                expected = bias * expected
+
+            npt.assert_allclose(weights, expected)

--- a/glass/test/test_points.py
+++ b/glass/test/test_points.py
@@ -100,16 +100,20 @@ def test_uniform_positions():
 def test_position_weights():
     from glass.points import position_weights
 
-    for bshape in None, (), (100,), (1, 100):
-        for cshape in (100,), (1, 100), (3, 2, 100):
+    for bshape in None, (), (100,), (100, 1):
+        for cshape in (100,), (100, 50), (100, 3, 2):
 
             counts = np.random.rand(*cshape)
             bias = None if bshape is None else np.random.rand(*bshape)
 
             weights = position_weights(counts, bias)
 
-            expected = counts / counts.sum(axis=-1, keepdims=True)
+            expected = counts / counts.sum(axis=0, keepdims=True)
             if bias is not None:
+                if np.ndim(bias) > np.ndim(expected):
+                    expected = np.expand_dims(expected, tuple(range(np.ndim(expected), np.ndim(bias))))
+                else:
+                    bias = np.expand_dims(bias, tuple(range(np.ndim(bias), np.ndim(expected))))
                 expected = bias * expected
 
             npt.assert_allclose(weights, expected)


### PR DESCRIPTION
Adds a function `effective_cls()` which takes a list of weights for each shell and the angular matter power spectrum and returns an array of the effective spectra for when matter shells are combined using the given weights. This can be used to exactly predict what the angular power spectra coming out of a simulation will be after discretisation.

To obtain the angular galaxy power spectrum, a new function `position_weights()` computes the weights corresponding to `positions_from_delta()`. To obtain the angular convergence power spectrum, a new function `multi_plane_weights()` computes the weights corresponding to `MultiPlaneConvergence`.

Closes: #130
Added: A new function `effective_cls()` which combines power spectra using a list of weights, which models what happens in the simulation.
Added: A new function `position_weights()` that returns weights for `effective_cls()` to model the result of `positions_from_delta()`.
Added: A new function `multi_plane_weights()` that returns weights for `effective_cls()` to model the result of `MultiPlaneConvergence`.