### PR TITLE
gh-346: enforce `NumPy` docstrings + use static typing in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ autodoc_typehints = "description"
 # -- napoleon ----------------------------------------------------------------
 
 napoleon_google_docstring = False
-napoleon_use_rtype = False
 
 
 # -- plot_directive ----------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ autodoc_typehints = "description"
 # -- napoleon ----------------------------------------------------------------
 
 napoleon_google_docstring = False
+napoleon_use_rtype = False
 
 
 # -- plot_directive ----------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,12 +23,12 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "numpydoc",
-    "sphinx.ext.intersphinx",
-    "sphinxcontrib.katex",
     "matplotlib.sphinxext.plot_directive",
     "nbsphinx",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinxcontrib.katex",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -69,15 +69,13 @@ intersphinx_mapping = {
 
 # -- autodoc -----------------------------------------------------------------
 
-autodoc_typehints = "none"
+autodoc_typehints = "description"
 
 
-# -- numpydoc ----------------------------------------------------------------
+# -- napoleon ----------------------------------------------------------------
 
-# Whether to create a Sphinx table of contents for the lists of class methods
-# and attributes. If a table of contents is made, Sphinx expects each entry to
-# have a separate page.
-numpydoc_class_members_toctree = False
+napoleon_google_docstring = False
+napoleon_preprocess_types = True
 
 
 # -- plot_directive ----------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
+# The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
 html_theme = "furo"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ autodoc_typehints = "description"
 # -- napoleon ----------------------------------------------------------------
 
 napoleon_google_docstring = False
-napoleon_preprocess_types = True
 
 
 # -- plot_directive ----------------------------------------------------------

--- a/glass/core/__init__.py
+++ b/glass/core/__init__.py
@@ -7,4 +7,4 @@ Core functions (:mod:`glass.core`)
 The :mod:`glass.core` module contains core functionality for developing
 GLASS modules.
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415

--- a/glass/core/__init__.py
+++ b/glass/core/__init__.py
@@ -7,4 +7,4 @@ Core functions (:mod:`glass.core`)
 The :mod:`glass.core` module contains core functionality for developing
 GLASS modules.
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400

