### PR TITLE
gh-304: exclude a few things from SDist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,13 @@ report = {exclude_also = [
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"
+build.targets.sdist.exclude = [
+    ".*",
+    "docs/*",
+    "examples/*",
+    "noxfile.py",
+    "tests/*",
+]
 version.source = "vcs"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Excludes `docs/`, `tests/`, `examples/`, `noxfile.py`, and all the `.*` files (except `.gitignore`) from the SDist.

Closes: #304 