### PR TITLE
Don't make second box mandatory for feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -17,8 +17,6 @@ body:
     attributes:
       label: Describe the Solution You'd Like
       description: A clear and concise description of what you want to happen.
-    validations:
-      required: true
   - id: alternatives
     type: textarea
     attributes:


### PR DESCRIPTION
Especially for small issues this can be a bit unnecessary so may as well remove it