### PR TITLE
gh-246: replace `numpy.ndarray` with `numpy.typing.NDArray`

### DIFF
--- a/glass/core/algorithm.py
+++ b/glass/core/algorithm.py
@@ -7,16 +7,16 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from numpy.typing import ArrayLike
+    import numpy.typing as npt
 
 
 def nnls(
-    a: ArrayLike,
-    b: ArrayLike,
+    a: npt.ArrayLike,
+    b: npt.ArrayLike,
     *,
     tol: float = 0.0,
     maxiter: int | None = None,
-) -> ArrayLike:
+) -> npt.ArrayLike:
     """
     Compute a non-negative least squares solution.
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -37,12 +37,12 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Array = np.ndarray
+Array = npt.NDArray
 Size = Union[None, int, Tuple[int, ...]]
 Iternorm = Tuple[Optional[int], Array, Array]
 ClTransform = Union[str, Callable[[Array], Array]]
 Cls = Sequence[Union[Array, Sequence[float]]]
-Alms = np.ndarray
+Alms = npt.NDArray
 
 
 def iternorm(

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -37,7 +37,7 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Size = None | int | tuple[int, ...]
+Size = int | tuple[int, ...] | None
 Iternorm = tuple[int | None, npt.NDArray, npt.NDArray]
 ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
 Cls = Sequence[npt.NDArray | Sequence[float]]

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import warnings
 
 # typing
-from typing import Any, Callable, Generator, Iterable, Optional, Sequence
+from typing import Any, Callable, Generator, Iterable, Sequence
 
 import healpy as hp
 import numpy as np
@@ -38,7 +38,7 @@ from gaussiancl import gaussiancl
 
 # types
 Size = None | int | tuple[int, ...]
-Iternorm = tuple[Optional[int], npt.NDArray, npt.NDArray]
+Iternorm = tuple[int | None, npt.NDArray, npt.NDArray]
 ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
 Cls = Sequence[npt.NDArray | Sequence[float]]
 Alms = npt.NDArray

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -39,7 +39,7 @@ from gaussiancl import gaussiancl
 # types
 Size = Optional[Union[int | Tuple[int, ...]]]
 Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
-ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
+ClTransform = Union[str, Callable[[npt.NDArray], npt.NDArray]]
 Cls = Sequence[Union[npt.NDArray, Sequence[float]]]
 Alms = npt.NDArray
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -37,7 +37,7 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Size = Optional[Union[int | Tuple[int, ...]]]
+Size = Optional[Union[int, Tuple[int, ...]]]
 Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
 ClTransform = Union[str, Callable[[npt.NDArray], npt.NDArray]]
 Cls = Sequence[Union[npt.NDArray, Sequence[float]]]

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -40,7 +40,7 @@ from gaussiancl import gaussiancl
 Size = Optional[Union[int | Tuple[int, ...]]]
 Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
 ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
-Cls = Sequence[npt.NDArray | Sequence[float]]
+Cls = Sequence[Union[npt.NDArray, Sequence[float]]]
 Alms = npt.NDArray
 
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -37,17 +37,16 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Array = npt.NDArray
 Size = Union[None, int, Tuple[int, ...]]
-Iternorm = Tuple[Optional[int], Array, Array]
-ClTransform = Union[str, Callable[[Array], Array]]
-Cls = Sequence[Union[Array, Sequence[float]]]
+Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
+ClTransform = Union[str, Callable[[npt.NDArray], npt.NDArray]]
+Cls = Sequence[Union[npt.NDArray, Sequence[float]]]
 Alms = npt.NDArray
 
 
 def iternorm(
     k: int,
-    cov: Iterable[Array],
+    cov: Iterable[npt.NDArray],
     size: Size = None,
 ) -> Generator[Iternorm, None, None]:
     """Return the vector a and variance sigma^2 for iterative normal sampling."""
@@ -107,7 +106,7 @@ def iternorm(
         yield j, a, s
 
 
-def cls2cov(cls: Cls, nl: int, nf: int, nc: int) -> Generator[Array, None, None]:
+def cls2cov(cls: Cls, nl: int, nf: int, nc: int) -> Generator[npt.NDArray, None, None]:
     """Return array of cls as a covariance matrix for iterative sampling."""
     cov = np.zeros((nl, nc + 1))
     end = 0
@@ -127,7 +126,7 @@ def cls2cov(cls: Cls, nl: int, nf: int, nc: int) -> Generator[Array, None, None]
         yield cov
 
 
-def multalm(alm: Alms, bl: Array, *, inplace: bool = False) -> Alms:
+def multalm(alm: Alms, bl: npt.NDArray, *, inplace: bool = False) -> Alms:
     """Multiply alm by bl."""
     n = len(bl)
     out = np.asanyarray(alm) if inplace else np.copy(alm)
@@ -214,7 +213,7 @@ def generate_gaussian(
     *,
     ncorr: int | None = None,
     rng: np.random.Generator | None = None,
-) -> Generator[Array, None, None]:
+) -> Generator[npt.NDArray, None, None]:
     """
     Sample Gaussian random fields from Cls iteratively.
 
