### PR TITLE
gh-288: run CI when a draft PR is marked as ready

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,6 +10,12 @@ on:
   pull_request:
     paths:
       - glass/**
+    # ensure the draft PRs are tested when ready
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
   pull_request:
+    # ensure the draft PRs are tested when ready
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Fixes #288. Currently a PR is never tested the moment it gets marked as draft. The idea behind not running in draft is to limit CI use, but we need to ensure everything is ran before merging to `main`.