### PR TITLE
gh-137: deprecate `redshifts_from_nz` in favor of `redshifts`

### DIFF
--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -19,6 +19,7 @@ Functions
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -99,6 +100,10 @@ def redshifts_from_nz(
         samples from all populations.
 
     """
+    warnings.warn(
+        "redshifts_from_nz is deprecated; use redshifts instead", stacklevel=2
+    )
+
     # get default RNG if not given
     if rng is None:
         rng = np.random.default_rng()

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -61,7 +61,7 @@ def redshifts(
         Random redshifts following the radial window function.
 
     """
-    return redshifts_from_nz(n, w.za, w.wa, rng=rng)
+    return redshifts_from_nz(n, w.za, w.wa, rng=rng, warn=False)
 
 
 def redshifts_from_nz(
@@ -70,6 +70,7 @@ def redshifts_from_nz(
     nz: npt.ArrayLike,
     *,
     rng: np.random.Generator | None = None,
+    warn: bool = True,
 ) -> npt.NDArray:
     """
     Generate galaxy redshifts from a source distribution.
@@ -91,6 +92,8 @@ def redshifts_from_nz(
         shape of *count*.
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
+    warn : bool
+        Throw relevant warnings.
 
     Returns
     -------
@@ -100,9 +103,12 @@ def redshifts_from_nz(
         samples from all populations.
 
     """
-    warnings.warn(
-        "redshifts_from_nz is deprecated; use redshifts instead", stacklevel=2
-    )
+    if warn:
+        warnings.warn(
+            "when sampling galaxies, redshifts_from_nz() is often not the function you"
+            " want. Try redshifts() instead. Use warn=False to suppress this warning.",
+            stacklevel=2,
+        )
 
     # get default RNG if not given
     if rng is None:

--- a/tests/test_galaxies.py
+++ b/tests/test_galaxies.py
@@ -24,16 +24,16 @@ def test_redshifts(mocker):
 def test_redshifts_from_nz():
     # test sampling
 
-    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0])
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0], warn=False)
     assert np.all((0 <= redshifts) & (redshifts <= 1))  # noqa: SIM300
 
-    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 0, 0])
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 0, 0], warn=False)
     assert np.all((1 <= redshifts) & (redshifts <= 3))  # noqa: SIM300
 
-    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 0, 0, 1])
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 0, 0, 1], warn=False)
     assert np.all((3 <= redshifts) & (redshifts <= 4))  # noqa: SIM300
 
-    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 1, 1])
+    redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 1, 1], warn=False)
     assert not np.any(redshifts <= 1)
 
     # test interface
@@ -44,7 +44,7 @@ def test_redshifts_from_nz():
     z = np.linspace(0, 1, 100)
     nz = z * (1 - z)
 
-    redshifts = redshifts_from_nz(count, z, nz)
+    redshifts = redshifts_from_nz(count, z, nz, warn=False)
 
     assert redshifts.shape == (count,)
     assert np.all((0 <= redshifts) & (redshifts <= 1))  # noqa: SIM300
@@ -55,7 +55,7 @@ def test_redshifts_from_nz():
     z = np.linspace(0, 1, 100)
     nz = z * (1 - z)
 
-    redshifts = redshifts_from_nz(count, z, nz)
+    redshifts = redshifts_from_nz(count, z, nz, warn=False)
 
     assert np.shape(redshifts) == (60,)
 
@@ -65,7 +65,7 @@ def test_redshifts_from_nz():
     z = np.linspace(0, 1, 100)
     nz = [z * (1 - z), (z - 0.5) ** 2]
 
-    redshifts = redshifts_from_nz(count, z, nz)
+    redshifts = redshifts_from_nz(count, z, nz, warn=False)
 
     assert redshifts.shape == (20,)
 
@@ -75,7 +75,7 @@ def test_redshifts_from_nz():
     z = np.linspace(0, 1, 100)
     nz = [z * (1 - z), (z - 0.5) ** 2]
 
-    redshifts = redshifts_from_nz(count, z, nz)
+    redshifts = redshifts_from_nz(count, z, nz, warn=False)
 
     assert redshifts.shape == (120,)
 
@@ -86,7 +86,10 @@ def test_redshifts_from_nz():
     nz = [z * (1 - z), (z - 0.5) ** 2]
 
     with pytest.raises(ValueError):
-        redshifts_from_nz(count, z, nz)
+        redshifts_from_nz(count, z, nz, warn=False)
+
+    with pytest.warns(UserWarning, match="when sampling galaxies"):
+        redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0])
 
 
 def test_gaussian_phz():


### PR DESCRIPTION
I have started looking into tests for `galaxies.py` and this popped up during my research.

Closes: #137 