### PR TITLE
gh-267: move verbose output flag for ruff and pytest to pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -c .github/test-constraints.txt -e '.[test]'
-      - run: pytest --cov=glass --doctest-plus -v
+      - run: pytest --cov=glass --doctest-plus
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,9 +75,6 @@ repos:
     rev: v0.6.7
     hooks:
       - id: ruff
-        args:
-          - --fix
-          - --show-fixes
       - id: ruff-format
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.18.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ addopts = [
     "--strict-config",
     "--strict-markers",
     "-ra",
+    "-v",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",
@@ -91,6 +92,7 @@ xfail_strict = true
 [tool.ruff]
 fix = true
 force-exclude = true
+show-fixes = true
 src = [
     "glass",
 ]


### PR DESCRIPTION
Verbose output flags for both ruff and pytest are used frequently enough to be added to pyproject.toml.

Refs: #267 