### PR TITLE
gh-307: fix nox examples session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import nox
 
 # Options to modify nox behaviour
@@ -48,7 +50,9 @@ def doctests(session: nox.Session) -> None:
 def examples(session: nox.Session) -> None:
     """Run the example notebooks."""
     session.install("-e", ".[examples]")
-    session.run("jupyter", "execute", "examples/**/*.ipynb", *session.posargs)
+    session.run(
+        "jupyter", "execute", *Path().glob("examples/**/*.ipynb"), *session.posargs
+    )
 
 
 @nox.session


### PR DESCRIPTION
`jupyter execute` does not work with `glob` patterns when used within `subprocess.run` or `session.run`. Now the path passed into `jupyter execute` is more explicit. Working locally (should have tested this before locally) -
```py
(.env) saransh@Saranshs-MacBook-Pro glass % nox -e examples
nox > Running session examples
nox > Re-using existing virtual environment at .nox/examples.
nox > python -m pip install -e '.[examples]'
nox > jupyter execute examples/2-advanced/stage_4_galaxies.ipynb examples/2-advanced/cosmic_shear.ipynb examples/1-basic/lensing.ipynb examples/1-basic/matter.ipynb examples/1-basic/shells.ipynb examples/1-basic/photoz.ipynb examples/1-basic/density.ipynb
[NbClientApp] Executing examples/2-advanced/stage_4_galaxies.ipynb
[NbClientApp] Executing notebook with kernel: python3
[NbClientApp] Executing examples/2-advanced/cosmic_shear.ipynb
[NbClientApp] Executing notebook with kernel: python3
[NbClientApp] Executing examples/1-basic/lensing.ipynb
[NbClientApp] Executing notebook with kernel: python3
[NbClientApp] Executing examples/1-basic/matter.ipynb
[NbClientApp] Executing notebook with kernel: python3
[NbClientApp] Executing examples/1-basic/shells.ipynb
[NbClientApp] Executing notebook with kernel: python3
[NbClientApp] Executing examples/1-basic/photoz.ipynb
[NbClientApp] Executing notebook with kernel: python3
[NbClientApp] Executing examples/1-basic/density.ipynb
[NbClientApp] Executing notebook with kernel: python3
nox > Session examples was successful.
```

Fixes: #307 