### PR TITLE
MNT: pin NumPy to v1 (until v2 is supported)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy>=1.20.0",
+    "numpy~=1.0",
     "healpix>=2022.11.1",
     "healpy>=1.15.0",
     "cosmology>=2022.10.9",


### PR DESCRIPTION
Fixes (the necessary) bit of #189.

Can adjust once #163 is sorted.