### PR TITLE
Fix typos running `crate-ci/typos` over code base

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,14 @@ repos:
     rev: v0.6.3
     hooks:
       - id: ruff-format
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.24.3
+    hooks:
+      - id: typos
+        args:
+          - --force-exclude
+          - --hidden
+          - --locale=en-gb
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.23.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,6 @@ repos:
     rev: v0.6.3
     hooks:
       - id: ruff-format
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.24.3
-    hooks:
-      - id: typos
-        args:
-          - --force-exclude
-          - --hidden
-          - --locale=en-gb
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.23.1
     hooks:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,20 +14,20 @@ diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
+Examples of behaviour that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+* Accepting responsibility and apologising to those affected by our mistakes,
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 
-Examples of unacceptable behavior include:
+Examples of unacceptable behaviour include:
 
-* The use of sexualized language or imagery, and sexual attention or
+* The use of sexualised language or imagery, and sexual attention or
   advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
@@ -39,8 +39,8 @@ Examples of unacceptable behavior include:
 ## Enforcement Responsibilities
 
 Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
 or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject
@@ -58,7 +58,7 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported to the project maintainers.
 All complaints will be reviewed and investigated promptly and fairly.
 
@@ -72,19 +72,19 @@ the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
+**Community Impact**: Use of inappropriate language or other behaviour deemed
 unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing
 clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+behaviour was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
 **Community Impact**: A violation through a single incident or series
 of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
+**Consequence**: A warning with consequences for continued behaviour. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
@@ -94,7 +94,7 @@ permanent ban.
 ### 3. Temporary Ban
 
 **Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+sustained inappropriate behaviour.
 
 **Consequence**: A temporary ban from any sort of interaction or public
 communication with the community for a specified period of time. No public or
@@ -105,7 +105,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behaviour,  harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -421,7 +421,7 @@ def partition(
         \\end{pmatrix} \\;,
 
     where :math:`\\lambda` is a multiplier to enforce the integral
-    contraints.
+    constraints.
 
     The :func:`partition()` function implements a number of methods to
     obtain a solution:

--- a/glass/user.py
+++ b/glass/user.py
@@ -50,7 +50,7 @@ def load_cls(filename):
 
 
 class _FitsWriter:
-    """Writer that creates a FITS file.  Initialised with the fits object and extention name."""
+    """Writer that creates a FITS file.  Initialised with the fits object and extension name."""
 
     def __init__(self, fits, ext=None):
         """Create a new, uninitialised writer."""


### PR DESCRIPTION
I'm not going to add it to the list of `pre-commit` hooks, as it can have a lot of false positives. But adding manually once and fixing some typos. Please remind me to remove from `pre-commit` after this PR. https://github.com/crate-ci/typos