### PR TITLE
gh-328: efficient resampling in `ellipticity_ryden04`

### DIFF
--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -142,17 +142,24 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     if size is None:
         size = np.broadcast(mu, sigma, gamma, sigma_gamma).shape
 
+    # broadcast all inputs to output shape
+    # this makes it possible to efficiently resample later
+    mu = np.broadcast_to(mu, size, subok=True)
+    sigma = np.broadcast_to(sigma, size, subok=True)
+    gamma = np.broadcast_to(gamma, size, subok=True)
+    sigma_gamma = np.broadcast_to(sigma_gamma, size, subok=True)
+
     # draw gamma and epsilon from truncated normal -- eq.s (10)-(11)
     # first sample unbounded normal, then rejection sample truncation
     eps = rng.normal(mu, sigma, size=size)
     bad = eps > 0
     while np.any(bad):
-        eps[bad] = rng.normal(mu, sigma, size=size)[bad]
+        eps[bad] = rng.normal(mu[bad], sigma[bad])
         bad = eps > 0
     gam = rng.normal(gamma, sigma_gamma, size=size)
     bad = (gam < 0) | (gam > 1)
     while np.any(bad):
-        gam[bad] = rng.normal(gamma, sigma_gamma, size=size)[bad]
+        gam[bad] = rng.normal(gamma[bad], sigma_gamma[bad])
         bad = (gam < 0) | (gam > 1)
 
     # compute triaxial axis ratios zeta = B/A, xi = C/A

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -152,13 +152,12 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     # draw gamma and epsilon from truncated normal -- eq.s (10)-(11)
     # first sample unbounded normal, then rejection sample truncation
     eps = rng.normal(mu, sigma, size=size)
-    bad = eps > 0
-    while np.any(bad):
+    while np.any(bad := eps > 0):
         eps[bad] = rng.normal(mu[bad], sigma[bad])
         bad = eps > 0
     gam = rng.normal(gamma, sigma_gamma, size=size)
     bad = (gam < 0) | (gam > 1)
-    while np.any(bad):
+    while np.any(bad := eps > 0):
         gam[bad] = rng.normal(gamma[bad], sigma_gamma[bad])
         bad = (gam < 0) | (gam > 1)
 

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -154,12 +154,9 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     eps = rng.normal(mu, sigma, size=size)
     while np.any(bad := eps > 0):
         eps[bad] = rng.normal(mu[bad], sigma[bad])
-        bad = eps > 0
     gam = rng.normal(gamma, sigma_gamma, size=size)
-    bad = (gam < 0) | (gam > 1)
-    while np.any(bad := eps > 0):
+    while np.any(bad := (gam < 0) | (gam > 1)):
         gam[bad] = rng.normal(gamma[bad], sigma_gamma[bad])
-        bad = (gam < 0) | (gam > 1)
 
     # compute triaxial axis ratios zeta = B/A, xi = C/A
     zeta = -np.expm1(eps)


### PR DESCRIPTION
The code now generates only the required values while resampling making it more efficient. The implementation works with the existing test cases, but given that the function accepts `ArrayLike` args, the following fails -

```py
In [1]: from glass import ellipticity_ryden04

In [2]: mu, sigma, gamma, sigma_gamma = [-1.85, -2.85], [0.89, 0.89, 0.33], [0.056, 0.02, 0.3, 0.2], [0.222]\

In [3]: ellipticity_ryden04(mu, sigma, gamma, sigma_gamma)
----------------------------------------------------------------------
ValueError                           Traceback (most recent call last)
Cell In[3], line 1
----> 1 ellipticity_ryden04(mu, sigma, gamma, sigma_gamma)

File ~/Code/UCL/glass/glass/shapes.py:143, in ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size, rng)
    141 # default size if not given
    142 if size is None:
--> 143     size = np.broadcast(mu, sigma, gamma, sigma_gamma).shape
    145 # broadcast all inputs to output shape
    146 # this makes it possible to efficiently resample later
    147 mu = np.broadcast_to(mu, size, subok=True)

ValueError: shape mismatch: objects cannot be broadcast to a single shape.  Mismatch is between arg 0 with shape (2,) and arg 1 with shape (3,).
```

I am not sure if this is a "valid" case or will scientists never pass in such arguments.

Refs: #328
Changed: resampling in `ellipticity_ryden04` is more efficient now