### PR TITLE
gh-321: group markdown badges into sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # **GLASS**: Generator for Large Scale Structure
 
-[![Test](https://github.com/glass-dev/glass/actions/workflows/test.yml/badge.svg)](https://github.com/glass-dev/glass/actions/workflows/test.yml)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/glass-dev/glass/main.svg)](https://results.pre-commit.ci/latest/github/glass-dev/glass/main)
-[![Documentation](https://readthedocs.org/projects/glass/badge/?version=latest)](https://glass.readthedocs.io/latest/)
-[![Coverage Status](https://coveralls.io/repos/github/glass-dev/glass/badge.svg?branch=main)](https://coveralls.io/github/glass-dev/glass?branch=main)
+<!-- Essentials -->
+
 [![PyPI](https://img.shields.io/pypi/v/glass)](https://pypi.org/project/glass)
-[![PyPI platforms](https://img.shields.io/pypi/pyversions/glass)](https://pypi.org/project/glass/)
+[![Documentation](https://readthedocs.org/projects/glass/badge/?version=latest)](https://glass.readthedocs.io/latest)
+[![LICENSE](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+<!-- Code -->
+
+[![Python Versions](https://img.shields.io/pypi/pyversions/glass)](https://pypi.org/project/glass)
+[![Test](https://github.com/glass-dev/glass/actions/workflows/test.yml/badge.svg)](https://github.com/glass-dev/glass/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/glass-dev/glass/badge.svg?branch=main)](https://coveralls.io/github/glass-dev/glass?branch=main)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/glass-dev/glass/main.svg)](https://results.pre-commit.ci/latest/github/glass-dev/glass/main)
+
+<!-- Science -->
+
 [![arXiv](https://img.shields.io/badge/arXiv-2302.01942-red)](https://arxiv.org/abs/2302.01942)
 [![adsabs](https://img.shields.io/badge/ads-2023OJAp....6E..11T-blueviolet)](https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..11T)
 [![doi](https://img.shields.io/badge/doi-10.21105/astro.2302.01942-blue)](https://dx.doi.org/10.21105/astro.2302.01942)
-[![LICENSE](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![GitHub Discussion](https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github)](https://github.com/orgs/glass-dev/discussions)
+
+<!-- Community -->
+
+[![GitHub Discussions](https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github)](https://github.com/orgs/glass-dev/discussions)
 [![Slack](https://img.shields.io/badge/join-Slack-4A154B)](https://glass-dev.github.io/slack)
 
 This is the core library for GLASS, the Generator for Large Scale Structure. For


### PR DESCRIPTION
Closes #321. Makes it slightly easier to see each badge. I don't feel strongly about the sections, so we can always change them. There are probably other badges we could add, but will leave for a separate PR.