### PR TITLE
gh-208: remove legacy random number generation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture
+def rng():
+    import numpy as np
+
+    return np.random.default_rng(seed=42)

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -17,8 +17,9 @@ def test_nnls():
 
     from glass.core.algorithm import nnls as nnls_glass
 
-    a = np.random.randn(100, 20)
-    b = np.random.randn(100)
+    rng = np.random.default_rng(seed=42)
+    a = rng.standard_normal((100, 20))
+    b = rng.standard_normal((100,))
 
     x_glass = nnls_glass(a, b)
     x_scipy, _ = nnls_scipy(a, b)

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -10,13 +10,6 @@ else:
     HAVE_SCIPY = True
 
 
-@pytest.fixture
-def rng():
-    import numpy as np
-
-    return np.random.default_rng(seed=42)
-
-
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")
 def test_nnls(rng):
     import numpy as np

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -10,14 +10,20 @@ else:
     HAVE_SCIPY = True
 
 
+@pytest.fixture
+def rng():
+    import numpy as np
+
+    return np.random.default_rng(seed=42)
+
+
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")
-def test_nnls():
+def test_nnls(rng):
     import numpy as np
     from scipy.optimize import nnls as nnls_scipy
 
     from glass.core.algorithm import nnls as nnls_glass
 
-    rng = np.random.default_rng(seed=42)
     a = rng.standard_normal((100, 20))
     b = rng.standard_normal((100,))
 

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -73,11 +73,12 @@ def test_deflect_many():
     from glass.lensing import deflect
 
     n = 1000
-    abs_alpha = np.random.uniform(0, 2 * np.pi, size=n)
-    arg_alpha = np.random.uniform(-np.pi, np.pi, size=n)
+    rng = np.random.default_rng(seed=42)
+    abs_alpha = rng.uniform(0, 2 * np.pi, size=n)
+    arg_alpha = rng.uniform(-np.pi, np.pi, size=n)
 
-    lon_ = np.degrees(np.random.uniform(-np.pi, np.pi, size=n))
-    lat_ = np.degrees(np.arcsin(np.random.uniform(-1, 1, size=n)))
+    lon_ = np.degrees(rng.uniform(-np.pi, np.pi, size=n))
+    lat_ = np.degrees(np.arcsin(rng.uniform(-1, 1, size=n)))
 
     lon, lat = deflect(lon_, lat_, abs_alpha * np.exp(1j * arg_alpha))
 
@@ -99,7 +100,8 @@ def test_multi_plane_matrix(shells, cosmo):
 
     convergence = MultiPlaneConvergence(cosmo)
 
-    deltas = np.random.rand(len(shells), 10)
+    rng = np.random.default_rng(seed=42)
+    deltas = rng.random((len(shells), 10))
     kappas = []
     for shell, delta in zip(shells, deltas):
         convergence.add_window(delta, shell)
@@ -119,8 +121,9 @@ def test_multi_plane_weights(shells, cosmo):
 
     convergence = MultiPlaneConvergence(cosmo)
 
-    deltas = np.random.rand(len(shells), 10)
-    weights = np.random.rand(len(shells), 3)
+    rng = np.random.default_rng(seed=42)
+    deltas = rng.random((len(shells), 10))
+    weights = rng.random((len(shells), 3))
     kappa = 0
     for shell, delta, weight in zip(shells, deltas, weights):
         convergence.add_window(delta, shell)

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -4,11 +4,6 @@ import pytest
 
 
 @pytest.fixture
-def rng():
-    return np.random.default_rng(seed=42)
-
-
-@pytest.fixture
 def shells():
     from glass.shells import RadialWindow
 

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -4,6 +4,11 @@ import pytest
 
 
 @pytest.fixture
+def rng():
+    return np.random.default_rng(seed=42)
+
+
+@pytest.fixture
 def shells():
     from glass.shells import RadialWindow
 
@@ -67,13 +72,12 @@ def test_deflect_nsew(usecomplex):
     assert np.allclose([lon, lat], [d, 0.0])
 
 
-def test_deflect_many():
+def test_deflect_many(rng):
     import healpix
 
     from glass.lensing import deflect
 
     n = 1000
-    rng = np.random.default_rng(seed=42)
     abs_alpha = rng.uniform(0, 2 * np.pi, size=n)
     arg_alpha = rng.uniform(-np.pi, np.pi, size=n)
 
@@ -90,7 +94,7 @@ def test_deflect_many():
     npt.assert_allclose(dotp, np.cos(abs_alpha))
 
 
-def test_multi_plane_matrix(shells, cosmo):
+def test_multi_plane_matrix(shells, cosmo, rng):
     from glass.lensing import MultiPlaneConvergence, multi_plane_matrix
 
     mat = multi_plane_matrix(shells, cosmo)
@@ -100,7 +104,6 @@ def test_multi_plane_matrix(shells, cosmo):
 
     convergence = MultiPlaneConvergence(cosmo)
 
-    rng = np.random.default_rng(seed=42)
     deltas = rng.random((len(shells), 10))
     kappas = []
     for shell, delta in zip(shells, deltas):
@@ -110,7 +113,7 @@ def test_multi_plane_matrix(shells, cosmo):
     npt.assert_allclose(mat @ deltas, kappas)
 
 
-def test_multi_plane_weights(shells, cosmo):
+def test_multi_plane_weights(shells, cosmo, rng):
     from glass.lensing import MultiPlaneConvergence, multi_plane_weights
 
     w_in = np.eye(len(shells))
@@ -121,7 +124,6 @@ def test_multi_plane_weights(shells, cosmo):
 
     convergence = MultiPlaneConvergence(cosmo)
 
-    rng = np.random.default_rng(seed=42)
     deltas = rng.random((len(shells), 10))
     weights = rng.random((len(shells), 3))
     kappa = 0

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -102,8 +102,9 @@ def test_position_weights():
 
     for bshape in None, (), (100,), (100, 1):
         for cshape in (100,), (100, 50), (100, 3, 2):
-            counts = np.random.rand(*cshape)
-            bias = None if bshape is None else np.random.rand(*bshape)
+            rng = np.random.default_rng(seed=42)
+            counts = rng.random(cshape)
+            bias = None if bshape is None else rng.random(bshape)
 
             weights = position_weights(counts, bias)
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -1,5 +1,11 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(seed=42)
 
 
 def catpos(pos):
@@ -97,12 +103,11 @@ def test_uniform_positions():
     assert lon.shape == lat.shape == (cnt.sum(),)
 
 
-def test_position_weights():
+def test_position_weights(rng):
     from glass.points import position_weights
 
     for bshape in None, (), (100,), (100, 1):
         for cshape in (100,), (100, 50), (100, 3, 2):
-            rng = np.random.default_rng(seed=42)
             counts = rng.random(cshape)
             bias = None if bshape is None else rng.random(bshape)
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -1,11 +1,5 @@
 import numpy as np
 import numpy.testing as npt
-import pytest
-
-
-@pytest.fixture
-def rng():
-    return np.random.default_rng(seed=42)
 
 
 def catpos(pos):


### PR DESCRIPTION
Gets rid of legacy `RandomState` and replaced it with the new random number `Generator` for rng calls.

Fixes: #208