### PR TITLE
gh-285: move test imports to the top

### DIFF
--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -1,16 +1,12 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
 from glass.core.algorithm import nnls as nnls_glass
 
 # check if scipy is available for testing
-try:
-    import scipy
-except ImportError:
-    HAVE_SCIPY = False
-else:
-    del scipy
-    HAVE_SCIPY = True
+HAVE_SCIPY = importlib.util.find_spec("scipy") is not None
 
 
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -1,4 +1,7 @@
+import numpy as np
 import pytest
+
+from glass.core.algorithm import nnls as nnls_glass
 
 # check if scipy is available for testing
 try:
@@ -12,10 +15,7 @@ else:
 
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")
 def test_nnls(rng):
-    import numpy as np
     from scipy.optimize import nnls as nnls_scipy
-
-    from glass.core.algorithm import nnls as nnls_glass
 
     # cross-check output with scipy's nnls
 

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -16,10 +16,6 @@ HAVE_SCIPY = importlib.util.find_spec("scipy") is not None
 
 
 def test_broadcast_first():
-    pass
-
-
-def test_broadcast_first():
     a = np.ones((2, 3, 4))
     b = np.ones((2, 1))
 

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -1,6 +1,14 @@
 import numpy as np
 import pytest
 
+from glass.core.array import (
+    broadcast_first,
+    broadcast_leading_axes,
+    cumtrapz,
+    ndinterp,
+    trapz_product,
+)
+
 # check if scipy is available for testing
 try:
     import scipy
@@ -11,9 +19,7 @@ else:
     HAVE_SCIPY = True
 
 
-def broadcast_first():
-    from glass.core.array import broadcast_first
-
+def test_broadcast_first():
     a = np.ones((2, 3, 4))
     b = np.ones((2, 1))
 
@@ -43,8 +49,6 @@ def broadcast_first():
 
 
 def test_broadcast_leading_axes():
-    from glass.core.array import broadcast_leading_axes
-
     a = 0
     b = np.zeros((4, 10))
     c = np.zeros((3, 1, 5, 6))
@@ -58,8 +62,6 @@ def test_broadcast_leading_axes():
 
 
 def test_ndinterp():
-    from glass.core.array import ndinterp
-
     # test 1d interpolation
 
     xp = [0, 1, 2, 3, 4]
@@ -143,8 +145,6 @@ def test_ndinterp():
 
 
 def test_trapz_product():
-    from glass.core.array import trapz_product
-
     x1 = np.linspace(0, 2, 100)
     f1 = np.full_like(x1, 2.0)
 
@@ -159,8 +159,6 @@ def test_trapz_product():
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")
 def test_cumtrapz():
     from scipy.integrate import cumulative_trapezoid
-
-    from glass.core.array import cumtrapz
 
     # 1D f and x
 

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
@@ -10,13 +12,7 @@ from glass.core.array import (
 )
 
 # check if scipy is available for testing
-try:
-    import scipy
-except ImportError:
-    HAVE_SCIPY = False
-else:
-    del scipy
-    HAVE_SCIPY = True
+HAVE_SCIPY = importlib.util.find_spec("scipy") is not None
 
 
 def test_broadcast_first():

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -14,8 +14,10 @@ from glass.core.array import (
 # check if scipy is available for testing
 HAVE_SCIPY = importlib.util.find_spec("scipy") is not None
 
+
 def test_broadcast_first():
-    from glass.core.array import broadcast_first
+    pass
+
 
 def test_broadcast_first():
     a = np.ones((2, 3, 4))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
-def test_getcl():
-    from glass.fields import getcl
+from glass.fields import getcl
 
+
+def test_getcl():
     # make a mock Cls array with the index pairs as entries
     cls = [{i, j} for i in range(10) for j in range(i, -1, -1)]
     # make sure indices are retrieved correctly

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,4 +1,3 @@
-# check if fitsio is available for testing
 import importlib.util
 
 import numpy as np
@@ -6,6 +5,7 @@ import pytest
 
 from glass import user
 
+# check if fitsio is available for testing
 HAVE_FITSIO = importlib.util.find_spec("fitsio") is not None
 
 

--- a/tests/test_galaxies.py
+++ b/tests/test_galaxies.py
@@ -1,11 +1,10 @@
+import numpy as np
 import pytest
+
+from glass.galaxies import gaussian_phz, redshifts, redshifts_from_nz
 
 
 def test_redshifts(mocker):
-    import numpy as np
-
-    from glass.galaxies import redshifts
-
     # create a mock radial window function
     w = mocker.Mock()
     w.za = np.linspace(0.0, 1.0, 20)
@@ -23,10 +22,6 @@ def test_redshifts(mocker):
 
 
 def test_redshifts_from_nz():
-    import numpy as np
-
-    from glass.galaxies import redshifts_from_nz
-
     # test sampling
 
     redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0])
@@ -95,10 +90,6 @@ def test_redshifts_from_nz():
 
 
 def test_gaussian_phz():
-    import numpy as np
-
-    from glass.galaxies import gaussian_phz
-
     # test sampling
 
     # case: zero variance

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -1,11 +1,18 @@
+import healpix
 import numpy as np
 import pytest
