### PR TITLE
BUG(fields): infer correct lmax in effective_cls()

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -362,7 +362,7 @@ def effective_cls(cls, weights1, weights2=None, *, lmax=None):
 
     # find lmax if not given
     if lmax is None:
-        lmax = max(map(len, cls), default=-1)
+        lmax = max(map(len, cls), default=0) - 1
 
     # broadcast weights1 such that its shape ends in n
     weights1 = np.asanyarray(weights1)


### PR DESCRIPTION
Fixes a bug in the `effective_cls()` function that caused the returned arrays to be 1 entry too long when `lmax` was not given explicitly.

Closes: #152
Fixed: A bug in `effective_cls()` that caused arrays to be one entry too
  long if `lmax` was not given explicitly.