### PR TITLE
gh-312: fix tests for broadcast_first

### DIFF
--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -11,7 +11,7 @@ else:
     HAVE_SCIPY = True
 
 
-def broadcast_first():
+def test_broadcast_first():
     from glass.core.array import broadcast_first
 
     a = np.ones((2, 3, 4))
@@ -36,7 +36,7 @@ def broadcast_first():
         broadcast_first(a, b)
 
     # plain np.broadcast_arrays will work
-    a_a, b_a = broadcast_first(a, b)
+    a_a, b_a = np.broadcast_arrays(a, b)
 
     assert a_a.shape == (4, 5, 6)
     assert b_a.shape == (4, 5, 6)


### PR DESCRIPTION
The comment was right but the code was wrong 🤦🏻‍♂️

Use `np.broadcast_arrays` for comparison.

Fixes: #312 