### PR TITLE
gh-175: update and rename CITATION.md to CITATION.bib

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,12 +1,3 @@
-Citation
-========
-
-If you use GLASS simulations or the GLASS library in your research, please cite
-the GLASS paper in your publications.
-
-Here is the bibliography entry from [NASA/ADS]:
-
-```bib
 @ARTICLE{2023OJAp....6E..11T,
        author = {{Tessore}, Nicolas and {Loureiro}, Arthur and {Joachimi}, Benjamin and {von Wietersheim-Kramsta}, Maximilian and {Jeffrey}, Niall},
         title = "{GLASS: Generator for Large Scale Structure}",
@@ -24,6 +15,3 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-```
-
-[NASA/ADS]: https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T


### PR DESCRIPTION
Changes the citation file format to `.bib` and uses BibTex from ADS.

Closes: #175