### PR TITLE
gh-265: calculate `fixture` once per testing `session`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def rng():
     import numpy as np
 


### PR DESCRIPTION
Follows up https://github.com/glass-dev/glass/pull/241. See explanation of what the `scope` parameter does for `pytest.fixture`. Seems silly to not use it (although in this case the speed-up will be minimal).