@@ -300,7 +299,7 @@ def generate_lognormal(
     *,
     ncorr: int | None = None,
     rng: np.random.Generator | None = None,
-) -> Generator[Array, None, None]:
+) -> Generator[npt.NDArray, None, None]:
     """Sample lognormal random fields from Gaussian Cls iteratively."""
     for i, m in enumerate(generate_gaussian(gls, nside, ncorr=ncorr, rng=rng)):
         # compute the variance of the auto-correlation

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import warnings
 
 # typing
-from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Tuple
+from typing import Any, Callable, Generator, Iterable, Optional, Sequence
 
 import healpy as hp
 import numpy as np
@@ -37,8 +37,8 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Size = None | int | Tuple[int, ...]
-Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
+Size = None | int | tuple[int, ...]
+Iternorm = tuple[Optional[int], npt.NDArray, npt.NDArray]
 ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
 Cls = Sequence[npt.NDArray | Sequence[float]]
 Alms = npt.NDArray

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import warnings
 
 # typing
-from typing import Any, Callable, Generator, Iterable, Sequence
+from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Tuple, Union
 
 import healpy as hp
 import numpy as np
@@ -37,8 +37,8 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Size = int | tuple[int, ...] | None
-Iternorm = tuple[int | None, npt.NDArray, npt.NDArray]
+Size = Optional[Union[int | Tuple[int, ...]]]
+Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
 ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
 Cls = Sequence[npt.NDArray | Sequence[float]]
 Alms = npt.NDArray

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import warnings
 
 # typing
-from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Tuple
 
 import healpy as hp
 import numpy as np
@@ -37,10 +37,10 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Size = Union[None, int, Tuple[int, ...]]
+Size = None | int | Tuple[int, ...]
 Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
-ClTransform = Union[str, Callable[[npt.NDArray], npt.NDArray]]
-Cls = Sequence[Union[npt.NDArray, Sequence[float]]]
+ClTransform = str | Callable[[npt.NDArray], npt.NDArray]
+Cls = Sequence[npt.NDArray | Sequence[float]]
 Alms = npt.NDArray
 
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from numpy.typing import ArrayLike
+    import numpy.typing as npt
 
     from glass.shells import RadialWindow
 
