### PR TITLE
gh-327: use `numpy.testing` everywhere in existing tests

### DIFF
--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -149,7 +149,7 @@ def test_trapz_product():
 
     s = trapz_product((x1, f1), (x2, f2))
 
-    assert np.allclose(s, 1.0)
+    np.testing.assert_allclose(s, 1.0)
 
 
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -56,19 +56,19 @@ def test_deflect_nsew(usecomplex):
 
     # north
     lon, lat = deflect(0.0, 0.0, alpha(r, 0))
-    assert np.allclose([lon, lat], [0.0, d])
+    np.testing.assert_allclose([lon, lat], [0.0, d], atol=1e-15)
 
     # south
     lon, lat = deflect(0.0, 0.0, alpha(-r, 0))
-    assert np.allclose([lon, lat], [0.0, -d])
+    np.testing.assert_allclose([lon, lat], [0.0, -d], atol=1e-15)
 
     # east
     lon, lat = deflect(0.0, 0.0, alpha(0, r))
-    assert np.allclose([lon, lat], [-d, 0.0])
+    np.testing.assert_allclose([lon, lat], [-d, 0.0], atol=1e-15)
 
     # west
     lon, lat = deflect(0.0, 0.0, alpha(0, -r))
-    assert np.allclose([lon, lat], [d, 0.0])
+    np.testing.assert_allclose([lon, lat], [d, 0.0], atol=1e-15)
 
 
 def test_deflect_many(rng):

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -91,21 +91,21 @@ def test_ellipticity_gaussian():
 
     assert eps.shape == (n,)
 
-    assert np.all(np.abs(eps) < 1)
+    np.testing.assert_array_less(np.abs(eps), 1)
 
-    assert np.isclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
 
     eps = ellipticity_gaussian([n, n], [0.128, 0.256])
 
     assert eps.shape == (2 * n,)
 
-    assert np.all(np.abs(eps) < 1)
+    np.testing.assert_array_less(np.abs(eps), 1)
 
-    assert np.isclose(np.std(eps.real[:n]), 0.128, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.imag[:n]), 0.128, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.real[n:]), 0.256, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.real[:n]), 0.128, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag[:n]), 0.128, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.real[n:]), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
 
 
 def test_ellipticity_intnorm():
@@ -115,21 +115,21 @@ def test_ellipticity_intnorm():
 
     assert eps.shape == (n,)
 
-    assert np.all(np.abs(eps) < 1)
+    np.testing.assert_array_less(np.abs(eps), 1)
 
-    assert np.isclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
 
     eps = ellipticity_intnorm([n, n], [0.128, 0.256])
 
     assert eps.shape == (2 * n,)
 
-    assert np.all(np.abs(eps) < 1)
+    np.testing.assert_array_less(np.abs(eps), 1)
 
-    assert np.isclose(np.std(eps.real[:n]), 0.128, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.imag[:n]), 0.128, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.real[n:]), 0.256, atol=1e-3, rtol=0)
-    assert np.isclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.real[:n]), 0.128, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag[:n]), 0.128, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.real[n:]), 0.256, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
 
     with pytest.raises(ValueError):
         ellipticity_intnorm(1, 0.71)

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -69,4 +69,4 @@ def test_partition(method):
 
     assert part.shape == (len(shells), 3, 2)
 
-    assert np.allclose(part.sum(axis=0), np.trapz(fz, z))
+    np.testing.assert_allclose(part.sum(axis=0), np.trapz(fz, z))


### PR DESCRIPTION
Use `numpy.testing.assert*` methods wherever possible.

Closes #327