### PR TITLE
gh-226: pre-commit's mirror of prettier is obsolete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
           - --in-place
           - --spaces-indent-inline-array=4
           - --trailing-comma-inline-array
-  - repo: https://github.com/pre-commit/mirrors-prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
           - --spaces-indent-inline-array=4
           - --trailing-comma-inline-array
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.1.0
+    rev: v3.3.3
     hooks:
       - id: prettier
         args:


### PR DESCRIPTION
[pre-commit's mirror of prettier](https://github.com/pre-commit/mirrors-prettier) was [archived](https://github.com/pre-commit/mirrors-prettier?tab=readme-ov-file#archived) a few months back -

> # archived
>
> prettier made some changes that breaks plugins entirely

Scientific Python recommends using https://github.com/rbubley/mirrors-prettier?tab=readme-ov-file now.

Refs: #226 