@@ -33,11 +33,11 @@ from glass.core.array import broadcast_leading_axes, cumtrapz
 
 
 def redshifts(
-    n: int | ArrayLike,
+    n: int | npt.ArrayLike,
     w: RadialWindow,
     *,
     rng: np.random.Generator | None = None,
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Sample redshifts from a radial window function.
 
@@ -64,12 +64,12 @@ def redshifts(
 
 
 def redshifts_from_nz(
-    count: int | ArrayLike,
-    z: ArrayLike,
-    nz: ArrayLike,
+    count: int | npt.ArrayLike,
+    z: npt.ArrayLike,
+    nz: npt.ArrayLike,
     *,
     rng: np.random.Generator | None = None,
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Generate galaxy redshifts from a source distribution.
 
@@ -132,15 +132,15 @@ def redshifts_from_nz(
 
 
 def galaxy_shear(  # noqa: PLR0913
-    lon: np.ndarray,
-    lat: np.ndarray,
-    eps: np.ndarray,
-    kappa: np.ndarray,
-    gamma1: np.ndarray,
-    gamma2: np.ndarray,
+    lon: npt.NDArray,
+    lat: npt.NDArray,
+    eps: npt.NDArray,
+    kappa: npt.NDArray,
+    gamma1: npt.NDArray,
+    gamma2: npt.NDArray,
     *,
     reduced_shear: bool = True,
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Observed galaxy shears from weak lensing.
 
@@ -195,13 +195,13 @@ def galaxy_shear(  # noqa: PLR0913
 
 
 def gaussian_phz(
-    z: ArrayLike,
-    sigma_0: float | ArrayLike,
+    z: npt.ArrayLike,
+    sigma_0: float | npt.ArrayLike,
     *,
-    lower: ArrayLike | None = None,
-    upper: ArrayLike | None = None,
+    lower: npt.ArrayLike | None = None,
+    upper: npt.ArrayLike | None = None,
     rng: np.random.Generator | None = None,
-) -> np.ndarray:
+) -> npt.NDArray:
     r"""
     Photometric redshifts assuming a Gaussian error.
 

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -39,7 +39,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     # to prevent circular dependencies, only import these for type checking
-    from numpy.typing import ArrayLike, NDArray
+    import numpy.typing as npt
 
     from cosmology import Cosmology
 
@@ -47,14 +47,14 @@ if TYPE_CHECKING:
 
 
 def from_convergence(  # noqa: PLR0913
-    kappa: NDArray,
+    kappa: npt.NDArray,
     lmax: int | None = None,
     *,
     potential: bool = False,
     deflection: bool = False,
     shear: bool = False,
     discretized: bool = True,
-) -> tuple[NDArray, ...]:
+) -> tuple[npt.NDArray, ...]:
     r"""
     Compute other weak lensing maps from the convergence.
 
@@ -226,11 +226,11 @@ def from_convergence(  # noqa: PLR0913
 
 
 def shear_from_convergence(
-    kappa: np.ndarray,
+    kappa: npt.NDArray,
     lmax: int | None = None,
     *,
     discretized: bool = True,
-) -> np.ndarray:
+) -> npt.NDArray:
     r"""
     Weak lensing shear from convergence.
 
@@ -282,11 +282,11 @@ class MultiPlaneConvergence:
         self.x3: float = 0.0
         self.w3: float = 0.0
         self.r23: float = 1.0
-        self.delta3: np.ndarray = np.array(0.0)
-        self.kappa2: np.ndarray | None = None
-        self.kappa3: np.ndarray | None = None
+        self.delta3: npt.NDArray = np.array(0.0)
+        self.kappa2: npt.NDArray | None = None
+        self.kappa3: npt.NDArray | None = None
 
-    def add_window(self, delta: np.ndarray, w: RadialWindow) -> None:
+    def add_window(self, delta: npt.NDArray, w: RadialWindow) -> None:
         """
         Add a mass plane from a window function to the convergence.
 
@@ -299,7 +299,7 @@ class MultiPlaneConvergence:
 
         self.add_plane(delta, zsrc, lens_weight)
 
-    def add_plane(self, delta: np.ndarray, zsrc: float, wlens: float = 1.0) -> None:
+    def add_plane(self, delta: npt.NDArray, zsrc: float, wlens: float = 1.0) -> None:
         """Add a mass plane at redshift ``zsrc`` to the convergence."""
         if zsrc <= self.z3:
             msg = "source redshift must be increasing"
@@ -348,12 +348,12 @@ class MultiPlaneConvergence:
         return self.z3
 
     @property
-    def kappa(self) -> np.ndarray | None:
+    def kappa(self) -> npt.NDArray | None:
         """The current convergence plane."""
         return self.kappa3
 
     @property
-    def delta(self) -> np.ndarray:
+    def delta(self) -> npt.NDArray:
         """The current matter plane."""
         return self.delta3
 
@@ -366,7 +366,7 @@ class MultiPlaneConvergence:
 def multi_plane_matrix(
     shells: Sequence[RadialWindow],
     cosmo: Cosmology,
-) -> ArrayLike:
+) -> npt.ArrayLike:
     """Compute the matrix of lensing contributions from each shell."""
     mpc = MultiPlaneConvergence(cosmo)
     wmat = np.eye(len(shells))
@@ -377,10 +377,10 @@ def multi_plane_matrix(
 
 
 def multi_plane_weights(
-    weights: ArrayLike,
+    weights: npt.ArrayLike,
     shells: Sequence[RadialWindow],
     cosmo: Cosmology,
-) -> ArrayLike:
+) -> npt.ArrayLike:
     """
     Compute effective weights for multi-plane convergence.
 
@@ -419,7 +419,9 @@ def multi_plane_weights(
     return np.matmul(mat.T, weights)
 
 
-def deflect(lon: ArrayLike, lat: ArrayLike, alpha: ArrayLike) -> NDArray:
+def deflect(
+    lon: npt.ArrayLike, lat: npt.ArrayLike, alpha: npt.ArrayLike
+) -> npt.NDArray:
     r"""
     Apply deflections to positions.
 

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -37,14 +37,14 @@ import numpy as np
 from glass.core.array import cumtrapz
 
 if TYPE_CHECKING:
-    from numpy.typing import ArrayLike
+    import numpy.typing as npt
 
 
 def vmap_galactic_ecliptic(
     nside: int,
     galactic: tuple[float, float] = (30, 90),
     ecliptic: tuple[float, float] = (20, 80),
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Visibility map masking galactic and ecliptic plane.
 
@@ -86,12 +86,12 @@ def vmap_galactic_ecliptic(
 
 
 def gaussian_nz(
-    z: np.ndarray,
-    mean: ArrayLike,
-    sigma: ArrayLike,
+    z: npt.NDArray,
+    mean: npt.ArrayLike,
+    sigma: npt.ArrayLike,
     *,
-    norm: ArrayLike | None = None,
-) -> np.ndarray:
+    norm: npt.ArrayLike | None = None,
+) -> npt.NDArray:
     r"""
     Gaussian redshift distribution.
 
@@ -131,13 +131,13 @@ def gaussian_nz(
 
 
 def smail_nz(
-    z: np.ndarray,
-    z_mode: ArrayLike,
-    alpha: ArrayLike,
-    beta: ArrayLike,
+    z: npt.NDArray,
+    z_mode: npt.ArrayLike,
+    alpha: npt.ArrayLike,
+    beta: npt.ArrayLike,
     *,
-    norm: ArrayLike | None = None,
-) -> np.ndarray:
+    norm: npt.ArrayLike | None = None,
+) -> npt.NDArray:
     r"""
     Redshift distribution following Smail et al. (1994).
 
@@ -232,8 +232,8 @@ def fixed_zbins(
 
 
 def equal_dens_zbins(
-    z: np.ndarray,
-    nz: np.ndarray,
+    z: npt.NDArray,
+    nz: npt.NDArray,
     nbins: int,
 ) -> list[tuple[float, float]]:
     """
@@ -267,11 +267,11 @@ def equal_dens_zbins(
 
 
 def tomo_nz_gausserr(
-    z: np.ndarray,
-    nz: np.ndarray,
+    z: npt.NDArray,
+    nz: npt.NDArray,
     sigma_0: float,
     zbins: list[tuple[float, float]],
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Tomographic redshift bins with a Gaussian redshift error.
 

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
+    import numpy.typing as npt
 
 
 def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
@@ -167,11 +167,11 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
 
 
 def ellipticity_gaussian(
-    count: int | ArrayLike,
-    sigma: ArrayLike,
+    count: int | npt.ArrayLike,
+    sigma: npt.ArrayLike,
     *,
     rng: np.random.Generator | None = None,
-) -> NDArray:
+) -> npt.NDArray:
     r"""
     Sample Gaussian galaxy ellipticities.
 
@@ -224,11 +224,11 @@ def ellipticity_gaussian(
 
 
 def ellipticity_intnorm(
-    count: int | ArrayLike,
-    sigma: ArrayLike,
+    count: int | npt.ArrayLike,
+    sigma: npt.ArrayLike,
     *,
     rng: np.random.Generator | None = None,
-) -> NDArray:
+) -> npt.NDArray:
     r"""
     Sample galaxy ellipticities with intrinsic normal distribution.
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import warnings
 
 # type checking
-from typing import TYPE_CHECKING, Callable, NamedTuple, Sequence
+from typing import TYPE_CHECKING, Callable, NamedTuple, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 
 
 # types
-ArrayLike1D = Sequence[float] | npt.NDArray
+ArrayLike1D = Union[Sequence[float], npt.NDArray]
 WeightFunc = Callable[[ArrayLike1D], npt.NDArray]
 
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -50,31 +50,30 @@ import warnings
 from typing import TYPE_CHECKING, Callable, NamedTuple, Sequence, Union
 
 import numpy as np
+import numpy.typing as npt
 
 from glass.core.array import ndinterp
 
 if TYPE_CHECKING:
-    from numpy.typing import ArrayLike
-
     from cosmology import Cosmology
 
 
 # types
-ArrayLike1D = Union[Sequence[float], np.ndarray]
-WeightFunc = Callable[[ArrayLike1D], np.ndarray]
+ArrayLike1D = Union[Sequence[float], npt.NDArray]
+WeightFunc = Callable[[ArrayLike1D], npt.NDArray]
 
 
-def distance_weight(z: ArrayLike, cosmo: Cosmology) -> np.ndarray:
+def distance_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray:
     """Uniform weight in comoving distance."""
     return 1 / cosmo.ef(z)
 
 
-def volume_weight(z: ArrayLike, cosmo: Cosmology) -> np.ndarray:
+def volume_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray:
     """Uniform weight in comoving volume."""
     return cosmo.xm(z) ** 2 / cosmo.ef(z)
 
 
-def density_weight(z: ArrayLike, cosmo: Cosmology) -> np.ndarray:
+def density_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray:
     """Uniform weight in matter density."""
     return cosmo.rho_m_z(z) * cosmo.xm(z) ** 2 / cosmo.ef(z)
 
@@ -314,7 +313,7 @@ def restrict(
     z: ArrayLike1D,
     f: ArrayLike1D,
     w: RadialWindow,
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[npt.NDArray, npt.NDArray]:
     """
     Restrict a function to a redshift window.
 
@@ -352,12 +351,12 @@ def restrict(
 
 
 def partition(
-    z: ArrayLike,
-    fz: ArrayLike,
+    z: npt.ArrayLike,
+    fz: npt.ArrayLike,
     shells: Sequence[RadialWindow],
     *,
     method: str = "nnls",
-) -> ArrayLike:
+) -> npt.ArrayLike:
     r"""
     Partition a function by a sequence of windows.
 
@@ -462,12 +461,12 @@ def partition(
 
 
 def partition_lstsq(
-    z: ArrayLike,
-    fz: ArrayLike,
+    z: npt.ArrayLike,
+    fz: npt.ArrayLike,
     shells: Sequence[RadialWindow],
     *,
     sumtol: float = 0.01,
-) -> ArrayLike:
+) -> npt.ArrayLike:
     """Least-squares partition."""
     # make sure nothing breaks
     sumtol = max(sumtol, 1e-4)
@@ -508,12 +507,12 @@ def partition_lstsq(
 
 
 def partition_nnls(
-    z: ArrayLike,
-    fz: ArrayLike,
+    z: npt.ArrayLike,
+    fz: npt.ArrayLike,
     shells: Sequence[RadialWindow],
     *,
     sumtol: float = 0.01,
-) -> ArrayLike:
+) -> npt.ArrayLike:
     """
     Non-negative least-squares partition.
 
@@ -569,10 +568,10 @@ def partition_nnls(
 
 
 def partition_restrict(
-    z: ArrayLike,
-    fz: ArrayLike,
+    z: npt.ArrayLike,
+    fz: npt.ArrayLike,
     shells: Sequence[RadialWindow],
-) -> ArrayLike:
+) -> npt.ArrayLike:
     """Partition by restriction and integration."""
     part = np.empty((len(shells),) + np.shape(fz)[:-1])
     for i, w in enumerate(shells):
@@ -607,10 +606,10 @@ def distance_grid(cosmo, zmin, zmax, *, dx=None, num=None):
 
 
 def combine(
-    z: ArrayLike,
-    weights: ArrayLike,
+    z: npt.ArrayLike,
+    weights: npt.ArrayLike,
     shells: Sequence[RadialWindow],
-) -> ArrayLike:
+) -> npt.ArrayLike:
     r"""
     Evaluate a linear combination of window functions.
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import warnings
 
 # type checking
-from typing import TYPE_CHECKING, Callable, NamedTuple, Sequence, Union
+from typing import TYPE_CHECKING, Callable, NamedTuple, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 
 
 # types
-ArrayLike1D = Union[Sequence[float], npt.NDArray]
+ArrayLike1D = Sequence[float] | npt.NDArray
 WeightFunc = Callable[[ArrayLike1D], npt.NDArray]
 
 

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.testing as npt
 import pytest
 
 # check if scipy is available for testing
@@ -69,17 +68,17 @@ def test_ndinterp():
     x = 0.5
     y = ndinterp(x, xp, yp)
     assert np.shape(y) == ()
-    npt.assert_allclose(y, 1.15, atol=1e-15)
+    np.testing.assert_allclose(y, 1.15, atol=1e-15)
 
     x = [0.5, 1.5, 2.5]
     y = ndinterp(x, xp, yp)
     assert np.shape(y) == (3,)
-    npt.assert_allclose(y, [1.15, 1.25, 1.35], atol=1e-15)
+    np.testing.assert_allclose(y, [1.15, 1.25, 1.35], atol=1e-15)
 
     x = [[0.5, 1.5], [2.5, 3.5]]
     y = ndinterp(x, xp, yp)
     assert np.shape(y) == (2, 2)
-    npt.assert_allclose(y, [[1.15, 1.25], [1.35, 1.45]], atol=1e-15)
+    np.testing.assert_allclose(y, [[1.15, 1.25], [1.35, 1.45]], atol=1e-15)
 
     # test nd interpolation in final axis
 
@@ -88,17 +87,17 @@ def test_ndinterp():
     x = 0.5
     y = ndinterp(x, xp, yp)
     assert np.shape(y) == (2,)
-    npt.assert_allclose(y, [1.15, 2.15], atol=1e-15)
+    np.testing.assert_allclose(y, [1.15, 2.15], atol=1e-15)
 
     x = [0.5, 1.5, 2.5]
     y = ndinterp(x, xp, yp)
     assert np.shape(y) == (2, 3)
-    npt.assert_allclose(y, [[1.15, 1.25, 1.35], [2.15, 2.25, 2.35]], atol=1e-15)
+    np.testing.assert_allclose(y, [[1.15, 1.25, 1.35], [2.15, 2.25, 2.35]], atol=1e-15)
 
     x = [[0.5, 1.5], [2.5, 3.5]]
     y = ndinterp(x, xp, yp)
     assert np.shape(y) == (2, 2, 2)
-    npt.assert_allclose(
+    np.testing.assert_allclose(
         y,
         [[[1.15, 1.25], [1.35, 1.45]], [[2.15, 2.25], [2.35, 2.45]]],
         atol=1e-15,
@@ -111,12 +110,12 @@ def test_ndinterp():
     x = 0.5
     y = ndinterp(x, xp, yp, axis=1)
     assert np.shape(y) == (2, 1)
-    npt.assert_allclose(y, [[1.15], [2.15]], atol=1e-15)
+    np.testing.assert_allclose(y, [[1.15], [2.15]], atol=1e-15)
 
     x = [0.5, 1.5, 2.5]
     y = ndinterp(x, xp, yp, axis=1)
     assert np.shape(y) == (2, 3, 1)
-    npt.assert_allclose(
+    np.testing.assert_allclose(
         y,
         [[[1.15], [1.25], [1.35]], [[2.15], [2.25], [2.35]]],
         atol=1e-15,
@@ -125,7 +124,7 @@ def test_ndinterp():
     x = [[0.5, 1.5, 2.5, 3.5], [3.5, 2.5, 1.5, 0.5], [0.5, 3.5, 1.5, 2.5]]
     y = ndinterp(x, xp, yp, axis=1)
     assert np.shape(y) == (2, 3, 4, 1)
-    npt.assert_allclose(
+    np.testing.assert_allclose(
         y,
         [
             [
@@ -171,19 +170,19 @@ def test_cumtrapz():
     # default dtype (int - not supported by scipy)
 
     glass_ct = cumtrapz(f, x)
-    npt.assert_allclose(glass_ct, np.array([0, 1, 4, 7]))
+    np.testing.assert_allclose(glass_ct, np.array([0, 1, 4, 7]))
 
     # explicit dtype (float)
 
     glass_ct = cumtrapz(f, x, dtype=float)
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
-    npt.assert_allclose(glass_ct, scipy_ct)
+    np.testing.assert_allclose(glass_ct, scipy_ct)
 
     # explicit return array
 
     result = cumtrapz(f, x, dtype=float, out=np.zeros((4,)))
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
-    npt.assert_allclose(result, scipy_ct)
+    np.testing.assert_allclose(result, scipy_ct)
 
     # 2D f and 1D x
 
@@ -193,16 +192,16 @@ def test_cumtrapz():
     # default dtype (int - not supported by scipy)
 
     glass_ct = cumtrapz(f, x)
-    npt.assert_allclose(glass_ct, np.array([[0, 2, 12, 31], [0, 2, 8, 17]]))
+    np.testing.assert_allclose(glass_ct, np.array([[0, 2, 12, 31], [0, 2, 8, 17]]))
 
     # explicit dtype (float)
 
     glass_ct = cumtrapz(f, x, dtype=float)
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
-    npt.assert_allclose(glass_ct, scipy_ct)
+    np.testing.assert_allclose(glass_ct, scipy_ct)
 
     # explicit return array
 
     glass_ct = cumtrapz(f, x, dtype=float, out=np.zeros((2, 4)))
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
-    npt.assert_allclose(glass_ct, scipy_ct)
+    np.testing.assert_allclose(glass_ct, scipy_ct)

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.testing as npt
 import pytest
 
 
@@ -86,7 +85,7 @@ def test_deflect_many(rng):
 
     dotp = x * x_ + y * y_ + z * z_
 
-    npt.assert_allclose(dotp, np.cos(abs_alpha))
+    np.testing.assert_allclose(dotp, np.cos(abs_alpha))
 
 
 def test_multi_plane_matrix(shells, cosmo, rng):
@@ -94,8 +93,8 @@ def test_multi_plane_matrix(shells, cosmo, rng):
 
     mat = multi_plane_matrix(shells, cosmo)
 
-    npt.assert_array_equal(mat, np.tril(mat))
-    npt.assert_array_equal(np.triu(mat, 1), 0)
+    np.testing.assert_array_equal(mat, np.tril(mat))
+    np.testing.assert_array_equal(np.triu(mat, 1), 0)
 
     convergence = MultiPlaneConvergence(cosmo)
 
@@ -105,7 +104,7 @@ def test_multi_plane_matrix(shells, cosmo, rng):
         convergence.add_window(delta, shell)
         kappas.append(convergence.kappa.copy())
 
-    npt.assert_allclose(mat @ deltas, kappas)
+    np.testing.assert_allclose(mat @ deltas, kappas)
 
 
 def test_multi_plane_weights(shells, cosmo, rng):
@@ -114,8 +113,8 @@ def test_multi_plane_weights(shells, cosmo, rng):
     w_in = np.eye(len(shells))
     w_out = multi_plane_weights(w_in, shells, cosmo)
 
-    npt.assert_array_equal(w_out, np.triu(w_out, 1))
-    npt.assert_array_equal(np.tril(w_out), 0)
+    np.testing.assert_array_equal(w_out, np.triu(w_out, 1))
+    np.testing.assert_array_equal(np.tril(w_out), 0)
 
     convergence = MultiPlaneConvergence(cosmo)
 
@@ -129,4 +128,4 @@ def test_multi_plane_weights(shells, cosmo, rng):
 
     wmat = multi_plane_weights(weights, shells, cosmo)
 
-    npt.assert_allclose(np.einsum("ij,ik", wmat, deltas), kappa)
+    np.testing.assert_allclose(np.einsum("ij,ik", wmat, deltas), kappa)

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.testing as npt
 
 
 def catpos(pos):
@@ -121,4 +120,4 @@ def test_position_weights(rng):
                     )
                 expected = bias * expected
 
-            npt.assert_allclose(weights, expected)
+            np.testing.assert_allclose(weights, expected)


### PR DESCRIPTION
Closes #246. Use `numpy.typing.NDArray` as the first step towards #280. With `NDArray` we can use types, i.e. `NDArray[np.float64]`, which I'll save for future work (#306).

I have also gone throughout and made sure anything like `ArrayLike` is using the alias `import numpy.typing as npt`. Imports are generally in a `if TYPE_CHECKING` block where possible.

We are using `numpy.testing` in some places. This was being aliased as `npt`. To avoid confusion, I have removed this alias and left them as an explicit import.