### PR TITLE
gh-282: extend `coverage` options to improve output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ The tests can be executed using the `test` dependencies of _GLASS_ in the
 following way -
 
 ```bash
-python -m pytest --cov=glass --doctest-plus
+python -m pytest --cov --doctest-plus
 ```
 
 ## Documenting

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ def tests(session: nox.Session) -> None:
 @nox.session(python=ALL_PYTHON)
 def coverage(session: nox.Session) -> None:
     """Run tests and compute coverage."""
-    session.posargs.append("--cov=glass")
+    session.posargs.append("--cov")
     tests(session)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ Homepage = "https://github.com/glass-dev/glass"
 Issues = "https://github.com/glass-dev/glass/issues"
 
 [tool.coverage]
-relative_files = true
 report = {exclude_also = [
     "if TYPE_CHECKING:",
 ], omit = [
@@ -79,6 +78,10 @@ report = {exclude_also = [
 run = {branch = true, parallel = true, source = [
     "glass",
 ]}
+paths.source = [
+    "src",
+    ".nox*/*/lib/python*/site-packages",
+]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,6 @@ report = {exclude_also = [
 run = {branch = true, parallel = true, source = [
     "glass",
 ]}
-paths.source = [
-    ".tox*/*/lib/python*/site-packages",
-    "src",
-]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ Homepage = "https://github.com/glass-dev/glass"
 Issues = "https://github.com/glass-dev/glass/issues"
 
 [tool.coverage]
+relative_files = true
 report = {exclude_also = [
     "if TYPE_CHECKING:",
 ], omit = [
@@ -78,10 +79,6 @@ report = {exclude_also = [
 run = {branch = true, parallel = true, source = [
     "glass",
 ]}
-paths.source = [
-    "src",
-    ".nox*/*/lib/python*/site-packages",
-]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,14 @@ report = {exclude_also = [
     "if TYPE_CHECKING:",
 ], omit = [
     "glass/_version.py",
+], skip_covered = true, sort = "cover"}
+run = {branch = true, parallel = true, source = [
+    "glass",
 ]}
+paths.source = [
+    ".tox*/*/lib/python*/site-packages",
+    "src",
+]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ report = {exclude_also = [
 run = {branch = true, parallel = true, source = [
     "glass",
 ]}
+paths.source = [
+    "src",
+    ".nox*/*/lib/python*/site-packages",
+]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "glass/_version.py"
@@ -176,4 +180,5 @@ in_place = true
 spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 overrides."project.classifiers".inline_arrays = false
+overrides."tool.coverage.paths.source".inline_arrays = false
 overrides."tool.ruff.lint.isort.section-order".inline_arrays = false


### PR DESCRIPTION
Closes #282. Run locally, the output looks like below. Makes it easy to know what needs prioritising to improve the overall score. Options come from my experience with https://github.com/astro-informatics/sleplet/blob/9d8884177135d17876a65b65dd85e99712a43622/pyproject.toml#L102-L110.

```
---------- coverage: platform darwin, python 3.12.6-final-0 ----------
Name                      Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------
glass/ext/__init__.py         6      6      2      0     0%
glass/fields.py             173    146     82      1    12%
glass/observations.py        59     47     12      0    17%
glass/shells.py             144     57     40      2    54%
glass/lensing.py            132     55     36      2    55%
glass/galaxies.py            59     18     22      4    68%
glass/user.py                34      9     14      3    71%
glass/points.py              88     14     40     12    78%
glass/core/algorithm.py      42      3     16      3    90%
glass/shapes.py              75      0     22      3    97%
-----------------------------------------------------------
TOTAL                       856    355    302     30    54%

3 files skipped due to complete coverage.
```

Coverage is expected to decrease as we are now using branch coverage. See explanation here: https://coverage.readthedocs.io/en/latest/branch.html.
