### PR TITLE
gh-323: rm broken support for uv + update constraint format

### DIFF
--- a/.github/test-constraints.txt
+++ b/.github/test-constraints.txt
@@ -1,2 +1,13 @@
---only-binary numpy,scipy,healpy,healpix
+numpy
+--only-binary numpy
+
+scipy
+--only-binary scipy
+
+healpy
+--only-binary healpy
+
+healpix
+--only-binary healpix
+
 --prefer-binary

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import nox
 
 # Options to modify nox behaviour
-nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = ["lint", "tests"]
 


### PR DESCRIPTION
`Nox` will always use `virtualenv` now and the `.txt` file for constraints is in a more widely accepted format now (readable by both `uv` and plain `pip install`.

Refs: #323 