### PR TITLE
DOC: fix intersphinx URL for examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ html_css_files = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'examples': ('https://glass.readthedocs.io/projects/examples/en/latest/', None),
+    'examples': ('https://glass.readthedocs.io/projects/examples/latest/', None),
 }
 
 


### PR DESCRIPTION
Update the URL to the GLASS examples documentation in the intersphinx configuration.

Fixed: Now uses the updated intersphinx URL for the GLASS examples.
Reviewed-by: baugstein
