### PR TITLE
ENH(shells): evaluate a linear combination of window functions

### DIFF
--- a/glass/shells.py
+++ b/glass/shells.py
@@ -624,7 +624,7 @@ def combine(
 
     """
     return sum(
-        weight[..., None] * np.interp(
+        np.expand_dims(weight, -1) * np.interp(
             z,
             shell.za,
             shell.wa / np.trapz(shell.wa, shell.za),

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -611,7 +611,7 @@ def combine(
         Weights of the linear combination, where the leading axis
         corresponds to *shells*.
     shells : sequence of :class:`RadialWindow`
-        Ordered sequence of window functions for the partition.
+        Ordered sequence of window functions to be combined.
 
     Returns
     -------


### PR DESCRIPTION
Adds a function `combine(z, weights, shells)` that computes the linear combination of the window functions in *shells* using coefficients from *weights* evaluated in the redshifts *z*.  This is hence the inverse operation to `partition()`, which returns *weights*.

Closes: #147
Added: A new function `combine()` that evaluates the linear combination
  of radial window functions with given weights.