### PR TITLE
gh-51: a button to show source code in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ extensions = [
     'sphinxcontrib.katex',
     'matplotlib.sphinxext.plot_directive',
     'nbsphinx',
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fixes #51 

Looks like this - 

<img width="773" alt="image" src="https://github.com/user-attachments/assets/d1211810-f9ec-44e8-accc-28b756cc9f32">

Clicking source directs users to -

<img width="756" alt="image" src="https://github.com/user-attachments/assets/3b683e54-0be6-4503-8eb5-86b6045f0b3a">
