### PR TITLE
gh-302: add `actionlint` and fix issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,9 @@ jobs:
       - name: Install nox and coverage.py
         run: pip install coverage[toml] nox
       - name: Run doctests
-        run:
-          nox -s doctests-${{ matrix.python-version.key || matrix.python-version
-          }} --verbose
+        run: nox -s doctests-${{ matrix.python-version }} --verbose
       - name: Run tests and generate coverage report
-        run:
-          nox -s coverage-${{ matrix.python-version.key || matrix.python-version
-          }} --verbose
+        run: nox -s coverage-${{ matrix.python-version }} --verbose
       - name: Coveralls requires XML report
         run: coverage xml
       - uses: coverallsapp/github-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,7 @@ repos:
       - id: markdownlint-fix
         args:
           - --dot
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.3
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
Add https://github.com/rhysd/actionlint to check through GitHub Actions workflows.

The fix was related to this error

```yaml
.github/workflows/test.yml:51:31: receiver of object dereference "key" must be type of object but got "number" [expression]
   |
51 |           nox -s doctests-${{ matrix.python-version.key || matrix.python-version
   |                               ^~~~~~~~~~~~~~~~~~~~~~~~~
.github/workflows/test.yml:55:31: receiver of object dereference "key" must be type of object but got "number" [expression]
   |
55 |           nox -s coverage-${{ matrix.python-version.key || matrix.python-version
```

Why did we have this `matrix.python-version.key` bit @Saransh-cpp? Introduced in https://github.com/glass-dev/glass/pull/287, sorry I missed it.