### PR TITLE
gh-290: add extra contact links to the raise issue button

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,12 @@
 ---
 blank_issues_enabled: false
+contact_links:
+  - name: Raise a GLASS Discussion
+    url: https://github.com/orgs/glass-dev/discussions
+    about:
+      If you would like to start a discussion with the wider GLASS community
+      about e.g. a design decision or API change, you can use our Discussions
+      page.
+  - name: Join the GLASS Slack
+    url: https://glass-dev.github.io/slack
+    about: We have a public Slack workspace for discussions about the project.


### PR DESCRIPTION
Closes #290. Utilise the powerful `contact_links` feature GitHub provides https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser. Tested on a dummy repo.

![image](https://github.com/user-attachments/assets/574129aa-d2af-4e95-93de-16cabeb3e70a)