--- a/glass/core/algorithm.py
+++ b/glass/core/algorithm.py
@@ -20,13 +20,13 @@ def nnls(
     """
     Compute a non-negative least squares solution.
 
-    Implementation of the algorithm due to [1]_ as described in [2]_.
+    Implementation of the algorithm due to [1] as described in [2].
 
     References
     ----------
-    .. [1] Lawson, C. L. and Hanson, R. J. (1995), Solving Least Squares
+    * [1] Lawson, C. L. and Hanson, R. J. (1995), Solving Least Squares
         Problems. doi: 10.1137/1.9781611971217
-    .. [2] Bro, R. and De Jong, S. (1997), A fast
+    * [2] Bro, R. and De Jong, S. (1997), A fast
         non-negativity-constrained least squares algorithm. J.
         Chemometrics, 11, 393-401.
 

--- a/glass/core/algorithm.py
+++ b/glass/core/algorithm.py
@@ -22,7 +22,7 @@ def nnls(
 
     Implementation of the algorithm due to [1]_ as described in [2]_.
 
-    References
+    References:
     ----------
     .. [1] Lawson, C. L. and Hanson, R. J. (1995), Solving Least Squares
         Problems. doi: 10.1137/1.9781611971217

--- a/glass/core/algorithm.py
+++ b/glass/core/algorithm.py
@@ -22,7 +22,7 @@ def nnls(
 
     Implementation of the algorithm due to [1]_ as described in [2]_.
 
-    References:
+    References
     ----------
     .. [1] Lawson, C. L. and Hanson, R. J. (1995), Solving Least Squares
         Problems. doi: 10.1137/1.9781611971217

--- a/glass/core/array.py
+++ b/glass/core/array.py
@@ -19,7 +19,7 @@ def broadcast_leading_axes(*args):
     Returns the shape of the broadcast dimensions, and all input arrays
     with leading axes matching that shape.
 
-    Examples
+    Examples:
     --------
     Broadcast all dimensions of ``a``, all except the last dimension of
     ``b``, and all except the last two dimensions of ``c``.

--- a/glass/core/array.py
+++ b/glass/core/array.py
@@ -19,7 +19,7 @@ def broadcast_leading_axes(*args):
     Returns the shape of the broadcast dimensions, and all input arrays
     with leading axes matching that shape.
 
-    Examples:
+    Examples
     --------
     Broadcast all dimensions of ``a``, all except the last dimension of
     ``b``, and all except the last two dimensions of ``c``.

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -5,7 +5,7 @@ Random fields
 .. currentmodule:: glass
 
 The following functions provide functionality for simulating random
-fields on the sphere.  This is done in the form of HEALPix maps.
+fields on the sphere. This is done in the form of HEALPix maps.
 
 Functions
 ---------
@@ -163,7 +163,7 @@ def gaussian_gls(
 
     Depending on the given arguments, this truncates the angular power spectra
     to ``lmax``, removes all but ``ncorr`` correlations between fields, and
-    applies the HEALPix pixel window function of the given ``nside``.  If no
+    applies the HEALPix pixel window function of the given ``nside``. If no
     arguments are given, no action is performed.
 
     """
@@ -221,7 +221,7 @@ def generate_gaussian(
     ``nside``.
 
     The optional argument ``ncorr`` can be used to artificially limit now many
-    realised fields are correlated.  This saves memory, as only `ncorr` previous
+    realised fields are correlated. This saves memory, as only `ncorr` previous
     fields need to be kept.
 
     The ``gls`` array must contain the auto-correlation of each new field
@@ -327,19 +327,14 @@ def getcl(cls, i, j, lmax=None):
     Return the angular power spectrum for indices *i* and *j* from an
     array in *GLASS* ordering.
 
-    Parameters
-    ----------
-    cls : list of array_like
-        List of angular power spectra in *GLASS* ordering.
-    i, j : int
-        Combination of indices to return.
-    lmax : int, optional
-        Truncate the returned spectrum at this mode number.
+    Args:
+        cls: List of angular power spectra in *GLASS* ordering.
+        i: Indices to return.
+        j: Indices to return.
+        lmax: Truncate the returned spectrum at this mode number.
 
     Returns:
-    -------
-    cl : array_like
-        The angular power spectrum for indices *i* and *j*.
+        cl: The angular power spectrum for indices *i* and *j*.
 
     """
     if j > i:
@@ -360,21 +355,16 @@ def effective_cls(
     Compute effective angular power spectra from weights.
 
     Computes a linear combination of the angular power spectra *cls*
-    using the factors provided by *weights1* and *weights2*.  Additional
+    using the factors provided by *weights1* and *weights2*. Additional
     axes in *weights1* and *weights2* produce arrays of spectra.
 
-    Parameters
-    ----------
-    cls : (N,) list of array_like
-        Angular matter power spectra to combine, in *GLASS* ordering.
-    weights1 : (N, \\*M1) array_like
-        Weight factors for spectra.  The first axis must be equal to the
-        number of fields.
-    weights2 : (N, \\*M2) array_like, optional
-        Second set of weights.  If not given, *weights1* is used.
-    lmax : int, optional
-        Truncate the angular power spectra at this mode number.  If not
-        given, the longest input in *cls* will be used.
+    Args:
+        cls: Angular matter power spectra to combine, in *GLASS* ordering.
+        weights1: Weight factors for spectra. The first axis must be equal to
+            the number of fields.
+        weights2:  Second set of weights. If not given, *weights1* is used.
+        lmax: Truncate the angular power spectra at this mode number. If not
+            given, the longest input in *cls* will be used.
 
     Returns:
     -------

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -340,7 +340,8 @@ def getcl(cls, i, j, lmax=None):
 
     Returns
     -------
-        cl: The angular power spectrum for indices *i* and *j*.
+    cl:
+        The angular power spectrum for indices *i* and *j*.
 
     """
     if j > i:
@@ -379,7 +380,7 @@ def effective_cls(
 
     Returns
     -------
-    cls : (\\*M1, \\*M2, LMAX+1) array_like
+    cls:
         Dictionary of effective angular power spectra, where keys
         correspond to the leading axes of *weights1* and *weights2*.
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -22,7 +22,7 @@ Utility functions
 
 .. autofunction:: getcl
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 
@@ -336,7 +336,7 @@ def getcl(cls, i, j, lmax=None):
     lmax : int, optional
         Truncate the returned spectrum at this mode number.
 
-    Returns
+    Returns:
     -------
     cl : array_like
         The angular power spectrum for indices *i* and *j*.
@@ -376,7 +376,7 @@ def effective_cls(
         Truncate the angular power spectra at this mode number.  If not
         given, the longest input in *cls* will be used.
 
-    Returns
+    Returns:
     -------
     cls : (\\*M1, \\*M2, LMAX+1) array_like
         Dictionary of effective angular power spectra, where keys

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -329,10 +329,14 @@ def getcl(cls, i, j, lmax=None):
 
     Parameters
     ----------
-        cls: List of angular power spectra in *GLASS* ordering.
-        i: Indices to return.
-        j: Indices to return.
-        lmax: Truncate the returned spectrum at this mode number.
+    cls:
+        List of angular power spectra in *GLASS* ordering.
+    i:
+        Indices to return.
+    j:
+        Indices to return.
+    lmax:
+        Truncate the returned spectrum at this mode number.
 
     Returns
     -------
@@ -362,12 +366,16 @@ def effective_cls(
 
     Parameters
     ----------
-        cls: Angular matter power spectra to combine, in *GLASS* ordering.
-        weights1: Weight factors for spectra. The first axis must be equal to
-            the number of fields.
-        weights2:  Second set of weights. If not given, *weights1* is used.
-        lmax: Truncate the angular power spectra at this mode number. If not
-            given, the longest input in *cls* will be used.
+    cls:
+        Angular matter power spectra to combine, in *GLASS* ordering.
+    weights1:
+        Weight factors for spectra. The first axis must be equal to
+        the number of fields.
+    weights2:
+        Second set of weights. If not given, *weights1* is used.
+    lmax:
+        Truncate the angular power spectra at this mode number. If not
+        given, the longest input in *cls* will be used.
 
     Returns
     -------

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -327,7 +327,8 @@ def getcl(cls, i, j, lmax=None):
     Return the angular power spectrum for indices *i* and *j* from an
     array in *GLASS* ordering.
 
-    Args:
+    Parameters
+    ----------
         cls: List of angular power spectra in *GLASS* ordering.
         i: Indices to return.
         j: Indices to return.
@@ -359,7 +360,8 @@ def effective_cls(
     using the factors provided by *weights1* and *weights2*. Additional
     axes in *weights1* and *weights2* produce arrays of spectra.
 
-    Args:
+    Parameters
+    ----------
         cls: Angular matter power spectra to combine, in *GLASS* ordering.
         weights1: Weight factors for spectra. The first axis must be equal to
             the number of fields.

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -22,7 +22,7 @@ Utility functions
 
 .. autofunction:: getcl
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from __future__ import annotations
 
@@ -333,7 +333,8 @@ def getcl(cls, i, j, lmax=None):
         j: Indices to return.
         lmax: Truncate the returned spectrum at this mode number.
 
-    Returns:
+    Returns
+    -------
         cl: The angular power spectrum for indices *i* and *j*.
 
     """
@@ -366,7 +367,7 @@ def effective_cls(
         lmax: Truncate the angular power spectra at this mode number. If not
             given, the longest input in *cls* will be used.
 
-    Returns:
+    Returns
     -------
     cls : (\\*M1, \\*M2, LMAX+1) array_like
         Dictionary of effective angular power spectra, where keys

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -338,11 +338,6 @@ def getcl(cls, i, j, lmax=None):
     lmax:
         Truncate the returned spectrum at this mode number.
 
-    Returns
-    -------
-    cl:
-        The angular power spectrum for indices *i* and *j*.
-
     """
     if j > i:
         i, j = j, i
@@ -365,6 +360,9 @@ def effective_cls(
     using the factors provided by *weights1* and *weights2*. Additional
     axes in *weights1* and *weights2* produce arrays of spectra.
 
+    Returns a dictionary of effective angular power spectra, where keys
+    correspond to the leading axes of *weights1* and *weights2*.
+
     Parameters
     ----------
     cls:
@@ -377,12 +375,6 @@ def effective_cls(
     lmax:
         Truncate the angular power spectra at this mode number. If not
         given, the longest input in *cls* will be used.
-
-    Returns
-    -------
-    cls:
-        Dictionary of effective angular power spectra, where keys
-        correspond to the leading axes of *weights1* and *weights2*.
 
     """
     from itertools import combinations_with_replacement, product

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -15,7 +15,7 @@ Functions
 .. autofunction:: galaxy_shear
 .. autofunction:: gaussian_phz
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ def redshifts(
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
-    Returns
+    Returns:
     -------
     z : array_like
         Random redshifts following the radial window function.
@@ -95,7 +95,7 @@ def redshifts_from_nz(
     warn : bool
         Throw relevant warnings.
 
-    Returns
+    Returns:
     -------
     redshifts : array_like
         Redshifts sampled from the given source distribution.  For
@@ -170,7 +170,7 @@ def galaxy_shear(  # noqa: PLR0913
         If ``False``, galaxy shears are not reduced by the convergence.
         Default is ``True``.
 
-    Returns
+    Returns:
     -------
     she : array_like
         Array of complex-valued observed galaxy shears (lensed ellipticities).
@@ -231,30 +231,30 @@ def gaussian_phz(
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
-    Returns
+    Returns:
     -------
     phz : array_like
         Photometric redshifts assuming Gaussian errors, of the same
         shape as *z*.
 
-    Warnings
+    Warnings:
     --------
     The *lower* and *upper* bounds are implemented using plain rejection
     sampling from the non-truncated normal distribution.  If bounds are
     used, they should always contain significant probability mass.
 
-    See Also
+    See Also:
     --------
     glass.tomo_nz_gausserr :
         Create tomographic redshift distributions assuming the same
         model.
 
-    References
+    References:
     ----------
     .. [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
            doi:10.1111/j.1365-2966.2007.12271.x
 
-    Examples
+    Examples:
     --------
     See the :doc:`/examples/1-basic/photoz` example.
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -15,7 +15,7 @@ Functions
 .. autofunction:: galaxy_shear
 .. autofunction:: gaussian_phz
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from __future__ import annotations
 
@@ -51,7 +51,7 @@ def redshifts(
         w: Radial window function.
         rng : Random number generator. If not given, a default RNG is used.
 
-    Returns:
+    Returns
     -------
     z : array_like
         Random redshifts following the radial window function.
@@ -88,7 +88,7 @@ def redshifts_from_nz(
         rng: Random number generator. If not given, a default RNG is used.
         warn: Throw relevant warnings.
 
-    Returns:
+    Returns
     -------
     redshifts : array_like
         Redshifts sampled from the given source distribution. For
@@ -161,7 +161,7 @@ def galaxy_shear(  # noqa: PLR0913
         reduced_shear: If ``False``, galaxy shears are not reduced
             by the convergence. Default is ``True``.
 
-    Returns:
+    Returns
     -------
     she : array_like
         Array of complex-valued observed galaxy shears (lensed ellipticities).
@@ -218,7 +218,7 @@ def gaussian_phz(
         upper: Bounds for the returned photometric redshifts.
         rng: Random number generator. If not given, a default RNG is used.
 
-    Returns:
+    Returns
     -------
     phz : array_like
         Photometric redshifts assuming Gaussian errors, of the same
@@ -230,18 +230,18 @@ def gaussian_phz(
     sampling from the non-truncated normal distribution. If bounds are
     used, they should always contain significant probability mass.
 
-    See Also:
+    See Also
     --------
     glass.tomo_nz_gausserr :
         Create tomographic redshift distributions assuming the same
         model.
 
-    References:
+    References
     ----------
     .. [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
            doi:10.1111/j.1365-2966.2007.12271.x
 
-    Examples:
+    Examples
     --------
     See the :doc:`/examples/1-basic/photoz` example.
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -45,7 +45,8 @@ def redshifts(
     This function samples *n* redshifts from a distribution that follows
     the given radial window function *w*.
 
-    Args:
+    Parameters
+    ----------
         n: Number of redshifts to sample. If an array is given, the
             results are concatenated.
         w: Radial window function.
@@ -78,7 +79,8 @@ def redshifts_from_nz(
     and redshifts are sampled independently for each extra dimension.
     The results are concatenated into a flat array.
 
-    Args:
+    Parameters
+    ----------
         count: Number of redshifts to sample. If an array is given, its shape
             is broadcast against the leading axes of *z* and *nz*.
         z: Source distribution. Leading axes are broadcast against the
@@ -151,7 +153,8 @@ def galaxy_shear(  # noqa: PLR0913
     Takes lensing maps for convergence and shear and produces a lensed
     ellipticity (shear) for each intrinsic galaxy ellipticity.
 
-    Args:
+    Parameters
+    ----------
         lon: Array for galaxy longitudes.
         lat: Array for galaxy latitudes.
         eps: Array of galaxy :term:`ellipticity`.
@@ -211,7 +214,8 @@ def gaussian_phz(
     Gaussian error with redshift-dependent standard deviation
     :math:`\sigma(z) = (1 + z) \sigma_0` [1]_.
 
-    Args:
+    Parameters
+    ----------
         z: True redshifts.
         sigma_0: Redshift error in the tomographic binning at zero redshift.
         lower: Bounds for the returned photometric redshifts.

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -57,7 +57,7 @@ def redshifts(
 
     Returns
     -------
-    z : array_like
+    z:
         Random redshifts following the radial window function.
 
     """
@@ -100,7 +100,7 @@ def redshifts_from_nz(
 
     Returns
     -------
-    redshifts : array_like
+    redshifts:
         Redshifts sampled from the given source distribution. For
         inputs with extra dimensions, returns a flattened 1-D array of
         samples from all populations.
@@ -181,7 +181,7 @@ def galaxy_shear(  # noqa: PLR0913
 
     Returns
     -------
-    she : array_like
+    she:
         Array of complex-valued observed galaxy shears (lensed ellipticities).
 
     """
@@ -244,7 +244,7 @@ def gaussian_phz(
 
     Returns
     -------
-    phz : array_like
+    phz:
         Photometric redshifts assuming Gaussian errors, of the same
         shape as *z*.
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -227,7 +227,7 @@ def gaussian_phz(
 
     A simple toy model of photometric redshift errors that assumes a
     Gaussian error with redshift-dependent standard deviation
-    :math:`\sigma(z) = (1 + z) \sigma_0` [1]_.
+    :math:`\sigma(z) = (1 + z) \sigma_0` [1].
 
     Parameters
     ----------
@@ -261,7 +261,7 @@ def gaussian_phz(
 
     References
     ----------
-    .. [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
+    * [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
            doi:10.1111/j.1365-2966.2007.12271.x
 
     Examples

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -248,7 +248,7 @@ def gaussian_phz(
         Photometric redshifts assuming Gaussian errors, of the same
         shape as *z*.
 
-    Warnings:
+    Warnings
     --------
     The *lower* and *upper* bounds are implemented using plain rejection
     sampling from the non-truncated normal distribution. If bounds are
@@ -256,9 +256,8 @@ def gaussian_phz(
 
     See Also
     --------
-    glass.tomo_nz_gausserr :
-        Create tomographic redshift distributions assuming the same
-        model.
+    glass.tomo_nz_gausserr:
+        Create tomographic redshift distributions assuming the same model.
 
     References
     ----------

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -45,6 +45,8 @@ def redshifts(
     This function samples *n* redshifts from a distribution that follows
     the given radial window function *w*.
 
+    Returns random redshifts following the radial window function.
+
     Parameters
     ----------
     n:
@@ -54,11 +56,6 @@ def redshifts(
         Radial window function.
     rng:
         Random number generator. If not given, a default RNG is used.
-
-    Returns
-    -------
-    z:
-        Random redshifts following the radial window function.
 
     """
     return redshifts_from_nz(n, w.za, w.wa, rng=rng, warn=False)
@@ -82,6 +79,10 @@ def redshifts_from_nz(
     and redshifts are sampled independently for each extra dimension.
     The results are concatenated into a flat array.
 
+    Returns redshifts sampled from the given source distribution. For
+    inputs with extra dimensions, returns a flattened 1-D array of
+    samples from all populations.
+
     Parameters
     ----------
     count:
@@ -97,13 +98,6 @@ def redshifts_from_nz(
         Random number generator. If not given, a default RNG is used.
     warn:
         Throw relevant warnings.
-
-    Returns
-    -------
-    redshifts:
-        Redshifts sampled from the given source distribution. For
-        inputs with extra dimensions, returns a flattened 1-D array of
-        samples from all populations.
 
     """
     if warn:
@@ -161,6 +155,9 @@ def galaxy_shear(  # noqa: PLR0913
     Takes lensing maps for convergence and shear and produces a lensed
     ellipticity (shear) for each intrinsic galaxy ellipticity.
 
+    Returns an array of complex-valued observed galaxy shears
+    (lensed ellipticities).
+
     Parameters
     ----------
     lon:
@@ -178,11 +175,6 @@ def galaxy_shear(  # noqa: PLR0913
     reduced_shear:
         If ``False``, galaxy shears are not reduced
         by the convergence. Default is ``True``.
-
-    Returns
-    -------
-    she:
-        Array of complex-valued observed galaxy shears (lensed ellipticities).
 
     """
     nside = healpix.npix2nside(np.broadcast(kappa, gamma1, gamma2).shape[-1])
@@ -229,6 +221,9 @@ def gaussian_phz(
     Gaussian error with redshift-dependent standard deviation
     :math:`\sigma(z) = (1 + z) \sigma_0` [1].
 
+    Returns photometric redshifts assuming Gaussian errors, of the same
+    shape as *z*.
+
     Parameters
     ----------
     z:
@@ -241,12 +236,6 @@ def gaussian_phz(
         Bounds for the returned photometric redshifts.
     rng:
         Random number generator. If not given, a default RNG is used.
-
-    Returns
-    -------
-    phz:
-        Photometric redshifts assuming Gaussian errors, of the same
-        shape as *z*.
 
     Warnings
     --------

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -47,10 +47,13 @@ def redshifts(
 
     Parameters
     ----------
-        n: Number of redshifts to sample. If an array is given, the
-            results are concatenated.
-        w: Radial window function.
-        rng : Random number generator. If not given, a default RNG is used.
+    n:
+        Number of redshifts to sample. If an array is given, the
+        results are concatenated.
+    w:
+        Radial window function.
+    rng:
+        Random number generator. If not given, a default RNG is used.
 
     Returns
     -------
@@ -81,14 +84,19 @@ def redshifts_from_nz(
 
     Parameters
     ----------
-        count: Number of redshifts to sample. If an array is given, its shape
-            is broadcast against the leading axes of *z* and *nz*.
-        z: Source distribution. Leading axes are broadcast against the
-            shape of *count*.
-        nz: Source distribution. Leading axes are broadcast against the
-            shape of *count*.
-        rng: Random number generator. If not given, a default RNG is used.
-        warn: Throw relevant warnings.
+    count:
+        Number of redshifts to sample. If an array is given, its shape
+        is broadcast against the leading axes of *z* and *nz*.
+    z:
+        Source distribution. Leading axes are broadcast against the
+        shape of *count*.
+    nz:
+        Source distribution. Leading axes are broadcast against the
+        shape of *count*.
+    rng:
+        Random number generator. If not given, a default RNG is used.
+    warn:
+        Throw relevant warnings.
 
     Returns
     -------
@@ -155,14 +163,21 @@ def galaxy_shear(  # noqa: PLR0913
 
     Parameters
     ----------
-        lon: Array for galaxy longitudes.
-        lat: Array for galaxy latitudes.
-        eps: Array of galaxy :term:`ellipticity`.
-        kappa: HEALPix map for convergence.
-        gamma1: HEALPix maps for a component of shear.
-        gamma2: HEALPix maps for a component of shear.
-        reduced_shear: If ``False``, galaxy shears are not reduced
-            by the convergence. Default is ``True``.
+    lon:
+        Array for galaxy longitudes.
+    lat:
+        Array for galaxy latitudes.
+    eps:
+        Array of galaxy :term:`ellipticity`.
+    kappa:
+        HEALPix map for convergence.
+    gamma1:
+        HEALPix maps for a component of shear.
+    gamma2:
+        HEALPix maps for a component of shear.
+    reduced_shear:
+        If ``False``, galaxy shears are not reduced
+        by the convergence. Default is ``True``.
 
     Returns
     -------
@@ -216,11 +231,16 @@ def gaussian_phz(
 
     Parameters
     ----------
-        z: True redshifts.
-        sigma_0: Redshift error in the tomographic binning at zero redshift.
-        lower: Bounds for the returned photometric redshifts.
-        upper: Bounds for the returned photometric redshifts.
-        rng: Random number generator. If not given, a default RNG is used.
+    z:
+        True redshifts.
+    sigma_0:
+        Redshift error in the tomographic binning at zero redshift.
+    lower:
+        Bounds for the returned photometric redshifts.
+    upper:
+        Bounds for the returned photometric redshifts.
+    rng:
+        Random number generator. If not given, a default RNG is used.
 
     Returns
     -------

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -45,15 +45,11 @@ def redshifts(
     This function samples *n* redshifts from a distribution that follows
     the given radial window function *w*.
 
-    Parameters
-    ----------
-    n : int or array_like
-        Number of redshifts to sample.  If an array is given, the
-        results are concatenated.
-    w : :class:`~glass.RadialWindow`
-        Radial window function.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG is used.
+    Args:
+        n: Number of redshifts to sample. If an array is given, the
+            results are concatenated.
+        w: Radial window function.
+        rng : Random number generator. If not given, a default RNG is used.
 
     Returns:
     -------
@@ -77,28 +73,25 @@ def redshifts_from_nz(
 
     The function supports sampling from multiple populations of
     redshifts if *count* is an array or if there are additional axes in
-    the *z* or *nz* arrays.  In this case, the shape of *count* and the
+    the *z* or *nz* arrays. In this case, the shape of *count* and the
     leading dimensions of *z* and *nz* are broadcast to a common shape,
     and redshifts are sampled independently for each extra dimension.
     The results are concatenated into a flat array.
 
-    Parameters
-    ----------
-    count : int or array_like
-        Number of redshifts to sample.  If an array is given, its shape
-        is broadcast against the leading axes of *z* and *nz*.
-    z, nz : array_like
-        Source distribution.  Leading axes are broadcast against the
-        shape of *count*.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG is used.
-    warn : bool
-        Throw relevant warnings.
+    Args:
+        count: Number of redshifts to sample. If an array is given, its shape
+            is broadcast against the leading axes of *z* and *nz*.
+        z: Source distribution. Leading axes are broadcast against the
+            shape of *count*.
+        nz: Source distribution. Leading axes are broadcast against the
+            shape of *count*.
+        rng: Random number generator. If not given, a default RNG is used.
+        warn: Throw relevant warnings.
 
     Returns:
     -------
     redshifts : array_like
-        Redshifts sampled from the given source distribution.  For
+        Redshifts sampled from the given source distribution. For
         inputs with extra dimensions, returns a flattened 1-D array of
         samples from all populations.
 
@@ -158,17 +151,15 @@ def galaxy_shear(  # noqa: PLR0913
     Takes lensing maps for convergence and shear and produces a lensed
     ellipticity (shear) for each intrinsic galaxy ellipticity.
 
-    Parameters
-    ----------
-    lon, lat : array_like
-        Arrays for galaxy longitudes and latitudes.
-    eps : array_like
-        Array of galaxy :term:`ellipticity`.
-    kappa, gamma1, gamma2 : array_like
-        HEALPix maps for convergence and two components of shear.
-    reduced_shear : bool, optional
-        If ``False``, galaxy shears are not reduced by the convergence.
-        Default is ``True``.
+    Args:
+        lon: Array for galaxy longitudes.
+        lat: Array for galaxy latitudes.
+        eps: Array of galaxy :term:`ellipticity`.
+        kappa: HEALPix map for convergence.
+        gamma1: HEALPix maps for a component of shear.
+        gamma2: HEALPix maps for a component of shear.
+        reduced_shear: If ``False``, galaxy shears are not reduced
+            by the convergence. Default is ``True``.
 
     Returns:
     -------
@@ -220,16 +211,12 @@ def gaussian_phz(
     Gaussian error with redshift-dependent standard deviation
     :math:`\sigma(z) = (1 + z) \sigma_0` [1]_.
 
-    Parameters
-    ----------
-    z : array_like
-        True redshifts.
-    sigma_0 : float or array_like
-        Redshift error in the tomographic binning at zero redshift.
-    lower, upper : float or array_like, optional
-        Bounds for the returned photometric redshifts.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG is used.
+    Args:
+        z: True redshifts.
+        sigma_0: Redshift error in the tomographic binning at zero redshift.
+        lower: Bounds for the returned photometric redshifts.
+        upper: Bounds for the returned photometric redshifts.
+        rng: Random number generator. If not given, a default RNG is used.
 
     Returns:
     -------
@@ -240,7 +227,7 @@ def gaussian_phz(
     Warnings:
     --------
     The *lower* and *upper* bounds are implemented using plain rejection
-    sampling from the non-truncated normal distribution.  If bounds are
+    sampling from the non-truncated normal distribution. If bounds are
     used, they should always contain significant probability mass.
 
     See Also:

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -64,12 +64,18 @@ def from_convergence(  # noqa: PLR0913
 
     Parameters
     ----------
-        kappa: HEALPix map of the convergence field.
-        lmax: Maximum angular mode number to use in the transform.
-        potential: Which lensing maps to return.
-        deflection: Which lensing maps to return.
-        shear: Which lensing maps to return.
-        discretized: Correct the pixel window function in output maps.
+    kappa:
+        HEALPix map of the convergence field.
+    lmax:
+        Maximum angular mode number to use in the transform.
+    potential:
+        Which lensing maps to return.
+    deflection:
+        Which lensing maps to return.
+    shear:
+        Which lensing maps to return.
+    discretized:
+        Correct the pixel window function in output maps.
 
     Returns
     -------
@@ -391,10 +397,13 @@ def multi_plane_weights(
 
     Parameters
     ----------
-        weights: Relative weight of each shell. The first axis must broadcast
-            against the number of shells, and is normalised internally.
-        shells: Window functions of the shells.
-        cosmo: Cosmology instance.
+    weights:
+        Relative weight of each shell. The first axis must broadcast
+        against the number of shells, and is normalised internally.
+    shells:
+        Window functions of the shells.
+    cosmo:
+        Cosmology instance.
 
     Returns
     -------
@@ -425,10 +434,13 @@ def deflect(
 
     Parameters
     ----------
-        lon: Longitudes to be deflected.
-        lat: Latitudes to be deflected.
-        alpha: Deflection values. Must be complex-valued or have a leading
-            axis of size 2 for the real and imaginary component.
+    lon:
+        Longitudes to be deflected.
+    lat:
+        Latitudes to be deflected.
+    alpha:
+        Deflection values. Must be complex-valued or have a leading
+        axis of size 2 for the real and imaginary component.
 
     Returns
     -------

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -91,7 +91,7 @@ def from_convergence(  # noqa: PLR0913
     Notes
     -----
     The weak lensing fields are computed from the convergence or
-    deflection potential in the following way. [1]_
+    deflection potential in the following way. [1]
 
     Define the spin-raising and spin-lowering operators of the
     spin-weighted spherical harmonics as
@@ -157,7 +157,7 @@ def from_convergence(  # noqa: PLR0913
 
     References
     ----------
-    .. [1] Tessore N., et al., OJAp, 6, 11 (2023).
+    * [1] Tessore N., et al., OJAp, 6, 11 (2023).
            doi:10.21105/astro.2302.01942
 
     """

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -62,7 +62,8 @@ def from_convergence(  # noqa: PLR0913
     deflection potential, deflection, and shear maps. The maps are
     computed via spherical harmonic transforms.
 
-    Args:
+    Parameters
+    ----------
         kappa: HEALPix map of the convergence field.
         lmax: Maximum angular mode number to use in the transform.
         potential: Which lensing maps to return.
@@ -388,7 +389,8 @@ def multi_plane_weights(
     redshift distribution :math:`n(z)` into the lensing efficiency
     sometimes denoted :math:`g(z)` or :math:`q(z)`.
 
-    Args:
+    Parameters
+    ----------
         weights: Relative weight of each shell. The first axis must broadcast
             against the number of shells, and is normalised internally.
         shells: Window functions of the shells.
@@ -421,7 +423,8 @@ def deflect(
     Takes an array of :term:`deflection` values and applies them
     to the given positions.
 
-    Args:
+    Parameters
+    ----------
         lon: Longitudes to be deflected.
         lat: Latitudes to be deflected.
         alpha: Deflection values. Must be complex-valued or have a leading

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -27,7 +27,7 @@ Applying lensing
 
 .. autofunction:: deflect
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from __future__ import annotations
 
@@ -70,7 +70,7 @@ def from_convergence(  # noqa: PLR0913
         shear: Which lensing maps to return.
         discretized: Correct the pixel window function in output maps.
 
-    Returns:
+    Returns
     -------
     psi : array_like
         Map of the deflection potential. Only returned if ``potential``
@@ -81,7 +81,7 @@ def from_convergence(  # noqa: PLR0913
     gamma : array_like
         Map of the shear (complex). Only returned if ``shear`` is true.
 
-    Notes:
+    Notes
     -----
     The weak lensing fields are computed from the convergence or
     deflection potential in the following way. [1]_
@@ -148,7 +148,7 @@ def from_convergence(  # noqa: PLR0913
         2 \gamma_{lm}
         = \sqrt{(l+2) \, (l+1) \, l \, (l-1)} \, \psi_{lm} \;.
 
-    References:
+    References
     ----------
     .. [1] Tessore N., et al., OJAp, 6, 11 (2023).
            doi:10.21105/astro.2302.01942
@@ -394,7 +394,7 @@ def multi_plane_weights(
         shells: Window functions of the shells.
         cosmo: Cosmology instance.
 
-    Returns:
+    Returns
     -------
     lensing_weights : array_like
         Relative lensing weight of each shell.
@@ -427,12 +427,12 @@ def deflect(
         alpha: Deflection values. Must be complex-valued or have a leading
             axis of size 2 for the real and imaginary component.
 
-    Returns:
+    Returns
     -------
     lon, lat : array_like
         Longitudes and latitudes after deflection.
 
-    Notes:
+    Notes
     -----
     Deflections on the sphere are :term:`defined <deflection>` as
     follows:  The complex deflection :math:`\\alpha` transports a point

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -79,13 +79,13 @@ def from_convergence(  # noqa: PLR0913
 
     Returns
     -------
-    psi : array_like
+    psi:
         Map of the deflection potential. Only returned if ``potential``
         is true.
-    alpha : array_like
+    alpha:
         Map of the deflection (complex). Only returned if ``deflection``
         if true.
-    gamma : array_like
+    gamma:
         Map of the shear (complex). Only returned if ``shear`` is true.
 
     Notes
@@ -407,7 +407,7 @@ def multi_plane_weights(
 
     Returns
     -------
-    lensing_weights : array_like
+    lensing_weights:
         Relative lensing weight of each shell.
 
     """
@@ -444,8 +444,10 @@ def deflect(
 
     Returns
     -------
-    lon, lat : array_like
-        Longitudes and latitudes after deflection.
+    lon:
+        Longitudes after deflection.
+    lat:
+        Latitudes after deflection.
 
     Notes
     -----

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -59,30 +59,27 @@ def from_convergence(  # noqa: PLR0913
     Compute other weak lensing maps from the convergence.
 
     Takes a weak lensing convergence map and returns one or more of
-    deflection potential, deflection, and shear maps.  The maps are
+    deflection potential, deflection, and shear maps. The maps are
     computed via spherical harmonic transforms.
 
-    Parameters
-    ----------
-    kappa : array_like
-        HEALPix map of the convergence field.
-    lmax : int, optional
-        Maximum angular mode number to use in the transform.
-    potential, deflection, shear : bool, optional
-        Which lensing maps to return.
-    discretized : bool
-        Correct the pixel window function in output maps.
+    Args:
+        kappa: HEALPix map of the convergence field.
+        lmax: Maximum angular mode number to use in the transform.
+        potential: Which lensing maps to return.
+        deflection: Which lensing maps to return.
+        shear: Which lensing maps to return.
+        discretized: Correct the pixel window function in output maps.
 
     Returns:
     -------
     psi : array_like
-        Map of the deflection potential.  Only returned if ``potential``
+        Map of the deflection potential. Only returned if ``potential``
         is true.
     alpha : array_like
-        Map of the deflection (complex).  Only returned if ``deflection``
+        Map of the deflection (complex). Only returned if ``deflection``
         if true.
     gamma : array_like
-        Map of the shear (complex).  Only returned if ``shear`` is true.
+        Map of the shear (complex). Only returned if ``shear`` is true.
 
     Notes:
     -----
@@ -117,7 +114,7 @@ def from_convergence(  # noqa: PLR0913
         = -l \, (l+1) \, \psi_{lm} \;.
 
     The :term:`deflection` :math:`\alpha` is the gradient of the
-    deflection potential :math:`\psi`.  On the sphere, this is
+    deflection potential :math:`\psi`. On the sphere, this is
 
     .. math::
 
@@ -126,7 +123,7 @@ def from_convergence(  # noqa: PLR0913
 
     The deflection field has spin weight :math:`1` in the HEALPix
     convention, in order for points to be deflected towards regions of
-    positive convergence.  The modes :math:`\alpha_{lm}` of the
+    positive convergence. The modes :math:`\alpha_{lm}` of the
     deflection field are hence
 
     .. math::
@@ -143,7 +140,7 @@ def from_convergence(  # noqa: PLR0913
         = \eth\eth \, \psi
         = \eth \, \alpha \;,
 
-    and thus has spin weight :math:`2`.  The shear modes
+    and thus has spin weight :math:`2`. The shear modes
     :math:`\gamma_{lm}` are related to the deflection potential modes as
 
     .. math::
@@ -391,15 +388,11 @@ def multi_plane_weights(
     redshift distribution :math:`n(z)` into the lensing efficiency
     sometimes denoted :math:`g(z)` or :math:`q(z)`.
 
-    Parameters
-    ----------
-    weights : array_like
-        Relative weight of each shell.  The first axis must broadcast
-        against the number of shells, and is normalised internally.
-    shells : list of :class:`~glass.RadialWindow`
-        Window functions of the shells.
-    cosmo : Cosmology
-        Cosmology instance.
+    Args:
+        weights: Relative weight of each shell. The first axis must broadcast
+            against the number of shells, and is normalised internally.
+        shells: Window functions of the shells.
+        cosmo: Cosmology instance.
 
     Returns:
     -------
@@ -428,13 +421,11 @@ def deflect(
     Takes an array of :term:`deflection` values and applies them
     to the given positions.
 
-    Parameters
-    ----------
-    lon, lat : array_like
-        Longitudes and latitudes to be deflected.
-    alpha : array_like
-        Deflection values.  Must be complex-valued or have a leading
-        axis of size 2 for the real and imaginary component.
+    Args:
+        lon: Longitudes to be deflected.
+        lat: Latitudes to be deflected.
+        alpha: Deflection values. Must be complex-valued or have a leading
+            axis of size 2 for the real and imaginary component.
 
     Returns:
     -------

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -63,6 +63,7 @@ def from_convergence(  # noqa: PLR0913
     computed via spherical harmonic transforms.
 
     Returns the maps of:
+
     * deflection potential if ``potential`` is true.
     * potential (complex) if ``deflection`` is true.
     * shear (complex) if ``shear`` is true.

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -27,7 +27,7 @@ Applying lensing
 
 .. autofunction:: deflect
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 
@@ -73,7 +73,7 @@ def from_convergence(  # noqa: PLR0913
     discretized : bool
         Correct the pixel window function in output maps.
 
-    Returns
+    Returns:
     -------
     psi : array_like
         Map of the deflection potential.  Only returned if ``potential``
@@ -84,7 +84,7 @@ def from_convergence(  # noqa: PLR0913
     gamma : array_like
         Map of the shear (complex).  Only returned if ``shear`` is true.
 
-    Notes
+    Notes:
     -----
     The weak lensing fields are computed from the convergence or
     deflection potential in the following way. [1]_
@@ -151,7 +151,7 @@ def from_convergence(  # noqa: PLR0913
         2 \gamma_{lm}
         = \sqrt{(l+2) \, (l+1) \, l \, (l-1)} \, \psi_{lm} \;.
 
-    References
+    References:
     ----------
     .. [1] Tessore N., et al., OJAp, 6, 11 (2023).
            doi:10.21105/astro.2302.01942
@@ -401,7 +401,7 @@ def multi_plane_weights(
     cosmo : Cosmology
         Cosmology instance.
 
-    Returns
+    Returns:
     -------
     lensing_weights : array_like
         Relative lensing weight of each shell.
@@ -436,12 +436,12 @@ def deflect(
         Deflection values.  Must be complex-valued or have a leading
         axis of size 2 for the real and imaginary component.
 
-    Returns
+    Returns:
     -------
     lon, lat : array_like
         Longitudes and latitudes after deflection.
 
-    Notes
+    Notes:
     -----
     Deflections on the sphere are :term:`defined <deflection>` as
     follows:  The complex deflection :math:`\\alpha` transports a point

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -62,6 +62,11 @@ def from_convergence(  # noqa: PLR0913
     deflection potential, deflection, and shear maps. The maps are
     computed via spherical harmonic transforms.
 
+    Returns the maps of:
+    * deflection potential if ``potential`` is true.
+    * potential (complex) if ``deflection`` is true.
+    * shear (complex) if ``shear`` is true.
+
     Parameters
     ----------
     kappa:
@@ -76,17 +81,6 @@ def from_convergence(  # noqa: PLR0913
         Which lensing maps to return.
     discretized:
         Correct the pixel window function in output maps.
-
-    Returns
-    -------
-    psi:
-        Map of the deflection potential. Only returned if ``potential``
-        is true.
-    alpha:
-        Map of the deflection (complex). Only returned if ``deflection``
-        if true.
-    gamma:
-        Map of the shear (complex). Only returned if ``shear`` is true.
 
     Notes
     -----
@@ -395,6 +389,8 @@ def multi_plane_weights(
     redshift distribution :math:`n(z)` into the lensing efficiency
     sometimes denoted :math:`g(z)` or :math:`q(z)`.
 
+    Returns the relative lensing weight of each shell.
+
     Parameters
     ----------
     weights:
@@ -404,11 +400,6 @@ def multi_plane_weights(
         Window functions of the shells.
     cosmo:
         Cosmology instance.
-
-    Returns
-    -------
-    lensing_weights:
-        Relative lensing weight of each shell.
 
     """
     # ensure shape of weights ends with the number of shells
@@ -432,6 +423,8 @@ def deflect(
     Takes an array of :term:`deflection` values and applies them
     to the given positions.
 
+    Returns the longitudes and latitudes after deflection.
+
     Parameters
     ----------
     lon:
@@ -441,13 +434,6 @@ def deflect(
     alpha:
         Deflection values. Must be complex-valued or have a leading
         axis of size 2 for the real and imaginary component.
-
-    Returns
-    -------
-    lon:
-        Longitudes after deflection.
-    lat:
-        Latitudes after deflection.
 
     Notes
     -----

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -24,7 +24,7 @@ Visibility
 .. autofunction:: vmap_galactic_ecliptic
 
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 
@@ -60,12 +60,12 @@ def vmap_galactic_ecliptic(
         The location of the galactic and ecliptic plane in their respective
         coordinate systems.
 
-    Returns
+    Returns:
     -------
     vis : array_like
         A HEALPix :term:`visibility map`.
 
-    Raises
+    Raises:
     ------
     TypeError
         If the ``galactic`` or ``ecliptic`` arguments are not pairs of numbers.
@@ -112,7 +112,7 @@ def gaussian_nz(
     norm : float or array_like, optional
         If given, the normalisation of the distribution.
 
-    Returns
+    Returns:
     -------
     nz : array_like
         Redshift distribution at the given ``z`` values.
@@ -156,12 +156,12 @@ def smail_nz(
     norm : float or array_like, optional
         If given, the normalisation of the distribution.
 
-    Returns
+    Returns:
     -------
     pz : array_like
         Redshift distribution at the given ``z`` values.
 
-    Notes
+    Notes:
     -----
     The probability distribution function :math:`p(z)` for redshift :math:`z`
     is given by Amara & Refregier [2]_ as
@@ -173,7 +173,7 @@ def smail_nz(
 
     where :math:`z_0` is matched to the given mode of the distribution.
 
-    References
+    References:
     ----------
     .. [1] Smail I., Ellis R. S., Fitchett M. J., 1994, MNRAS, 270, 245
     .. [2] Amara A., Refregier A., 2007, MNRAS, 381, 1018
@@ -214,7 +214,7 @@ def fixed_zbins(
     dz : float, optional
         Size of redshift bin.  Only one of ``nbins`` and ``dz`` can be given.
 
-    Returns
+    Returns:
     -------
     zbins : list of tuple of float
         List of redshift bin edges.
@@ -249,7 +249,7 @@ def equal_dens_zbins(
     nbins : int
         Number of redshift bins.
 
-    Returns
+    Returns:
     -------
     zbins : list of tuple of float
         List of redshift bin edges.
@@ -291,20 +291,20 @@ def tomo_nz_gausserr(
     zbins : list of tuple of float
         List of redshift bin edges.
 
-    Returns
+    Returns:
     -------
     binned_nz : array_like
         Tomographic redshift bins convolved with a gaussian error.
         Array has a shape (nbins, len(z))
 
-    See Also
+    See Also:
     --------
     equal_dens_zbins :
         produce equal density redshift bins
     fixed_zbins :
         produce redshift bins of fixed size
 
-    References
+    References:
     ----------
     .. [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
            doi:10.1111/j.1365-2966.2007.12271.x

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -306,9 +306,9 @@ def tomo_nz_gausserr(
 
     See Also
     --------
-    equal_dens_zbins :
+    equal_dens_zbins:
         produce equal density redshift bins
-    fixed_zbins :
+    fixed_zbins:
         produce redshift bins of fixed size
 
     References

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -49,16 +49,15 @@ def vmap_galactic_ecliptic(
     Visibility map masking galactic and ecliptic plane.
 
     This function returns a :term:`visibility map` that blocks out stripes for
-    the galactic and ecliptic planes.  The location of the stripes is set with
+    the galactic and ecliptic planes. The location of the stripes is set with
     optional parameters.
 
-    Parameters
-    ----------
-    nside : int
-        The NSIDE parameter of the resulting HEALPix map.
-    galactic, ecliptic : (2,) tuple of float
-        The location of the galactic and ecliptic plane in their respective
-        coordinate systems.
+    Args:
+        nside: The NSIDE parameter of the resulting HEALPix map.
+        galactic: The location of the galactic plane in the
+            respective coordinate system.
+        ecliptic: The location of the ecliptic plane in the
+            respective coordinate system.
 
     Returns:
     -------
@@ -101,16 +100,11 @@ def gaussian_nz(
     If ``mean`` or ``sigma`` are array_like, their axes will be the leading
     axes of the redshift distribution.
 
-    Parameters
-    ----------
-    z : array_like
-        Redshift values of the distribution.
-    mean : float or array_like
-        Mean(s) of the redshift distribution.
-    sigma : float or array_like
-        Standard deviation(s) of the redshift distribution.
-    norm : float or array_like, optional
-        If given, the normalisation of the distribution.
+    Args:
+        z: Redshift values of the distribution.
+        mean: Mean(s) of the redshift distribution.
+        sigma: Standard deviation(s) of the redshift distribution.
+        norm: If given, the normalisation of the distribution.
 
     Returns:
     -------
@@ -143,18 +137,12 @@ def smail_nz(
 
     The redshift follows the Smail et al. [1]_ redshift distribution.
 
-    Parameters
-    ----------
-    z : array_like
-        Redshift values of the distribution.
-    z_mode : float or array_like
-        Mode of the redshift distribution, must be positive.
-    alpha : float or array_like
-        Power law exponent (z/z0)^\alpha, must be positive.
-    beta : float or array_like
-        Log-power law exponent exp[-(z/z0)^\beta], must be positive.
-    norm : float or array_like, optional
-        If given, the normalisation of the distribution.
+    Args:
+        z: Redshift values of the distribution.
+        z_mode: Mode of the redshift distribution, must be positive.
+        alpha: Power law exponent (z/z0)^\alpha, must be positive.
+        beta: Log-power law exponent exp[-(z/z0)^\beta], must be positive.
+        norm: If given, the normalisation of the distribution.
 
     Returns:
     -------
@@ -205,14 +193,12 @@ def fixed_zbins(
     This function creates contiguous tomographic redshift bins of fixed size.
     It takes either the number or size of the bins.
 
-    Parameters
-    ----------
-    zmin, zmax : float
-        Extent of the redshift binning.
-    nbins : int, optional
-        Number of redshift bins.  Only one of ``nbins`` and ``dz`` can be given.
-    dz : float, optional
-        Size of redshift bin.  Only one of ``nbins`` and ``dz`` can be given.
+    Args:
+        zmin: Extent of the redshift binning.
+        zmax: Extent of the redshift binning.
+        nbins: Number of redshift bins. Only one of ``nbins`` and
+            ``dz`` can be given.
+        dz: Size of redshift bin. Only one of ``nbins`` and ``dz`` can be given.
 
     Returns:
     -------
@@ -242,12 +228,10 @@ def equal_dens_zbins(
     This function subdivides a source redshift distribution into ``nbins``
     tomographic redshift bins with equal density.
 
-    Parameters
-    ----------
-    z, nz : array_like
-        The source redshift distribution. Must be one-dimensional.
-    nbins : int
-        Number of redshift bins.
+    Args:
+        z: The source redshift distribution. Must be one-dimensional.
+        nz: The source redshift distribution. Must be one-dimensional.
+        nbins: Number of redshift bins.
 
     Returns:
     -------
@@ -277,19 +261,16 @@ def tomo_nz_gausserr(
 
     This function takes a _true_ overall source redshift distribution ``z``,
     ``nz`` and returns tomographic source redshift distributions for the
-    tomographic redshift bins given by ``zbins``.  It is assumed that sources
+    tomographic redshift bins given by ``zbins``. It is assumed that sources
     are assigned a tomographic redshift bin with a Gaussian error [1]_. The
     standard deviation of the Gaussian depends on redshift and is given by
     ``sigma(z) = sigma_0*(1 + z)``.
 
-    Parameters
-    ----------
-    z, nz : array_like
-        The true source redshift distribution. Must be one-dimensional.
-    sigma_0 : float
-        Redshift error in the tomographic binning at zero redshift.
-    zbins : list of tuple of float
-        List of redshift bin edges.
+    Args:
+        z: The true source redshift distribution. Must be one-dimensional.
+        nz: The true source redshift distribution. Must be one-dimensional.
+        sigma_0: Redshift error in the tomographic binning at zero redshift.
+        zbins: List of redshift bin edges.
 
     Returns:
     -------

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -142,7 +142,7 @@ def smail_nz(
     r"""
     Redshift distribution following Smail et al. (1994).
 
-    The redshift follows the Smail et al. [1]_ redshift distribution.
+    The redshift follows the Smail et al. [1] redshift distribution.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def smail_nz(
     Notes
     -----
     The probability distribution function :math:`p(z)` for redshift :math:`z`
-    is given by Amara & Refregier [2]_ as
+    is given by Amara & Refregier [2] as
 
     .. math::
 
@@ -176,8 +176,8 @@ def smail_nz(
 
     References
     ----------
-    .. [1] Smail I., Ellis R. S., Fitchett M. J., 1994, MNRAS, 270, 245
-    .. [2] Amara A., Refregier A., 2007, MNRAS, 381, 1018
+    * [1] Smail I., Ellis R. S., Fitchett M. J., 1994, MNRAS, 270, 245
+    * [2] Amara A., Refregier A., 2007, MNRAS, 381, 1018
 
     """
     z_mode = np.asanyarray(z_mode)[..., np.newaxis]
@@ -283,7 +283,7 @@ def tomo_nz_gausserr(
     This function takes a _true_ overall source redshift distribution ``z``,
     ``nz`` and returns tomographic source redshift distributions for the
     tomographic redshift bins given by ``zbins``. It is assumed that sources
-    are assigned a tomographic redshift bin with a Gaussian error [1]_. The
+    are assigned a tomographic redshift bin with a Gaussian error [1]. The
     standard deviation of the Gaussian depends on redshift and is given by
     ``sigma(z) = sigma_0*(1 + z)``.
 
@@ -313,7 +313,7 @@ def tomo_nz_gausserr(
 
     References
     ----------
-    .. [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
+    * [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
            doi:10.1111/j.1365-2966.2007.12271.x
 
     """

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -24,7 +24,7 @@ Visibility
 .. autofunction:: vmap_galactic_ecliptic
 
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from __future__ import annotations
 
@@ -59,12 +59,12 @@ def vmap_galactic_ecliptic(
         ecliptic: The location of the ecliptic plane in the
             respective coordinate system.
 
-    Returns:
+    Returns
     -------
     vis : array_like
         A HEALPix :term:`visibility map`.
 
-    Raises:
+    Raises
     ------
     TypeError
         If the ``galactic`` or ``ecliptic`` arguments are not pairs of numbers.
@@ -106,7 +106,7 @@ def gaussian_nz(
         sigma: Standard deviation(s) of the redshift distribution.
         norm: If given, the normalisation of the distribution.
 
-    Returns:
+    Returns
     -------
     nz : array_like
         Redshift distribution at the given ``z`` values.
@@ -144,12 +144,12 @@ def smail_nz(
         beta: Log-power law exponent exp[-(z/z0)^\beta], must be positive.
         norm: If given, the normalisation of the distribution.
 
-    Returns:
+    Returns
     -------
     pz : array_like
         Redshift distribution at the given ``z`` values.
 
-    Notes:
+    Notes
     -----
     The probability distribution function :math:`p(z)` for redshift :math:`z`
     is given by Amara & Refregier [2]_ as
@@ -161,7 +161,7 @@ def smail_nz(
 
     where :math:`z_0` is matched to the given mode of the distribution.
 
-    References:
+    References
     ----------
     .. [1] Smail I., Ellis R. S., Fitchett M. J., 1994, MNRAS, 270, 245
     .. [2] Amara A., Refregier A., 2007, MNRAS, 381, 1018
@@ -200,7 +200,7 @@ def fixed_zbins(
             ``dz`` can be given.
         dz: Size of redshift bin. Only one of ``nbins`` and ``dz`` can be given.
 
-    Returns:
+    Returns
     -------
     zbins : list of tuple of float
         List of redshift bin edges.
@@ -233,7 +233,7 @@ def equal_dens_zbins(
         nz: The source redshift distribution. Must be one-dimensional.
         nbins: Number of redshift bins.
 
-    Returns:
+    Returns
     -------
     zbins : list of tuple of float
         List of redshift bin edges.
@@ -272,20 +272,20 @@ def tomo_nz_gausserr(
         sigma_0: Redshift error in the tomographic binning at zero redshift.
         zbins: List of redshift bin edges.
 
-    Returns:
+    Returns
     -------
     binned_nz : array_like
         Tomographic redshift bins convolved with a gaussian error.
         Array has a shape (nbins, len(z))
 
-    See Also:
+    See Also
     --------
     equal_dens_zbins :
         produce equal density redshift bins
     fixed_zbins :
         produce redshift bins of fixed size
 
-    References:
+    References
     ----------
     .. [1] Amara A., Réfrégier A., 2007, MNRAS, 381, 1018.
            doi:10.1111/j.1365-2966.2007.12271.x

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -52,7 +52,8 @@ def vmap_galactic_ecliptic(
     the galactic and ecliptic planes. The location of the stripes is set with
     optional parameters.
 
-    Args:
+    Parameters
+    ----------
         nside: The NSIDE parameter of the resulting HEALPix map.
         galactic: The location of the galactic plane in the
             respective coordinate system.
@@ -100,7 +101,8 @@ def gaussian_nz(
     If ``mean`` or ``sigma`` are array_like, their axes will be the leading
     axes of the redshift distribution.
 
-    Args:
+    Parameters
+    ----------
         z: Redshift values of the distribution.
         mean: Mean(s) of the redshift distribution.
         sigma: Standard deviation(s) of the redshift distribution.
@@ -137,7 +139,8 @@ def smail_nz(
 
     The redshift follows the Smail et al. [1]_ redshift distribution.
 
-    Args:
+    Parameters
+    ----------
         z: Redshift values of the distribution.
         z_mode: Mode of the redshift distribution, must be positive.
         alpha: Power law exponent (z/z0)^\alpha, must be positive.
@@ -193,7 +196,8 @@ def fixed_zbins(
     This function creates contiguous tomographic redshift bins of fixed size.
     It takes either the number or size of the bins.
 
-    Args:
+    Parameters
+    ----------
         zmin: Extent of the redshift binning.
         zmax: Extent of the redshift binning.
         nbins: Number of redshift bins. Only one of ``nbins`` and
@@ -228,7 +232,8 @@ def equal_dens_zbins(
     This function subdivides a source redshift distribution into ``nbins``
     tomographic redshift bins with equal density.
 
-    Args:
+    Parameters
+    ----------
         z: The source redshift distribution. Must be one-dimensional.
         nz: The source redshift distribution. Must be one-dimensional.
         nbins: Number of redshift bins.
@@ -266,7 +271,8 @@ def tomo_nz_gausserr(
     standard deviation of the Gaussian depends on redshift and is given by
     ``sigma(z) = sigma_0*(1 + z)``.
 
-    Args:
+    Parameters
+    ----------
         z: The true source redshift distribution. Must be one-dimensional.
         nz: The true source redshift distribution. Must be one-dimensional.
         sigma_0: Redshift error in the tomographic binning at zero redshift.

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -54,11 +54,12 @@ def vmap_galactic_ecliptic(
 
     Parameters
     ----------
-        nside: The NSIDE parameter of the resulting HEALPix map.
-        galactic: The location of the galactic plane in the
-            respective coordinate system.
-        ecliptic: The location of the ecliptic plane in the
-            respective coordinate system.
+    nside:
+        The NSIDE parameter of the resulting HEALPix map.
+    galactic:
+        The location of the galactic plane in the respective coordinate system.
+    ecliptic:
+        The location of the ecliptic plane in the respective coordinate system.
 
     Returns
     -------
@@ -103,10 +104,14 @@ def gaussian_nz(
 
     Parameters
     ----------
-        z: Redshift values of the distribution.
-        mean: Mean(s) of the redshift distribution.
-        sigma: Standard deviation(s) of the redshift distribution.
-        norm: If given, the normalisation of the distribution.
+    z:
+        Redshift values of the distribution.
+    mean:
+        Mean(s) of the redshift distribution.
+    sigma:
+        Standard deviation(s) of the redshift distribution.
+    norm:
+        If given, the normalisation of the distribution.
 
     Returns
     -------
@@ -141,11 +146,16 @@ def smail_nz(
 
     Parameters
     ----------
-        z: Redshift values of the distribution.
-        z_mode: Mode of the redshift distribution, must be positive.
-        alpha: Power law exponent (z/z0)^\alpha, must be positive.
-        beta: Log-power law exponent exp[-(z/z0)^\beta], must be positive.
-        norm: If given, the normalisation of the distribution.
+    z:
+        Redshift values of the distribution.
+    z_mode:
+        Mode of the redshift distribution, must be positive.
+    alpha:
+        Power law exponent (z/z0)^\alpha, must be positive.
+    beta:
+        Log-power law exponent exp[-(z/z0)^\beta], must be positive.
+    norm:
+        If given, the normalisation of the distribution.
 
     Returns
     -------
@@ -198,11 +208,14 @@ def fixed_zbins(
 
     Parameters
     ----------
-        zmin: Extent of the redshift binning.
-        zmax: Extent of the redshift binning.
-        nbins: Number of redshift bins. Only one of ``nbins`` and
-            ``dz`` can be given.
-        dz: Size of redshift bin. Only one of ``nbins`` and ``dz`` can be given.
+    zmin:
+        Extent of the redshift binning.
+    zmax:
+        Extent of the redshift binning.
+    nbins:
+        Number of redshift bins. Only one of ``nbins`` and ``dz`` can be given.
+    dz:
+        Size of redshift bin. Only one of ``nbins`` and ``dz`` can be given.
 
     Returns
     -------
@@ -234,9 +247,12 @@ def equal_dens_zbins(
 
     Parameters
     ----------
-        z: The source redshift distribution. Must be one-dimensional.
-        nz: The source redshift distribution. Must be one-dimensional.
-        nbins: Number of redshift bins.
+    z:
+        The source redshift distribution. Must be one-dimensional.
+    nz:
+        The source redshift distribution. Must be one-dimensional.
+    nbins:
+        Number of redshift bins.
 
     Returns
     -------
@@ -273,10 +289,14 @@ def tomo_nz_gausserr(
 
     Parameters
     ----------
-        z: The true source redshift distribution. Must be one-dimensional.
-        nz: The true source redshift distribution. Must be one-dimensional.
-        sigma_0: Redshift error in the tomographic binning at zero redshift.
-        zbins: List of redshift bin edges.
+    z:
+        The true source redshift distribution. Must be one-dimensional.
+    nz:
+        The true source redshift distribution. Must be one-dimensional.
+    sigma_0:
+        Redshift error in the tomographic binning at zero redshift.
+    zbins:
+        List of redshift bin edges.
 
     Returns
     -------

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -63,7 +63,7 @@ def vmap_galactic_ecliptic(
 
     Returns
     -------
-    vis : array_like
+    vis:
         A HEALPix :term:`visibility map`.
 
     Raises
@@ -115,7 +115,7 @@ def gaussian_nz(
 
     Returns
     -------
-    nz : array_like
+    nz:
         Redshift distribution at the given ``z`` values.
 
     """
@@ -159,7 +159,7 @@ def smail_nz(
 
     Returns
     -------
-    pz : array_like
+    pz:
         Redshift distribution at the given ``z`` values.
 
     Notes
@@ -219,7 +219,7 @@ def fixed_zbins(
 
     Returns
     -------
-    zbins : list of tuple of float
+    zbins:
         List of redshift bin edges.
 
     """
@@ -256,7 +256,7 @@ def equal_dens_zbins(
 
     Returns
     -------
-    zbins : list of tuple of float
+    zbins:
         List of redshift bin edges.
 
     """
@@ -300,7 +300,7 @@ def tomo_nz_gausserr(
 
     Returns
     -------
-    binned_nz : array_like
+    binned_nz:
         Tomographic redshift bins convolved with a gaussian error.
         Array has a shape (nbins, len(z))
 

--- a/glass/points.py
+++ b/glass/points.py
@@ -27,7 +27,7 @@ Bias models
 .. autofunction:: linear_bias
 .. autofunction:: loglinear_bias
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 import healpix
 import numpy as np
@@ -50,12 +50,12 @@ def effective_bias(z, bz, w):
         bz: Redshifts and values of the bias function :math:`b(z)`.
         w: The radial window function :math:`w(z)`.
 
-    Returns:
+    Returns
     -------
     beff : array_like
         Effective bias parameter for the window.
 
-    Notes:
+    Notes
     -----
     The effective bias parameter :math:`\\bar{b}` is computed using the
     window function :math:`w(z)` as the weighted average
@@ -131,7 +131,7 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
         batch: Maximum number of positions to yield in one batch.
         rng: Random number generator. If not given, a default RNG is used.
 
-    Yields:
+    Yields
     ------
     lon, lat : array_like
         Columns of longitudes and latitudes for the sampled points.
@@ -245,7 +245,7 @@ def uniform_positions(ngal, *, rng=None):
         ngal: Number density, expected number of positions per arcmin2.
         rng: Random number generator. If not given, a default RNG will be used.
 
-    Yields:
+    Yields
     ------
     lon, lat : array_like or list of array_like
         Columns of longitudes and latitudes for the sampled points.
@@ -300,7 +300,7 @@ def position_weights(densities, bias=None):
             broadcast against the number of shells, and is normalised internally.
         bias: Value or values of the linear bias parameter for each shell.
 
-    Returns:
+    Returns
     -------
     weights : array_like
         Relative weight of each shell for angular clustering.

--- a/glass/points.py
+++ b/glass/points.py
@@ -145,12 +145,13 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
 
     Yields
     ------
-    lon, lat : array_like
-        Columns of longitudes and latitudes for the sampled points.
-    count : int or array_like
-        The number of sampled points  If multiple populations are
-        sampled, an array of counts in the shape of the extra
-        dimensions is returned.
+    lon:
+        Columns of longitudes for the sampled points.
+    lat:
+        Columns of latitudes for the sampled points.
+    count:
+        The number of sampled points  If multiple populations are sampled, an
+        array of counts in the shape of the extra dimensions is returned.
 
     """
     # get default RNG if not given
@@ -262,9 +263,11 @@ def uniform_positions(ngal, *, rng=None):
 
     Yields
     ------
-    lon, lat : array_like or list of array_like
-        Columns of longitudes and latitudes for the sampled points.
-    count : int or list of ints
+    lon:
+        Columns of longitudes for the sampled points.
+    lat:
+        Columns of latitudes for the sampled points.
+    count:
         The number of sampled points. For array inputs, an array of
         counts with the same shape is returned.
 

--- a/glass/points.py
+++ b/glass/points.py
@@ -56,7 +56,7 @@ def effective_bias(z, bz, w):
 
     Returns
     -------
-    beff : array_like
+    beff:
         Effective bias parameter for the window.
 
     Notes
@@ -320,7 +320,7 @@ def position_weights(densities, bias=None):
 
     Returns
     -------
-    weights : array_like
+    weights:
         Relative weight of each shell for angular clustering.
 
     """

--- a/glass/points.py
+++ b/glass/points.py
@@ -45,7 +45,8 @@ def effective_bias(z, bz, w):
     and computes an effective bias parameter :math:`\\bar{b}` for a
     given window function :math:`w(z)`.
 
-    Args:
+    Parameters
+    ----------
         z: Redshifts and values of the bias function :math:`b(z)`.
         bz: Redshifts and values of the bias function :math:`b(z)`.
         w: The radial window function :math:`w(z)`.
@@ -115,7 +116,8 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
     number of points per population is returned in ``count`` as an array
     in the shape of the extra dimensions.
 
-    Args:
+    Parameters
+    ----------
         ngal: Number density, expected number of points per arcmin2.
         delta: Map of the input density contrast. This is fed into the bias
             model to produce the density contrast for sampling.
@@ -241,7 +243,8 @@ def uniform_positions(ngal, *, rng=None):
 
     The function supports array input for the ``ngal`` parameter.
 
-    Args:
+    Parameters
+    ----------
         ngal: Number density, expected number of positions per arcmin2.
         rng: Random number generator. If not given, a default RNG will be used.
 
@@ -295,7 +298,8 @@ def position_weights(densities, bias=None):
     redshift distribution and bias factor :math:`n(z) \\, b(z)` for the
     discretised shells.
 
-    Args:
+    Parameters
+    ----------
         densities: Density of points in each shell. The first axis must
             broadcast against the number of shells, and is normalised internally.
         bias: Value or values of the linear bias parameter for each shell.

--- a/glass/points.py
+++ b/glass/points.py
@@ -47,9 +47,12 @@ def effective_bias(z, bz, w):
 
     Parameters
     ----------
-        z: Redshifts and values of the bias function :math:`b(z)`.
-        bz: Redshifts and values of the bias function :math:`b(z)`.
-        w: The radial window function :math:`w(z)`.
+    z:
+        Redshifts and values of the bias function :math:`b(z)`.
+    bz:
+        Redshifts and values of the bias function :math:`b(z)`.
+    w:
+        The radial window function :math:`w(z)`.
 
     Returns
     -------
@@ -118,20 +121,27 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
 
     Parameters
     ----------
-        ngal: Number density, expected number of points per arcmin2.
-        delta: Map of the input density contrast. This is fed into the bias
-            model to produce the density contrast for sampling.
-        bias: Bias parameter, is passed as an argument to the bias model.
-        vis: Visibility map for the observed points. This is multiplied with
-            the full sky number count map, and must hence be of compatible
-            shape.
-        bias_model: The bias model to apply. If a string, refers to a
-            function in the :mod:`~glass.points` module, e.g. ``'linear'`` for
-            :func:`linear_bias()` or ``'loglinear'`` for :func:`loglinear_bias`.
-        remove_monopole: If true, the monopole of the density contrast
-            after biasing is fixed to zero.
-        batch: Maximum number of positions to yield in one batch.
-        rng: Random number generator. If not given, a default RNG is used.
+    ngal:
+        Number density, expected number of points per arcmin2.
+    delta:
+        Map of the input density contrast. This is fed into the bias
+        model to produce the density contrast for sampling.
+    bias:
+        Bias parameter, is passed as an argument to the bias model.
+    vis:
+        Visibility map for the observed points. This is multiplied with
+        the full sky number count map, and must hence be of compatible shape.
+    bias_model:
+        The bias model to apply. If a string, refers to a function in
+        the :mod:`~glass.points` module, e.g. ``'linear'`` for
+        :func:`linear_bias()` or ``'loglinear'`` for :func:`loglinear_bias`.
+    remove_monopole:
+        If true, the monopole of the density contrast
+        after biasing is fixed to zero.
+    batch:
+        Maximum number of positions to yield in one batch.
+    rng:
+        Random number generator. If not given, a default RNG is used.
 
     Yields
     ------
@@ -245,8 +255,10 @@ def uniform_positions(ngal, *, rng=None):
 
     Parameters
     ----------
-        ngal: Number density, expected number of positions per arcmin2.
-        rng: Random number generator. If not given, a default RNG will be used.
+    ngal:
+        Number density, expected number of positions per arcmin2.
+    rng:
+        Random number generator. If not given, a default RNG will be used.
 
     Yields
     ------
@@ -300,9 +312,11 @@ def position_weights(densities, bias=None):
 
     Parameters
     ----------
-        densities: Density of points in each shell. The first axis must
-            broadcast against the number of shells, and is normalised internally.
-        bias: Value or values of the linear bias parameter for each shell.
+    densities:
+        Density of points in each shell. The first axis must broadcast
+        against the number of shells, and is normalised internally.
+    bias:
+        Value or values of the linear bias parameter for each shell.
 
     Returns
     -------

--- a/glass/points.py
+++ b/glass/points.py
@@ -45,12 +45,10 @@ def effective_bias(z, bz, w):
     and computes an effective bias parameter :math:`\\bar{b}` for a
     given window function :math:`w(z)`.
 
-    Parameters
-    ----------
-    z, bz : array_like
-        Redshifts and values of the bias function :math:`b(z)`.
-    w : :class:`~glass.RadialWindow`
-        The radial window function :math:`w(z)`.
+    Args:
+        z: Redshifts and values of the bias function :math:`b(z)`.
+        bz: Redshifts and values of the bias function :math:`b(z)`.
+        w: The radial window function :math:`w(z)`.
 
     Returns:
     -------
@@ -104,51 +102,41 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
     visibility map.
 
     If ``remove_monopole`` is set, the monopole of the computed density
-    contrast is removed.  Over the full sky, the mean number density of
-    the map will then match the given number density exactly.  This,
+    contrast is removed. Over the full sky, the mean number density of
+    the map will then match the given number density exactly. This,
     however, means that an effectively different bias model is being
     used, unless the monopole is already zero in the first place.
 
     The function supports multi-dimensional input for the ``ngal``,
-    ``delta``, ``bias``, and ``vis`` parameters.  Extra dimensions are
+    ``delta``, ``bias``, and ``vis`` parameters. Extra dimensions are
     broadcast to a common shape, and treated as separate populations of
-    points.  These are then sampled independently, and the results
-    concatenated into a flat list of longitudes and latitudes.  The
+    points. These are then sampled independently, and the results
+    concatenated into a flat list of longitudes and latitudes. The
     number of points per population is returned in ``count`` as an array
     in the shape of the extra dimensions.
 
-    Parameters
-    ----------
-    ngal : float or array_like
-        Number density, expected number of points per arcmin2.
-    delta : array_like
-        Map of the input density contrast.  This is fed into the bias
-        model to produce the density contrast for sampling.
-    bias : float or array_like, optional
-        Bias parameter, is passed as an argument to the bias model.
-    vis : array_like, optional
-        Visibility map for the observed points.  This is multiplied with
-        the full sky number count map, and must hence be of compatible
-        shape.
-    bias_model : str or callable, optional
-        The bias model to apply.  If a string, refers to a function in
-        the :mod:`~glass.points` module, e.g. ``'linear'`` for
-        :func:`linear_bias()` or ``'loglinear'`` for
-        :func:`loglinear_bias`.
-    remove_monopole : bool, optional
-        If true, the monopole of the density contrast after biasing is
-        fixed to zero.
-    batch : int, optional
-        Maximum number of positions to yield in one batch.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG is used.
+    Args:
+        ngal: Number density, expected number of points per arcmin2.
+        delta: Map of the input density contrast. This is fed into the bias
+            model to produce the density contrast for sampling.
+        bias: Bias parameter, is passed as an argument to the bias model.
+        vis: Visibility map for the observed points. This is multiplied with
+            the full sky number count map, and must hence be of compatible
+            shape.
+        bias_model: The bias model to apply. If a string, refers to a
+            function in the :mod:`~glass.points` module, e.g. ``'linear'`` for
+            :func:`linear_bias()` or ``'loglinear'`` for :func:`loglinear_bias`.
+        remove_monopole: If true, the monopole of the density contrast
+            after biasing is fixed to zero.
+        batch: Maximum number of positions to yield in one batch.
+        rng: Random number generator. If not given, a default RNG is used.
 
     Yields:
     ------
     lon, lat : array_like
         Columns of longitudes and latitudes for the sampled points.
     count : int or array_like
-        The number of sampled points.  If multiple populations are
+        The number of sampled points  If multiple populations are
         sampled, an array of counts in the shape of the extra
         dimensions is returned.
 
@@ -253,19 +241,16 @@ def uniform_positions(ngal, *, rng=None):
 
     The function supports array input for the ``ngal`` parameter.
 
-    Parameters
-    ----------
-    ngal : float or array_like
-        Number density, expected number of positions per arcmin2.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be used.
+    Args:
+        ngal: Number density, expected number of positions per arcmin2.
+        rng: Random number generator. If not given, a default RNG will be used.
 
     Yields:
     ------
     lon, lat : array_like or list of array_like
         Columns of longitudes and latitudes for the sampled points.
     count : int or list of ints
-        The number of sampled points.  For array inputs, an array of
+        The number of sampled points. For array inputs, an array of
         counts with the same shape is returned.
 
     """
@@ -303,20 +288,17 @@ def position_weights(densities, bias=None):
     Compute relative weights for angular clustering.
 
     Takes an array *densities* of densities in arbitrary units and
-    returns the relative weight of each shell.  If *bias* is given, a
+    returns the relative weight of each shell. If *bias* is given, a
     linear bias is applied to each shell.
 
     This is the equivalent of computing the product of normalised
     redshift distribution and bias factor :math:`n(z) \\, b(z)` for the
     discretised shells.
 
-    Parameters
-    ----------
-    densities : array_like
-        Density of points in each shell.  The first axis must broadcast
-        against the number of shells, and is normalised internally.
-    bias : array_like, optional
-        Value or values of the linear bias parameter for each shell.
+    Args:
+        densities: Density of points in each shell. The first axis must
+            broadcast against the number of shells, and is normalised internally.
+        bias: Value or values of the linear bias parameter for each shell.
 
     Returns:
     -------

--- a/glass/points.py
+++ b/glass/points.py
@@ -27,7 +27,7 @@ Bias models
 .. autofunction:: linear_bias
 .. autofunction:: loglinear_bias
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 import healpix
 import numpy as np
@@ -52,12 +52,12 @@ def effective_bias(z, bz, w):
     w : :class:`~glass.RadialWindow`
         The radial window function :math:`w(z)`.
 
-    Returns
+    Returns:
     -------
     beff : array_like
         Effective bias parameter for the window.
 
-    Notes
+    Notes:
     -----
     The effective bias parameter :math:`\\bar{b}` is computed using the
     window function :math:`w(z)` as the weighted average
@@ -143,7 +143,7 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
-    Yields
+    Yields:
     ------
     lon, lat : array_like
         Columns of longitudes and latitudes for the sampled points.
@@ -260,7 +260,7 @@ def uniform_positions(ngal, *, rng=None):
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG will be used.
 
-    Yields
+    Yields:
     ------
     lon, lat : array_like or list of array_like
         Columns of longitudes and latitudes for the sampled points.
@@ -318,7 +318,7 @@ def position_weights(densities, bias=None):
     bias : array_like, optional
         Value or values of the linear bias parameter for each shell.
 
-    Returns
+    Returns:
     -------
     weights : array_like
         Relative weight of each shell for angular clustering.

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -41,11 +41,15 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
 
     Parameters
     ----------
-        zeta: Axis ratio of intermediate and major axis.
-        xi: Axis ratio of minor and major axis.
-        size: Size of the random draw. If `None` is given, size is inferred from
-            other inputs.
-        rng: Random number generator. If not given, a default RNG will be used.
+    zeta:
+        Axis ratio of intermediate and major axis.
+    xi:
+        Axis ratio of minor and major axis.
+    size:
+        Size of the random draw. If `None` is given, size is inferred from
+        other inputs.
+    rng:
+        Random number generator. If not given, a default RNG will be used.
 
     Returns
     -------
@@ -106,12 +110,18 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
 
     Parameters
     ----------
-        mu: Mean of the truncated normal for :math:`\log(1 - B/A)`.
-        sigma: Standard deviation for :math:`\log(1 - B/A)`.
-        gamma: Mean of the truncated normal for :math:`1 - C/B`.
-        sigma_gamma: Standard deviation for :math:`1 - C/B`.
-        size: Sample size. If ``None``, the size is inferred from the parameters.
-        rng: Random number generator. If not given, a default RNG will be used.
+    mu:
+        Mean of the truncated normal for :math:`\log(1 - B/A)`.
+    sigma:
+        Standard deviation for :math:`\log(1 - B/A)`.
+    gamma:
+        Mean of the truncated normal for :math:`1 - C/B`.
+    sigma_gamma:
+        Standard deviation for :math:`1 - C/B`.
+    size:
+        Sample size. If ``None``, the size is inferred from the parameters.
+    rng:
+        Random number generator. If not given, a default RNG will be used.
 
     Returns
     -------
@@ -177,9 +187,12 @@ def ellipticity_gaussian(
 
     Parameters
     ----------
-        count: Number of ellipticities to be sampled.
-        sigma: Standard deviation in each component.
-        rng: Random number generator. If not given, a default RNG is used.
+    count:
+        Number of ellipticities to be sampled.
+    sigma:
+        Standard deviation in each component.
+    rng:
+        Random number generator. If not given, a default RNG is used.
 
     Returns
     -------
@@ -228,9 +241,12 @@ def ellipticity_intnorm(
 
     Parameters
     ----------
-        count: Number of ellipticities to sample.
-        sigma: Standard deviation of the ellipticity in each component.
-        rng: Random number generator. If not given, a default RNG is used.
+    count:
+        Number of ellipticities to sample.
+    sigma:
+        Standard deviation of the ellipticity in each component.
+    rng:
+        Random number generator. If not given, a default RNG is used.
 
     Returns
     -------

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -20,7 +20,7 @@ Utilities
 
 .. autofunction:: triaxial_axis_ratio
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from __future__ import annotations
 
@@ -46,16 +46,16 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
             other inputs.
         rng: Random number generator. If not given, a default RNG will be used.
 
-    Returns:
+    Returns
     -------
     q : array_like
         Axis ratio of the randomly projected ellipsoid.
 
-    Notes:
+    Notes
     -----
     See equations (11) and (12) in [1]_ for details.
 
-    References:
+    References
     ----------
     .. [1] Binney J., 1985, MNRAS, 212, 767. doi:10.1093/mnras/212.4.767
 
@@ -111,12 +111,12 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
         size: Sample size. If ``None``, the size is inferred from the parameters.
         rng: Random number generator. If not given, a default RNG will be used.
 
-    Returns:
+    Returns
     -------
     eps : array_like
         Array of :term:`ellipticity` from projected axis ratios.
 
-    References:
+    References
     ----------
     .. [1] Ryden B. S., 2004, ApJ, 601, 214.
     .. [2] Padilla N. D., Strauss M. A., 2008, MNRAS, 388, 1321.
@@ -178,7 +178,7 @@ def ellipticity_gaussian(
         sigma: Standard deviation in each component.
         rng: Random number generator. If not given, a default RNG is used.
 
-    Returns:
+    Returns
     -------
     eps : array_like
         Array of galaxy :term:`ellipticity`.
@@ -228,7 +228,7 @@ def ellipticity_intnorm(
         sigma: Standard deviation of the ellipticity in each component.
         rng: Random number generator. If not given, a default RNG is used.
 
-    Returns:
+    Returns
     -------
     eps : array_like
         Array of galaxy :term:`ellipticity`.

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -53,7 +53,7 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
 
     Returns
     -------
-    q : array_like
+    q:
         Axis ratio of the randomly projected ellipsoid.
 
     Notes
@@ -125,7 +125,7 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
 
     Returns
     -------
-    eps : array_like
+    eps:
         Array of :term:`ellipticity` from projected axis ratios.
 
     References
@@ -196,7 +196,7 @@ def ellipticity_gaussian(
 
     Returns
     -------
-    eps : array_like
+    eps:
         Array of galaxy :term:`ellipticity`.
 
     """
@@ -250,7 +250,7 @@ def ellipticity_intnorm(
 
     Returns
     -------
-    eps : array_like
+    eps:
         Array of galaxy :term:`ellipticity`.
 
     """

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -39,7 +39,8 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
     Given the two axis ratios `1 >= zeta >= xi` of a randomly oriented triaxial
     ellipsoid, computes the axis ratio `q` of the projection.
 
-    Args:
+    Parameters
+    ----------
         zeta: Axis ratio of intermediate and major axis.
         xi: Axis ratio of minor and major axis.
         size: Size of the random draw. If `None` is given, size is inferred from
@@ -103,7 +104,8 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     standard deviation :math:`\sigma_\gamma` [2]_. Both distributions are
     truncated to produce ratios in the range 0 to 1 using rejection sampling.
 
-    Args:
+    Parameters
+    ----------
         mu: Mean of the truncated normal for :math:`\log(1 - B/A)`.
         sigma: Standard deviation for :math:`\log(1 - B/A)`.
         gamma: Mean of the truncated normal for :math:`1 - C/B`.
@@ -173,7 +175,8 @@ def ellipticity_gaussian(
     this function with too large values of ``sigma``, or the sampling
     will become inefficient.
 
-    Args:
+    Parameters
+    ----------
         count: Number of ellipticities to be sampled.
         sigma: Standard deviation in each component.
         rng: Random number generator. If not given, a default RNG is used.
@@ -223,7 +226,8 @@ def ellipticity_intnorm(
     The ellipticities are sampled from an intrinsic normal distribution
     with standard deviation ``sigma`` for each component.
 
-    Args:
+    Parameters
+    ----------
         count: Number of ellipticities to sample.
         sigma: Standard deviation of the ellipticity in each component.
         rng: Random number generator. If not given, a default RNG is used.

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -39,17 +39,12 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
     Given the two axis ratios `1 >= zeta >= xi` of a randomly oriented triaxial
     ellipsoid, computes the axis ratio `q` of the projection.
 
-    Parameters
-    ----------
-    zeta : array_like
-        Axis ratio of intermediate and major axis.
-    xi : array_like
-        Axis ratio of minor and major axis.
-    size : tuple of int or None
-        Size of the random draw. If `None` is given, size is inferred from
-        other inputs.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be used.
+    Args:
+        zeta: Axis ratio of intermediate and major axis.
+        xi: Axis ratio of minor and major axis.
+        size: Size of the random draw. If `None` is given, size is inferred from
+            other inputs.
+        rng: Random number generator. If not given, a default RNG will be used.
 
     Returns:
     -------
@@ -102,26 +97,19 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     Ellipticity distribution following Ryden (2004).
 
     The ellipticities are sampled by randomly projecting a 3D ellipsoid with
-    principal axes :math:`A > B > C` [1]_.  The distribution of :math:`\log(1 -
+    principal axes :math:`A > B > C` [1]_. The distribution of :math:`\log(1 -
     B/A)` is normal with mean :math:`\mu` and standard deviation :math:`\sigma`.
     The distribution of :math:`1 - C/B` is normal with mean :math:`\gamma` and
-    standard deviation :math:`\sigma_\gamma` [2]_.  Both distributions are
+    standard deviation :math:`\sigma_\gamma` [2]_. Both distributions are
     truncated to produce ratios in the range 0 to 1 using rejection sampling.
 
-    Parameters
-    ----------
-    mu : array_like
-        Mean of the truncated normal for :math:`\log(1 - B/A)`.
-    sigma : array_like
-        Standard deviation for :math:`\log(1 - B/A)`.
-    gamma : array_like
-        Mean of the truncated normal for :math:`1 - C/B`.
-    sigma_gamma : array_like
-        Standard deviation for :math:`1 - C/B`.
-    size : int or tuple of ints or None
-        Sample size.  If ``None``, the size is inferred from the parameters.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG will be used.
+    Args:
+        mu: Mean of the truncated normal for :math:`\log(1 - B/A)`.
+        sigma: Standard deviation for :math:`\log(1 - B/A)`.
+        gamma: Mean of the truncated normal for :math:`1 - C/B`.
+        sigma_gamma: Standard deviation for :math:`1 - C/B`.
+        size: Sample size. If ``None``, the size is inferred from the parameters.
+        rng: Random number generator. If not given, a default RNG will be used.
 
     Returns:
     -------
@@ -180,19 +168,15 @@ def ellipticity_gaussian(
     Sample Gaussian galaxy ellipticities.
 
     The ellipticities are sampled from a normal distribution with
-    standard deviation ``sigma`` for each component.  Samples where the
-    ellipticity is larger than unity are discarded.  Hence, do not use
+    standard deviation ``sigma`` for each component. Samples where the
+    ellipticity is larger than unity are discarded. Hence, do not use
     this function with too large values of ``sigma``, or the sampling
     will become inefficient.
 
-    Parameters
-    ----------
-    count : int or array_like
-        Number of ellipticities to be sampled.
-    sigma : array_like
-        Standard deviation in each component.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG is used.
+    Args:
+        count: Number of ellipticities to be sampled.
+        sigma: Standard deviation in each component.
+        rng: Random number generator. If not given, a default RNG is used.
 
     Returns:
     -------
@@ -239,14 +223,10 @@ def ellipticity_intnorm(
     The ellipticities are sampled from an intrinsic normal distribution
     with standard deviation ``sigma`` for each component.
 
-    Parameters
-    ----------
-    count : int | array_like
-        Number of ellipticities to sample.
-    sigma : array_like
-        Standard deviation of the ellipticity in each component.
-    rng : :class:`~numpy.random.Generator`, optional
-        Random number generator.  If not given, a default RNG is used.
+    Args:
+        count: Number of ellipticities to sample.
+        sigma: Standard deviation of the ellipticity in each component.
+        rng: Random number generator. If not given, a default RNG is used.
 
     Returns:
     -------

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -58,11 +58,11 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
 
     Notes
     -----
-    See equations (11) and (12) in [1]_ for details.
+    See equations (11) and (12) in [1] for details.
 
     References
     ----------
-    .. [1] Binney J., 1985, MNRAS, 212, 767. doi:10.1093/mnras/212.4.767
+    * [1] Binney J., 1985, MNRAS, 212, 767. doi:10.1093/mnras/212.4.767
 
     """
     # default RNG if not provided
@@ -102,10 +102,10 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     Ellipticity distribution following Ryden (2004).
 
     The ellipticities are sampled by randomly projecting a 3D ellipsoid with
-    principal axes :math:`A > B > C` [1]_. The distribution of :math:`\log(1 -
+    principal axes :math:`A > B > C` [1]. The distribution of :math:`\log(1 -
     B/A)` is normal with mean :math:`\mu` and standard deviation :math:`\sigma`.
     The distribution of :math:`1 - C/B` is normal with mean :math:`\gamma` and
-    standard deviation :math:`\sigma_\gamma` [2]_. Both distributions are
+    standard deviation :math:`\sigma_\gamma` [2]. Both distributions are
     truncated to produce ratios in the range 0 to 1 using rejection sampling.
 
     Parameters
@@ -130,8 +130,8 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
 
     References
     ----------
-    .. [1] Ryden B. S., 2004, ApJ, 601, 214.
-    .. [2] Padilla N. D., Strauss M. A., 2008, MNRAS, 388, 1321.
+    * [1] Ryden B. S., 2004, ApJ, 601, 214.
+    * [2] Padilla N. D., Strauss M. A., 2008, MNRAS, 388, 1321.
 
     """
     # default RNG if not provided

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -20,7 +20,7 @@ Utilities
 
 .. autofunction:: triaxial_axis_ratio
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 
@@ -51,16 +51,16 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG will be used.
 
-    Returns
+    Returns:
     -------
     q : array_like
         Axis ratio of the randomly projected ellipsoid.
 
-    Notes
+    Notes:
     -----
     See equations (11) and (12) in [1]_ for details.
 
-    References
+    References:
     ----------
     .. [1] Binney J., 1985, MNRAS, 212, 767. doi:10.1093/mnras/212.4.767
 
@@ -123,12 +123,12 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG will be used.
 
-    Returns
+    Returns:
     -------
     eps : array_like
         Array of :term:`ellipticity` from projected axis ratios.
 
-    References
+    References:
     ----------
     .. [1] Ryden B. S., 2004, ApJ, 601, 214.
     .. [2] Padilla N. D., Strauss M. A., 2008, MNRAS, 388, 1321.
@@ -194,7 +194,7 @@ def ellipticity_gaussian(
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
-    Returns
+    Returns:
     -------
     eps : array_like
         Array of galaxy :term:`ellipticity`.
@@ -248,7 +248,7 @@ def ellipticity_intnorm(
     rng : :class:`~numpy.random.Generator`, optional
         Random number generator.  If not given, a default RNG is used.
 
-    Returns
+    Returns:
     -------
     eps : array_like
         Array of galaxy :term:`ellipticity`.

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -155,7 +155,7 @@ def tophat_windows(
 
     Returns
     -------
-    ws : (N,) list of :class:`RadialWindow`
+    ws:
         List of window functions.
 
     See Also
@@ -213,7 +213,7 @@ def linear_windows(
 
     Returns
     -------
-    ws : (N,) list of :class:`RadialWindow`
+    ws:
         List of window functions.
 
     See Also
@@ -274,7 +274,7 @@ def cubic_windows(
 
     Returns
     -------
-    ws : (N,) list of :class:`RadialWindow`
+    ws:
         List of window functions.
 
     See Also
@@ -337,7 +337,9 @@ def restrict(
 
     Returns
     -------
-    zr, fr : array
+    zr:
+        The restricted function.
+    fr:
         The restricted function.
 
     """
@@ -385,7 +387,7 @@ def partition(
 
     Returns
     -------
-    x : array_like
+    x:
         Weights of the partition, where the leading axis corresponds to
         *shells*.
 
@@ -634,7 +636,7 @@ def combine(
 
     Returns
     -------
-    fz : array_like
+    fz:
         Linear combination of window functions, evaluated in *z*.
 
     See Also

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -107,11 +107,11 @@ class RadialWindow(NamedTuple):
 
     Attributes
     ----------
-    za: Sequence[float]
+    za:
         Redshift array; the abscissae of the window function.
-    wa: Sequence[float]
+    wa:
         Weight array; the values (ordinates) of the window function.
-    zeff: float
+    zeff:
         Effective redshift of the window.
 
     Methods

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -107,11 +107,11 @@ class RadialWindow(NamedTuple):
 
     Attributes
     ----------
-    za : Sequence[float]
+    za: Sequence[float]
         Redshift array; the abscissae of the window function.
-    wa : Sequence[float]
+    wa: Sequence[float]
         Weight array; the values (ordinates) of the window function.
-    zeff : float
+    zeff: float
         Effective redshift of the window.
 
     Methods
@@ -641,7 +641,8 @@ def combine(
 
     See Also
     --------
-    partition : Find weights for a given function.
+    partition:
+        Find weights for a given function.
 
     """
     return sum(

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -146,10 +146,12 @@ def tophat_windows(
 
     Parameters
     ----------
-        zbins: Redshift bin edges for the tophat window functions.
-        dz: Approximate spacing of the redshift grid.
-        weight: If given, a weight function to be applied to the window
-            functions.
+    zbins:
+        Redshift bin edges for the tophat window functions.
+    dz:
+        Approximate spacing of the redshift grid.
+    weight:
+        If given, a weight function to be applied to the window functions.
 
     Returns
     -------
@@ -202,10 +204,12 @@ def linear_windows(
 
     Parameters
     ----------
-        zgrid: Redshift grid for the triangular window functions.
-        dz: Approximate spacing of the redshift grid.
-        weight: If given, a weight function to be applied to the window
-            functions.
+    zgrid:
+        Redshift grid for the triangular window functions.
+    dz:
+        Approximate spacing of the redshift grid.
+    weight:
+        If given, a weight function to be applied to the window functions.
 
     Returns
     -------
@@ -261,10 +265,12 @@ def cubic_windows(
 
     Parameters
     ----------
-        zgrid: Redshift grid for the cubic spline window functions.
-        dz: Approximate spacing of the redshift grid.
-        weight: If given, a weight function to be applied to the window
-            functions.
+    zgrid:
+        Redshift grid for the cubic spline window functions.
+    dz:
+        Approximate spacing of the redshift grid.
+    weight:
+        If given, a weight function to be applied to the window functions.
 
     Returns
     -------
@@ -322,9 +328,12 @@ def restrict(
 
     Parameters
     ----------
-        z: The function to be restricted.
-        f: The function to be restricted.
-        w: The window function for the restriction.
+    z:
+        The function to be restricted.
+    f:
+        The function to be restricted.
+    w:
+        The window function for the restriction.
 
     Returns
     -------
@@ -362,13 +371,17 @@ def partition(
 
     Parameters
     ----------
-        z: The function to be partitioned. If *f* is multi-dimensional,
-            its last axis must agree with *z*.
-        fz: The function to be partitioned. If *f* is multi-dimensional,
-            its last axis must agree with *z*.
-        shells: Ordered sequence of window functions for the partition.
-        method: Method for the partition. See notes for description. The
-            options are "lstsq", "nnls", "restrict".
+    z:
+        The function to be partitioned. If *f* is multi-dimensional,
+        its last axis must agree with *z*.
+    fz:
+        The function to be partitioned. If *f* is multi-dimensional,
+        its last axis must agree with *z*.
+    shells:
+        Ordered sequence of window functions for the partition.
+    method:
+        Method for the partition. See notes for description. The
+        options are "lstsq", "nnls", "restrict".
 
     Returns
     -------
@@ -611,10 +624,13 @@ def combine(
 
     Parameters
     ----------
-        z: Redshifts *z* in which to evaluate the combined function.
-        weights: Weights of the linear combination, where the leading axis
-            corresponds to *shells*.
-        shells: Ordered sequence of window functions to be combined.
+    z:
+        Redshifts *z* in which to evaluate the combined function.
+    weights:
+        Weights of the linear combination, where the leading axis
+        corresponds to *shells*.
+    shells:
+        Ordered sequence of window functions to be combined.
 
     Returns
     -------

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -144,7 +144,8 @@ def tophat_windows(
     Their effective redshifts are the mean redshifts of the (weighted)
     tophat bins.
 
-    Args:
+    Parameters
+    ----------
         zbins: Redshift bin edges for the tophat window functions.
         dz: Approximate spacing of the redshift grid.
         weight: If given, a weight function to be applied to the window
@@ -199,7 +200,8 @@ def linear_windows(
     The resulting windows functions are :class:`RadialWindow` instances.
     Their effective redshifts correspond to the given nodes.
 
-    Args:
+    Parameters
+    ----------
         zgrid: Redshift grid for the triangular window functions.
         dz: Approximate spacing of the redshift grid.
         weight: If given, a weight function to be applied to the window
@@ -257,7 +259,8 @@ def cubic_windows(
     The resulting windows functions are :class:`RadialWindow` instances.
     Their effective redshifts correspond to the given nodes.
 
-    Args:
+    Parameters
+    ----------
         zgrid: Redshift grid for the cubic spline window functions.
         dz: Approximate spacing of the redshift grid.
         weight: If given, a weight function to be applied to the window
@@ -317,7 +320,8 @@ def restrict(
     the function and window over the support of the window.
     Intermediate function values are found by linear interpolation
 
-    Args:
+    Parameters
+    ----------
         z: The function to be restricted.
         f: The function to be restricted.
         w: The window function for the restriction.
@@ -356,7 +360,8 @@ def partition(
     The window functions are given by the sequence *shells* of
     :class:`RadialWindow` or compatible entries.
 
-    Args:
+    Parameters
+    ----------
         z: The function to be partitioned. If *f* is multi-dimensional,
             its last axis must agree with *z*.
         fz: The function to be partitioned. If *f* is multi-dimensional,
@@ -604,7 +609,8 @@ def combine(
     The window functions are given by the sequence *shells* of
     :class:`RadialWindow` or compatible entries.
 
-    Args:
+    Parameters
+    ----------
         z: Redshifts *z* in which to evaluate the combined function.
         weights: Weights of the linear combination, where the leading axis
             corresponds to *shells*.

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -40,7 +40,7 @@ Weight functions
 .. autofunction:: distance_weight
 .. autofunction:: volume_weight
 .. autofunction:: density_weight
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from __future__ import annotations
 
@@ -105,7 +105,7 @@ class RadialWindow(NamedTuple):
         >>> w1
         RadialWindow(za=..., wa=..., zeff=0.15)
 
-    Attributes:
+    Attributes
     ----------
     za : Sequence[float]
         Redshift array; the abscissae of the window function.
@@ -114,7 +114,7 @@ class RadialWindow(NamedTuple):
     zeff : float
         Effective redshift of the window.
 
-    Methods:
+    Methods
     -------
     _replace
 
@@ -150,12 +150,12 @@ def tophat_windows(
         weight: If given, a weight function to be applied to the window
             functions.
 
-    Returns:
+    Returns
     -------
     ws : (N,) list of :class:`RadialWindow`
         List of window functions.
 
-    See Also:
+    See Also
     --------
     :ref:`user-window-functions`
 
@@ -205,12 +205,12 @@ def linear_windows(
         weight: If given, a weight function to be applied to the window
             functions.
 
-    Returns:
+    Returns
     -------
     ws : (N,) list of :class:`RadialWindow`
         List of window functions.
 
-    See Also:
+    See Also
     --------
     :ref:`user-window-functions`
 
@@ -263,12 +263,12 @@ def cubic_windows(
         weight: If given, a weight function to be applied to the window
             functions.
 
-    Returns:
+    Returns
     -------
     ws : (N,) list of :class:`RadialWindow`
         List of window functions.
 
-    See Also:
+    See Also
     --------
     :ref:`user-window-functions`
 
@@ -322,7 +322,7 @@ def restrict(
         f: The function to be restricted.
         w: The window function for the restriction.
 
-    Returns:
+    Returns
     -------
     zr, fr : array
         The restricted function.
@@ -365,13 +365,13 @@ def partition(
         method: Method for the partition. See notes for description. The
             options are "lstsq", "nnls", "restrict".
 
-    Returns:
+    Returns
     -------
     x : array_like
         Weights of the partition, where the leading axis corresponds to
         *shells*.
 
-    Notes:
+    Notes
     -----
     Formally, if :math:`w_i` are the normalised window functions,
     :math:`f` is the target function, and :math:`z_i` is a redshift grid
@@ -610,12 +610,12 @@ def combine(
             corresponds to *shells*.
         shells: Ordered sequence of window functions to be combined.
 
-    Returns:
+    Returns
     -------
     fz : array_like
         Linear combination of window functions, evaluated in *z*.
 
-    See Also:
+    See Also
     --------
     partition : Find weights for a given function.
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -144,6 +144,8 @@ def tophat_windows(
     Their effective redshifts are the mean redshifts of the (weighted)
     tophat bins.
 
+    Returns a list of window functions.
+
     Parameters
     ----------
     zbins:
@@ -152,11 +154,6 @@ def tophat_windows(
         Approximate spacing of the redshift grid.
     weight:
         If given, a weight function to be applied to the window functions.
-
-    Returns
-    -------
-    ws:
-        List of window functions.
 
     See Also
     --------
@@ -202,6 +199,8 @@ def linear_windows(
     The resulting windows functions are :class:`RadialWindow` instances.
     Their effective redshifts correspond to the given nodes.
 
+    Returns a list of window functions.
+
     Parameters
     ----------
     zgrid:
@@ -210,11 +209,6 @@ def linear_windows(
         Approximate spacing of the redshift grid.
     weight:
         If given, a weight function to be applied to the window functions.
-
-    Returns
-    -------
-    ws:
-        List of window functions.
 
     See Also
     --------
@@ -263,6 +257,8 @@ def cubic_windows(
     The resulting windows functions are :class:`RadialWindow` instances.
     Their effective redshifts correspond to the given nodes.
 
+    Returns a list of window functions.
+
     Parameters
     ----------
     zgrid:
@@ -271,11 +267,6 @@ def cubic_windows(
         Approximate spacing of the redshift grid.
     weight:
         If given, a weight function to be applied to the window functions.
-
-    Returns
-    -------
-    ws:
-        List of window functions.
 
     See Also
     --------
@@ -326,6 +317,8 @@ def restrict(
     the function and window over the support of the window.
     Intermediate function values are found by linear interpolation
 
+    Returns the restricted function
+
     Parameters
     ----------
     z:
@@ -334,13 +327,6 @@ def restrict(
         The function to be restricted.
     w:
         The window function for the restriction.
-
-    Returns
-    -------
-    zr:
-        The restricted function.
-    fr:
-        The restricted function.
 
     """
     z_ = np.compress(np.greater(z, w.za[0]) & np.less(z, w.za[-1]), z)
@@ -371,6 +357,9 @@ def partition(
     The window functions are given by the sequence *shells* of
     :class:`RadialWindow` or compatible entries.
 
+    Returns the weights of the partition, where the leading axis corresponds to
+    *shells*.
+
     Parameters
     ----------
     z:
@@ -384,12 +373,6 @@ def partition(
     method:
         Method for the partition. See notes for description. The
         options are "lstsq", "nnls", "restrict".
-
-    Returns
-    -------
-    x:
-        Weights of the partition, where the leading axis corresponds to
-        *shells*.
 
     Notes
     -----
@@ -624,6 +607,8 @@ def combine(
     The window functions are given by the sequence *shells* of
     :class:`RadialWindow` or compatible entries.
 
+    Returns a linear combination of window functions, evaluated in *z*.
+
     Parameters
     ----------
     z:
@@ -633,11 +618,6 @@ def combine(
         corresponds to *shells*.
     shells:
         Ordered sequence of window functions to be combined.
-
-    Returns
-    -------
-    fz:
-        Linear combination of window functions, evaluated in *z*.
 
     See Also
     --------

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -134,7 +134,7 @@ def tophat_windows(
     Tophat window functions from the given redshift bin edges.
 
     Uses the *N+1* given redshifts as bin edges to construct *N* tophat
-    window functions.  The redshifts of the windows have linear spacing
+    window functions. The redshifts of the windows have linear spacing
     approximately equal to ``dz``.
 
     An optional weight function :math:`w(z)` can be given using
@@ -144,15 +144,11 @@ def tophat_windows(
     Their effective redshifts are the mean redshifts of the (weighted)
     tophat bins.
 
-    Parameters
-    ----------
-    zbins : (N+1,) array_like
-        Redshift bin edges for the tophat window functions.
-    dz : float, optional
-        Approximate spacing of the redshift grid.
-    weight : callable, optional
-        If given, a weight function to be applied to the window
-        functions.
+    Args:
+        zbins: Redshift bin edges for the tophat window functions.
+        dz: Approximate spacing of the redshift grid.
+        weight: If given, a weight function to be applied to the window
+            functions.
 
     Returns:
     -------
@@ -193,8 +189,8 @@ def linear_windows(
     Linear interpolation window functions.
 
     Uses the *N+2* given redshifts as nodes to construct *N* triangular
-    window functions between the first and last node.  These correspond
-    to linear interpolation of radial functions.  The redshift spacing
+    window functions between the first and last node. These correspond
+    to linear interpolation of radial functions. The redshift spacing
     of the windows is approximately equal to ``dz``.
 
     An optional weight function :math:`w(z)` can be given using
@@ -203,15 +199,11 @@ def linear_windows(
     The resulting windows functions are :class:`RadialWindow` instances.
     Their effective redshifts correspond to the given nodes.
 
-    Parameters
-    ----------
-    zgrid : (N+2,) array_like
-        Redshift grid for the triangular window functions.
-    dz : float, optional
-        Approximate spacing of the redshift grid.
-    weight : callable, optional
-        If given, a weight function to be applied to the window
-        functions.
+    Args:
+        zgrid: Redshift grid for the triangular window functions.
+        dz: Approximate spacing of the redshift grid.
+        weight: If given, a weight function to be applied to the window
+            functions.
 
     Returns:
     -------
@@ -265,15 +257,11 @@ def cubic_windows(
     The resulting windows functions are :class:`RadialWindow` instances.
     Their effective redshifts correspond to the given nodes.
 
-    Parameters
-    ----------
-    zgrid : (N+2,) array_like
-        Redshift grid for the cubic spline window functions.
-    dz : float, optional
-        Approximate spacing of the redshift grid.
-    weight : callable, optional
-        If given, a weight function to be applied to the window
-        functions.
+    Args:
+        zgrid: Redshift grid for the cubic spline window functions.
+        dz: Approximate spacing of the redshift grid.
+        weight: If given, a weight function to be applied to the window
+            functions.
 
     Returns:
     -------
@@ -329,12 +317,10 @@ def restrict(
     the function and window over the support of the window.
     Intermediate function values are found by linear interpolation
 
-    Parameters
-    ----------
-    z, f : array_like
-        The function to be restricted.
-    w : :class:`RadialWindow`
-        The window function for the restriction.
+    Args:
+        z: The function to be restricted.
+        f: The function to be restricted.
+        w: The window function for the restriction.
 
     Returns:
     -------
@@ -370,15 +356,14 @@ def partition(
     The window functions are given by the sequence *shells* of
     :class:`RadialWindow` or compatible entries.
 
-    Parameters
-    ----------
-    z, fz : array_like
-        The function to be partitioned.  If *f* is multi-dimensional,
-        its last axis must agree with *z*.
-    shells : sequence of :class:`RadialWindow`
-        Ordered sequence of window functions for the partition.
-    method : {"lstsq", "nnls", "restrict"}
-        Method for the partition.  See notes for description.
+    Args:
+        z: The function to be partitioned. If *f* is multi-dimensional,
+            its last axis must agree with *z*.
+        fz: The function to be partitioned. If *f* is multi-dimensional,
+            its last axis must agree with *z*.
+        shells: Ordered sequence of window functions for the partition.
+        method: Method for the partition. See notes for description. The
+            options are "lstsq", "nnls", "restrict".
 
     Returns:
     -------
@@ -405,11 +390,11 @@ def partition(
         \\end{pmatrix} \\;.
 
     The redshift grid is the union of the given array *z* and the
-    redshift arrays of all window functions.  Intermediate function
+    redshift arrays of all window functions. Intermediate function
     values are found by linear interpolation.
 
     When partitioning a density function, it is usually desirable to
-    keep the normalisation fixed.  In that case, the problem can be
+    keep the normalisation fixed. In that case, the problem can be
     enhanced with the further constraint that the sum of the solution
     equals the integral of the target function,
 
@@ -434,19 +419,19 @@ def partition(
     obtain a solution:
 
     If ``method="nnls"`` (the default), obtain a partition from a
-    non-negative least-squares solution.  This will usually match the
-    shape of the input function closely.  The contribution from each
+    non-negative least-squares solution. This will usually match the
+    shape of the input function closely. The contribution from each
     shell is a positive number, which is required to partition e.g.
     density functions.
 
     If ``method="lstsq"``, obtain a partition from an unconstrained
-    least-squares solution.  This will more closely match the shape of
+    least-squares solution. This will more closely match the shape of
     the input function, but might lead to shells with negative
     contributions.
 
     If ``method="restrict"``, obtain a partition by integrating the
     restriction (using :func:`restrict`) of the function :math:`f` to
-    each window.  For overlapping shells, this method might produce
+    each window. For overlapping shells, this method might produce
     results which are far from the input function.
 
     """
@@ -619,15 +604,11 @@ def combine(
     The window functions are given by the sequence *shells* of
     :class:`RadialWindow` or compatible entries.
 
-    Parameters
-    ----------
-    z : array_like
-        Redshifts *z* in which to evaluate the combined function.
-    weights : array_like
-        Weights of the linear combination, where the leading axis
-        corresponds to *shells*.
-    shells : sequence of :class:`RadialWindow`
-        Ordered sequence of window functions to be combined.
+    Args:
+        z: Redshifts *z* in which to evaluate the combined function.
+        weights: Weights of the linear combination, where the leading axis
+            corresponds to *shells*.
+        shells: Ordered sequence of window functions to be combined.
 
     Returns:
     -------

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -40,7 +40,7 @@ Weight functions
 .. autofunction:: distance_weight
 .. autofunction:: volume_weight
 .. autofunction:: density_weight
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 
@@ -105,7 +105,7 @@ class RadialWindow(NamedTuple):
         >>> w1
         RadialWindow(za=..., wa=..., zeff=0.15)
 
-    Attributes
+    Attributes:
     ----------
     za : Sequence[float]
         Redshift array; the abscissae of the window function.
@@ -114,7 +114,7 @@ class RadialWindow(NamedTuple):
     zeff : float
         Effective redshift of the window.
 
-    Methods
+    Methods:
     -------
     _replace
 
@@ -154,12 +154,12 @@ def tophat_windows(
         If given, a weight function to be applied to the window
         functions.
 
-    Returns
+    Returns:
     -------
     ws : (N,) list of :class:`RadialWindow`
         List of window functions.
 
-    See Also
+    See Also:
     --------
     :ref:`user-window-functions`
 
@@ -213,12 +213,12 @@ def linear_windows(
         If given, a weight function to be applied to the window
         functions.
 
-    Returns
+    Returns:
     -------
     ws : (N,) list of :class:`RadialWindow`
         List of window functions.
 
-    See Also
+    See Also:
     --------
     :ref:`user-window-functions`
 
@@ -275,12 +275,12 @@ def cubic_windows(
         If given, a weight function to be applied to the window
         functions.
 
-    Returns
+    Returns:
     -------
     ws : (N,) list of :class:`RadialWindow`
         List of window functions.
 
-    See Also
+    See Also:
     --------
     :ref:`user-window-functions`
 
@@ -336,7 +336,7 @@ def restrict(
     w : :class:`RadialWindow`
         The window function for the restriction.
 
-    Returns
+    Returns:
     -------
     zr, fr : array
         The restricted function.
@@ -380,13 +380,13 @@ def partition(
     method : {"lstsq", "nnls", "restrict"}
         Method for the partition.  See notes for description.
 
-    Returns
+    Returns:
     -------
     x : array_like
         Weights of the partition, where the leading axis corresponds to
         *shells*.
 
-    Notes
+    Notes:
     -----
     Formally, if :math:`w_i` are the normalised window functions,
     :math:`f` is the target function, and :math:`z_i` is a redshift grid
@@ -629,12 +629,12 @@ def combine(
     shells : sequence of :class:`RadialWindow`
         Ordered sequence of window functions to be combined.
 
-    Returns
+    Returns:
     -------
     fz : array_like
         Linear combination of window functions, evaluated in *z*.
 
-    See Also
+    See Also:
     --------
     partition : Find weights for a given function.
 

--- a/glass/user.py
+++ b/glass/user.py
@@ -15,7 +15,7 @@ Input and Output
 .. autofunction:: load_cls
 .. autofunction:: write_catalog
 
-"""  # noqa: D205, D415
+"""  # noqa: D205, D400
 
 from contextlib import contextmanager
 

--- a/glass/user.py
+++ b/glass/user.py
@@ -15,7 +15,7 @@ Input and Output
 .. autofunction:: load_cls
 .. autofunction:: write_catalog
 
-"""  # noqa: D205, D400, D415
+"""  # noqa: D205, D415
 
 from contextlib import contextmanager
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ lint.select = [
     "ALL",
 ]
 lint.mccabe.max-complexity = 18
-lint.pydocstyle.convention = "google"
+lint.pydocstyle.convention = "numpy"
 
 [tool.tomlsort]
 all = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ docs = [
     "ipython",
     "matplotlib",
     "nbsphinx",
-    "numpydoc",
     "sphinx",
     "sphinxcontrib-katex",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ lint.select = [
     "ALL",
 ]
 lint.mccabe.max-complexity = 18
+lint.pydocstyle.convention = "google"
 
 [tool.tomlsort]
 all = true


### PR DESCRIPTION
Closes #346. Working towards #188.

The main changes here have been:
- Remove all types in the docstrings in favour of proper static typing (being added in #308)
- Switch from `numpydoc` to `sphinx.ext.napolean` due to https://github.com/numpy/numpydoc/issues/196

Have had to change the references to `[1]` rather than `[1]_` due to this bug, https://github.com/sphinx-doc/sphinx/issues/9689. Hopefully this can be fixed in the future.

Example:
`glass.lensing.from_convergence`
<img width="781" alt="image" src="https://github.com/user-attachments/assets/9b6fd087-686a-4a5c-a77a-f8a3ec9fc3e2">

Raised #350, #351.