### PR TITLE
gh-204: examples run twice on PRs

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,9 +4,13 @@ on:
   push:
     paths:
       - "glass/**"
+    branches:
+      - main
   pull_request:
     paths:
       - "glass/**"
+    branches:
+      - main
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     paths:
       - "glass/**"
-    branches:
-      - main
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Minor fix. The examples run twice on PRs right now as `branches` is not specified under `on`.

Refs: #204