### PR TITLE
gh-84: enable doctests using pytest-doctestplus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install -c .github/test-constraints.txt -e '.[test]'
-    - run: pytest --cov=glass -v
+    - run: pytest --cov=glass --doctest-plus -v
     - uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 dist
 .env
 .coverage*
+*.Fits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "fitsio",
     "pytest",
     "pytest-cov",
+    "pytest-doctestplus",
     "scipy",
 ]
 


### PR DESCRIPTION
Enable doctests in CI using the pytest-doctestplus plugin.

Closes: #84