### PR TITLE
gh-338: better autoupdate and autofix messages for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 ---
 ci:
   autofix_prs: false
-  autoupdate_commit_msg: "MNT: update pre-commit hooks"
-  autofix_commit_msg: "STY: pre-commit fixes"
+  autoupdate_commit_msg: "pre-commit.ci: update pre-commit hooks"
+  autofix_commit_msg: "pre-commit.ci: style fixes"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
`MNT` and `STY` keywords are not used anywhere in glass now, so it makes sense to make these automated commits and PRs have a more meaningful message.

Closes: #338