### PR TITLE
gh-170: add `yamllint` and run over the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     commit-message:
-      prefix: "DEV"
+      prefix: DEV

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,14 +1,15 @@
+---
 name: Test examples
 
 on:
   push:
     paths:
-      - "glass/**"
+      - glass/**
     branches:
       - main
   pull_request:
     paths:
-      - "glass/**"
+      - glass/**
 
 concurrency:
   # Skip intermediate builds: always.
@@ -27,6 +28,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: 3.x
           cache: pip
       - run: pipx run --spec '.[examples]' jupyter execute examples/**/*.ipynb

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,3 +1,4 @@
+---
 name: PR Title Checker
 on:
   pull_request_target:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Deployment target. Can be "pypi" or "testpypi"'
-        default: "testpypi"
+        description: Deployment target. Can be pypi or testpypi.
+        default: testpypi
   release:
     types:
       - published
@@ -31,7 +31,8 @@ jobs:
           path: dist/*
 
   publish:
-    needs: [dist]
+    needs:
+      - dist
     runs-on: ubuntu-latest
     environment:
       name: publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8
-          - 3.9
-          - 3.10
-          - 3.11
-          - 3.12
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test
 
 on:
@@ -19,7 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version:
+          - 3.8
+          - 3.9
+          - 3.10
+          - 3.11
+          - 3.12
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 ci:
   autoupdate_commit_msg: "MNT: update pre-commit hooks"
   autofix_commit_msg: "STY: pre-commit fixes"
@@ -24,6 +25,52 @@ repos:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args:
+          - >-
+            --config-data={
+              extends: default,
+              rules: {
+                anchors: enable,
+                braces: {
+                  forbid: non-empty
+                },
+                brackets: {
+                  forbid: non-empty
+                },
+                colons: enable,
+                commas: enable,
+                comments: {
+                  min-spaces-from-content: 1
+                },
+                comments-indentation: enable,
+                document-end: disable,
+                document-start: enable,
+                empty-lines: enable,
+                empty-values: disable,
+                float-values: enable,
+                hyphens: enable,
+                indentation: enable,
+                key-duplicates: enable,
+                key-ordering: disable,
+                line-length: enable,
+                new-line-at-end-of-file: enable,
+                new-lines: enable,
+                octal-values: enable,
+                quoted-strings: {
+                  quote-type: double,
+                  required: only-when-needed
+                },
+                trailing-spaces: enable,
+                truthy: {
+                  check-keys: false
+                }
+              }
+            }
+          - --strict
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,9 @@ repos:
     rev: v0.6.3
     hooks:
       - id: ruff
-        args: ["--fix", "--show-fixes"]
+        args:
+          - --fix
+          - --show-fixes
       - id: ruff-format
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.23.1

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 build:


### PR DESCRIPTION
Still working towards #170. The options seem like a lot but these are ones I've used and I've found great for readability. Plus, for example, removing Python versions makes diffs easier when doing something like
```yaml
python-version:
  - "3.8"
  - "3.9"
  - "3.10"
  - "3.11"
```
rather than
```yaml
python-version: ["3.8", "3.9", "3.10", "3.11"]
```