### PR TITLE
gh-319: run coverage in parallel and aggregate results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,22 @@ jobs:
         run: nox -s coverage-${{ matrix.python-version }} --verbose
       - name: Coveralls requires XML report
         run: coverage xml
-      - uses: coverallsapp/github-action@v2
+      - name: Run Coveralls in parallel
+        uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.python-version }}
+          parallel: true
+
+  aggregate-tests:
+    needs: tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+          carryforward: run-3.8,run-3.9,run-3.10,run-3.11,run-3.12
 
   build:
     name: Build


### PR DESCRIPTION
Closes #319. Reading the documentation of the action this is what you are _meant_ to do when you are using matrix builds. I've used this before.
https://github.com/coverallsapp/github-action?tab=readme-ov-file#complete-parallel-job-example

This has also fixed the `Tree` section of the `coveralls` UI which was previously just showing `core`/`ext` (and the files therein).
![image](https://github.com/user-attachments/assets/925851e6-e429-497a-b694-2fe1a188590f)