### PR TITLE
gh-204: split examples job and run it only on code changes

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,29 @@
+name: Test examples
+
+on:
+  push:
+    paths:
+      - "glass/**"
+  pull_request:
+    paths:
+      - "glass/**"
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test-examples:
+    name: Test examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - run: pipx run --spec '.[examples]' jupyter execute examples/**/*.ipynb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,16 +62,3 @@ jobs:
           sudo apt-get update
           sudo apt-get install pandoc
       - run: pipx run --spec '.[docs]' sphinx-build -W -b html docs _build/html
-
-  examples:
-    name: Examples
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-      - run: pipx run --spec '.[examples]' jupyter execute examples/**/*.ipynb


### PR DESCRIPTION
Makes example tests a standalone job that executes only if something is changed in `glass/`.

Closes: #204