### PR TITLE
gh-278: ignore reduandant lines and files from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,14 @@ Documentation = "https://glass.readthedocs.io/"
 Homepage = "https://github.com/glass-dev/glass"
 Issues = "https://github.com/glass-dev/glass/issues"
 
+[tool.coverage.report]
+exclude_also = [
+    "if TYPE_CHECKING:",
+]
+omit = [
+    "glass/_version.py",
+]
+
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"
 version.source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,11 @@ Homepage = "https://github.com/glass-dev/glass"
 Issues = "https://github.com/glass-dev/glass/issues"
 
 [tool.coverage]
-report.exclude_also = [
+report = {exclude_also = [
     "if TYPE_CHECKING:",
-]
-report.omit = [
+], omit = [
     "glass/_version.py",
-]
+]}
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ Documentation = "https://glass.readthedocs.io/"
 Homepage = "https://github.com/glass-dev/glass"
 Issues = "https://github.com/glass-dev/glass/issues"
 
-[tool.coverage.report]
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
-omit = [
+report.omit = [
     "glass/_version.py",
 ]
 


### PR DESCRIPTION
Adds coverage config in pyproject.toml to ignore VCS produced files and conditional code meant for type checking.

Closes: #278 