### PR TITLE
gh-198: enforce `python>3.8` & `numpy>1.21`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -67,7 +66,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: run-3.8,run-3.9,run-3.10,run-3.11,run-3.12
+          carryforward: run-3.9,run-3.10,run-3.11,run-3.12
 
   build:
     name: Build

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -27,9 +27,8 @@ Utility functions
 from __future__ import annotations
 
 import warnings
-
-# typing
-from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Tuple, Union
+from collections.abc import Generator, Iterable, Sequence
+from typing import Any, Callable, Optional, Union
 
 import healpy as hp
 import numpy as np
@@ -37,8 +36,8 @@ import numpy.typing as npt
 from gaussiancl import gaussiancl
 
 # types
-Size = Optional[Union[int, Tuple[int, ...]]]
-Iternorm = Tuple[Optional[int], npt.NDArray, npt.NDArray]
+Size = Optional[Union[int, tuple[int, ...]]]
+Iternorm = tuple[Optional[int], npt.NDArray, npt.NDArray]
 ClTransform = Union[str, Callable[[npt.NDArray], npt.NDArray]]
 Cls = Sequence[Union[npt.NDArray, Sequence[float]]]
 Alms = npt.NDArray

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -31,14 +31,14 @@ Applying lensing
 
 from __future__ import annotations
 
-# typing support
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import healpy as hp
 import numpy as np
 
 if TYPE_CHECKING:
-    # to prevent circular dependencies, only import these for type checking
+    from collections.abc import Sequence
+
     import numpy.typing as npt
 
     from cosmology import Cosmology

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -45,9 +45,8 @@ Weight functions
 from __future__ import annotations
 
 import warnings
-
-# type checking
-from typing import TYPE_CHECKING, Callable, NamedTuple, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Callable, NamedTuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -56,7 +55,6 @@ from glass.core.array import ndinterp
 
 if TYPE_CHECKING:
     from cosmology import Cosmology
-
 
 # types
 ArrayLike1D = Union[Sequence[float], npt.NDArray]

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = ["lint", "tests"]
 
-ALL_PYTHON = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+ALL_PYTHON = ["3.9", "3.10", "3.11", "3.12"]
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "gaussiancl>=2022.10.21",
     "healpix>=2022.11.1",
     "healpy>=1.15.0",
-    "numpy>=1.20.0",
+    "numpy>=1.22.0",
 ]
 description = "Generator for Large Scale Structure"
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -35,7 +34,7 @@ maintainers = [
 ]
 name = "glass"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license.file = "LICENSE"
 
 [project.optional-dependencies]

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -32,9 +32,10 @@ def test_basic_write(tmp_path):
     filename_gfits = "gfits.fits"  # what GLASS creates
     filename_tfits = "tfits.fits"  # file created on the fly to test against
 
-    with user.write_catalog(
-        tmp_path / filename_gfits, ext="CATALOG"
-    ) as out, fitsio.FITS(tmp_path / filename_tfits, "rw", clobber=True) as my_fits:
+    with (
+        user.write_catalog(tmp_path / filename_gfits, ext="CATALOG") as out,
+        fitsio.FITS(tmp_path / filename_tfits, "rw", clobber=True) as my_fits,
+    ):
         for i in range(my_max):
             array = np.arange(i, i + 1, delta)  # array of size 1/delta
             array2 = np.arange(i + 1, i + 2, delta)  # array of size 1/delta
@@ -43,9 +44,10 @@ def test_basic_write(tmp_path):
             names = ["RA", "RB"]
             _test_append(my_fits, arrays, names)
 
-    with fitsio.FITS(tmp_path / filename_gfits) as g_fits, fitsio.FITS(
-        tmp_path / filename_tfits
-    ) as t_fits:
+    with (
+        fitsio.FITS(tmp_path / filename_gfits) as g_fits,
+        fitsio.FITS(tmp_path / filename_tfits) as t_fits,
+    ):
         glass_data = g_fits[1].read()
         test_data = t_fits[1].read()
         assert glass_data["RA"].size == test_data["RA"].size


### PR DESCRIPTION
Closes #198. For Array API support (#67), we need minimum versions of:

1. `Python 3.9` as specified here https://data-apis.org/array-api-compat/changelog.html#id9
2. `NumPy 1.22` as specified here https://numpy.org/doc/stable/reference/array_api.html#array-api-standard-compatibility

In this PR I have enforced both of these. The code changes have come from `ruff` linting, utilising the benefits from [3.9](https://docs.python.org/3/whatsnew/3.9.html).

I also removed some of the overzealous comments on imports. They weren't adding anything and meant the imports took up more room.