### PR TITLE
gh-46: add infrastructure for coveralls (coverage)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install -c .github/test-constraints.txt '.[test]'
-    - run: pytest -v
+    - run: pytest --cov=glass -v
+    - uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install -c .github/test-constraints.txt '.[test]'
+    - run: pip install -c .github/test-constraints.txt -e '.[test]'
     - run: pytest --cov=glass -v
     - uses: coverallsapp/github-action@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 _build
 build
 dist
+.env
+.coverage*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 **GLASS**: Generator for Large Scale Structure
 ==============================================
 
+[![Test](https://github.com/glass-dev/glass/actions/workflows/test.yml/badge.svg)](https://github.com/glass-dev/glass/actions/workflows/test.yml)
 [![Documentation](https://readthedocs.org/projects/glass/badge/?version=latest)](https://glass.readthedocs.io/latest/)
+[![Coverage Status](https://coveralls.io/repos/github/glass-dev/glass/badge.svg?branch=main)](https://coveralls.io/github/glass-dev/glass?branch=main)
 [![PyPI](https://img.shields.io/pypi/v/glass)](https://pypi.org/project/glass)
 [![arXiv](https://img.shields.io/badge/arXiv-2302.01942-red)](https://arxiv.org/abs/2302.01942)
 [![adsabs](https://img.shields.io/badge/ads-2023OJAp....6E..11T-blueviolet)](https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ examples = [
 test = [
     "fitsio",
     "pytest",
+    "pytest-cov",
     "scipy",
 ]
 


### PR DESCRIPTION
Add code coverage in workflow using pytest-cov and coveralls.

Closes: #46
Ref: #180