### PR TITLE
gh-170: add traditional pygrep hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: python-check-blanket-type-ignore
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3
     hooks:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -13,7 +13,7 @@ and for the cosmological background.  Make sure you have CAMB installed:
     $ python -c 'import camb'  # should not give an error
 
 If you want to compute the angular matter power spectra in the examples, you
-need the `glass.ext.camb` package:
+need the ``glass.ext.camb`` package:
 
 .. code-block:: console
 

--- a/docs/manual/releases.rst
+++ b/docs/manual/releases.rst
@@ -75,7 +75,7 @@ These notes document the changes between individual *GLASS* releases.
   power spectra by index from a list using GLASS ordering.
 
 * The :func:`~glass.galaxies.gaussian_phz()` function now accepts bounds using
-  `lower=` and `upper=` keyword parameters.
+  ``lower=`` and ``upper=`` keyword parameters.
 
 
 2023.6 (30 Jun 2023)
@@ -157,7 +157,7 @@ These notes document the changes between individual *GLASS* releases.
     by window functions using :func:`glass.shells.restrict` and
     :func:`glass.shells.partition`.
 
-  - The ``zmin`` and ``zmax`` parameters of `glass.galaxies.redshifts_from_nz`
+  - The ``zmin`` and ``zmax`` parameters of ``glass.galaxies.redshifts_from_nz``
     have been removed for the same reason.
 
   - The ``glass.lensing.multi_plane_weights`` function, which computed all


### PR DESCRIPTION
Adds several misc `pygrep` hooks recommended by scientific python.

Refs: #170, #187