+
+from glass.lensing import (
+    MultiPlaneConvergence,
+    deflect,
+    multi_plane_matrix,
+    multi_plane_weights,
+)
+from glass.shells import RadialWindow
 
 
 @pytest.fixture
 def shells():
-    from glass.shells import RadialWindow
-
     return [
         RadialWindow([0.0, 1.0, 2.0], [0.0, 1.0, 0.0], 1.0),
         RadialWindow([1.0, 2.0, 3.0], [0.0, 1.0, 0.0], 2.0),
@@ -35,8 +42,6 @@ def cosmo():
 
 @pytest.mark.parametrize("usecomplex", [True, False])
 def test_deflect_nsew(usecomplex):
-    from glass.lensing import deflect
-
     d = 5.0
     r = np.radians(d)
 
@@ -67,10 +72,6 @@ def test_deflect_nsew(usecomplex):
 
 
 def test_deflect_many(rng):
-    import healpix
-
-    from glass.lensing import deflect
-
     n = 1000
     abs_alpha = rng.uniform(0, 2 * np.pi, size=n)
     arg_alpha = rng.uniform(-np.pi, np.pi, size=n)
@@ -89,8 +90,6 @@ def test_deflect_many(rng):
 
 
 def test_multi_plane_matrix(shells, cosmo, rng):
-    from glass.lensing import MultiPlaneConvergence, multi_plane_matrix
-
     mat = multi_plane_matrix(shells, cosmo)
 
     np.testing.assert_array_equal(mat, np.tril(mat))
@@ -108,8 +107,6 @@ def test_multi_plane_matrix(shells, cosmo, rng):
 
 
 def test_multi_plane_weights(shells, cosmo, rng):
-    from glass.lensing import MultiPlaneConvergence, multi_plane_weights
-
     w_in = np.eye(len(shells))
     w_out = multi_plane_weights(w_in, shells, cosmo)
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from glass.points import position_weights, positions_from_delta, uniform_positions
+
 
 def catpos(pos):
     lon, lat, cnt = [], [], 0
@@ -11,8 +13,6 @@ def catpos(pos):
 
 
 def test_positions_from_delta():
-    from glass.points import positions_from_delta
-
     # case: single-dimensional input
 
     ngal = 1e-3
@@ -66,8 +66,6 @@ def test_positions_from_delta():
 
 
 def test_uniform_positions():
-    from glass.points import uniform_positions
-
     # case: scalar input
 
     ngal = 1e-3
@@ -97,8 +95,6 @@ def test_uniform_positions():
 
 
 def test_position_weights(rng):
-    from glass.points import position_weights
-
     for bshape in None, (), (100,), (100, 1):
         for cshape in (100,), (100, 50), (100, 3, 2):
             counts = rng.random(cshape)

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,10 +1,15 @@
 import numpy as np
 import pytest
 
+from glass.shapes import (
+    ellipticity_gaussian,
+    ellipticity_intnorm,
+    ellipticity_ryden04,
+    triaxial_axis_ratio,
+)
+
 
 def test_triaxial_axis_ratio():
-    from glass.shapes import triaxial_axis_ratio
-
     # single axis ratio
 
     q = triaxial_axis_ratio(0.8, 0.4)
@@ -42,8 +47,6 @@ def test_triaxial_axis_ratio():
 
 
 def test_ellipticity_ryden04():
-    from glass.shapes import ellipticity_ryden04
-
     # single ellipticity
 
     e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056)
@@ -76,8 +79,6 @@ def test_ellipticity_ryden04():
 
 
 def test_ellipticity_gaussian():
-    from glass.shapes import ellipticity_gaussian
-
     n = 1_000_000
 
     eps = ellipticity_gaussian(n, 0.256)
@@ -102,8 +103,6 @@ def test_ellipticity_gaussian():
 
 
 def test_ellipticity_intnorm():
-    from glass.shapes import ellipticity_intnorm
-
     n = 1_000_000
 
     eps = ellipticity_intnorm(n, 0.256)

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
 
+from glass.shells import RadialWindow, partition, restrict, tophat_windows
+
 
 def test_tophat_windows():
-    from glass.shells import tophat_windows
-
     zb = [0.0, 0.1, 0.2, 0.5, 1.0, 2.0]
     dz = 0.005
 
@@ -22,8 +22,6 @@ def test_tophat_windows():
 
 
 def test_restrict():
-    from glass.shells import RadialWindow, restrict
-
     # Gaussian test function
     z = np.linspace(0.0, 5.0, 1000)
     f = np.exp(-(((z - 2.0) / 0.5) ** 2) / 2)
@@ -52,10 +50,6 @@ def test_restrict():
 
 @pytest.mark.parametrize("method", ["lstsq", "nnls", "restrict"])
 def test_partition(method):
-    import numpy as np
-
-    from glass.shells import RadialWindow, partition
-
     shells = [
         RadialWindow(np.array([0.0, 1.0]), np.array([1.0, 0.0]), 0.0),
         RadialWindow(np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0, 0.0]), 0.5),


### PR DESCRIPTION
Closes #285. Simplifies tests by just moving all imports to the top. I find this easier to read.

Have also simplified the logic to see if `scipy` is present, similarly to `fitsio`.

Also fixed the `broadcast_first` test, which was missing the `test_` prefix.