### PR TITLE
gh-315: add broadcasting rule in ellipticity_ryden04 + tests

### DIFF
--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -138,6 +138,10 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     if rng is None:
         rng = np.random.default_rng()
 
+    # default size if not given
+    if size is None:
+        size = np.broadcast(gamma, sigma_gamma, mu, sigma).shape
+
     # draw gamma and epsilon from truncated normal -- eq.s (10)-(11)
     # first sample unbounded normal, then rejection sample truncation
     eps = rng.normal(mu, sigma, size=size)

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -67,7 +67,13 @@ def test_ellipticity_ryden04():
     e1 = ellipticity_ryden04(-1.85, 0.89, [0.222, 0.333], 0.056)
     e2 = ellipticity_ryden04(-1.85, 0.89, 0.222, [0.056, 0.067])
     e3 = ellipticity_ryden04([-1.85, -2.85], 0.89, 0.222, 0.056)
-    assert np.shape(e1) == np.shape(e2) == np.shape(e3) == (2,)
+    e4 = ellipticity_ryden04(-1.85, [0.89, 1.001], 0.222, 0.056)
+    assert np.shape(e1) == np.shape(e2) == np.shape(e3) == np.shape(e4) == (2,)
+
+    # broadcasting rule
+
+    e = ellipticity_ryden04([-1.9, -2.9], 0.9, [[0.2, 0.3], [0.4, 0.5]], 0.1)
+    assert np.shape(e) == (2, 2)
 
     # check that result is in the specified range
 


### PR DESCRIPTION
Added a broadcasting rule inspired by `skypy` to prevent crashes. 

Fixes: #315
Closes: #299 
Fixed: `ellipticity_ryden04` infers the size argument on the basis of other arguments if not explicitly passed
