### PR TITLE
gh-170: add traditional pre-commit-hooks

### DIFF
--- a/.github/test-constraints.txt
+++ b/.github/test-constraints.txt
@@ -1,2 +1,2 @@
---prefer-binary
 --only-binary numpy,scipy,healpy,healpix
+--prefer-binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,17 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
+        args:
+          - --fix=lf
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3


### PR DESCRIPTION
Adds several misc `pre-commit-hooks` recommended by scientific python.

Refs: #170, #187