### PR TITLE
gh-297: do not autofix PRs using pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ---
 ci:
+  autofix_prs: false
   autoupdate_commit_msg: "MNT: update pre-commit hooks"
   autofix_commit_msg: "STY: pre-commit fixes"
 


### PR DESCRIPTION
The PRs will not be fixed automatically, but the bot can still be triggered for fixes by commenting `pre-commit.ci autofix` on a PR.

The other functionalities (occasional version updates, running checks in the CI) will stay as it is.