### PR TITLE
gh-352: fix latex rendering

### DIFF
--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -438,9 +438,9 @@ def deflect(
     Notes
     -----
     Deflections on the sphere are :term:`defined <deflection>` as
-    follows:  The complex deflection :math:`\\alpha` transports a point
-    on the sphere an angular distance :math:`|\\alpha|` along the
-    geodesic with bearing :math:`\\arg\\alpha` in the original point.
+    follows:  The complex deflection :math:`\alpha` transports a point
+    on the sphere an angular distance :math:`|\alpha|` along the
+    geodesic with bearing :math:`\arg\alpha` in the original point.
 
     In the language of differential geometry, this function is the
     exponential map.

--- a/glass/points.py
+++ b/glass/points.py
@@ -42,7 +42,7 @@ def effective_bias(z, bz, w):
     Effective bias parameter from a redshift-dependent bias function.
 
     This function takes a redshift-dependent bias function :math:`b(z)`
-    and computes an effective bias parameter :math:`\\bar{b}` for a
+    and computes an effective bias parameter :math:`\bar{b}` for a
     given window function :math:`w(z)`.
 
     Parameters
@@ -61,13 +61,13 @@ def effective_bias(z, bz, w):
 
     Notes
     -----
-    The effective bias parameter :math:`\\bar{b}` is computed using the
+    The effective bias parameter :math:`\bar{b}` is computed using the
     window function :math:`w(z)` as the weighted average
 
     .. math::
 
-        \\bar{b} = \\frac{\\int b(z) \\, w(z) \\, dz}{\\int w(z) \\, dz}
-        \\;.
+        \bar{b} = \frac{\int b(z) \, w(z) \, dz}{\int w(z) \, dz}
+        \;.
 
     """
     norm = np.trapz(w.wa, w.za)
@@ -75,12 +75,12 @@ def effective_bias(z, bz, w):
 
 
 def linear_bias(delta, b):
-    r"""Linear bias model :math:`\\delta_g = b \\, \\delta`."""
+    r"""Linear bias model :math:`\delta_g = b \, \delta`."""
     return b * delta
 
 
 def loglinear_bias(delta, b):
-    r"""log-linear bias model :math:`\\ln(1 + \\delta_g) = b \\ln(1 + \\delta)`."""
+    r"""log-linear bias model :math:`\ln(1 + \delta_g) = b \ln(1 + \delta)`."""
     delta_g = np.log1p(delta)
     delta_g *= b
     np.expm1(delta_g, out=delta_g)
@@ -310,7 +310,7 @@ def position_weights(densities, bias=None):
     linear bias is applied to each shell.
 
     This is the equivalent of computing the product of normalised
-    redshift distribution and bias factor :math:`n(z) \\, b(z)` for the
+    redshift distribution and bias factor :math:`n(z) \, b(z)` for the
     discretised shells.
 
     Parameters

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -345,9 +345,9 @@ def partition(
     r"""
     Partition a function by a sequence of windows.
 
-    Returns a vector of weights :math:`x_1, x_2, \\ldots` such that the
-    weighted sum of normalised radial window functions :math:`x_1 \\,
-    w_1(z) + x_2 \\, w_2(z) + \\ldots` approximates the given function
+    Returns a vector of weights :math:`x_1, x_2, \ldots` such that the
+    weighted sum of normalised radial window functions :math:`x_1 \,
+    w_1(z) + x_2 \, w_2(z) + \ldots` approximates the given function
     :math:`f(z)`.
 
     The function :math:`f(z)` is given by redshifts *z* of shape *(N,)*
@@ -378,19 +378,19 @@ def partition(
     -----
     Formally, if :math:`w_i` are the normalised window functions,
     :math:`f` is the target function, and :math:`z_i` is a redshift grid
-    with intervals :math:`\\Delta z_i`, the partition problem seeks an
+    with intervals :math:`\Delta z_i`, the partition problem seeks an
     approximate solution of
 
     .. math::
-        \\begin{pmatrix}
-        w_1(z_1) \\Delta z_1 & w_2(z_1) \\, \\Delta z_1 & \\cdots \\\\
-        w_1(z_2) \\Delta z_2 & w_2(z_2) \\, \\Delta z_2 & \\cdots \\\\
-        \\vdots & \\vdots & \\ddots
-        \\end{pmatrix} \\, \\begin{pmatrix}
-        x_1 \\\\ x_2 \\\\ \\vdots
-        \\end{pmatrix} = \\begin{pmatrix}
-        f(z_1) \\, \\Delta z_1 \\\\ f(z_2) \\, \\Delta z_2 \\\\ \\vdots
-        \\end{pmatrix} \\;.
+        \begin{pmatrix}
+        w_1(z_1) \Delta z_1 & w_2(z_1) \, \Delta z_1 & \cdots \\
+        w_1(z_2) \Delta z_2 & w_2(z_2) \, \Delta z_2 & \cdots \\
+        \vdots & \vdots & \ddots
+        \end{pmatrix} \, \begin{pmatrix}
+        x_1 \\ x_2 \\ \vdots
+        \end{pmatrix} = \begin{pmatrix}
+        f(z_1) \, \Delta z_1 \\ f(z_2) \, \Delta z_2 \\ \vdots
+        \end{pmatrix} \;.
 
     The redshift grid is the union of the given array *z* and the
     redshift arrays of all window functions. Intermediate function
@@ -402,20 +402,20 @@ def partition(
     equals the integral of the target function,
 
     .. math::
-        \\begin{pmatrix}
-        w_1(z_1) \\Delta z_1 & w_2(z_1) \\, \\Delta z_1 & \\cdots \\\\
-        w_1(z_2) \\Delta z_2 & w_2(z_2) \\, \\Delta z_2 & \\cdots \\\\
-        \\vdots & \\vdots & \\ddots \\\\
-        \\hline
-        \\lambda & \\lambda & \\cdots
-        \\end{pmatrix} \\, \\begin{pmatrix}
-        x_1 \\\\ x_2 \\\\ \\vdots
-        \\end{pmatrix} = \\begin{pmatrix}
-        f(z_1) \\, \\Delta z_1 \\\\ f(z_2) \\, \\Delta z_2 \\\\ \\vdots
-        \\\\ \\hline \\lambda \\int \\! f(z) \\, dz
-        \\end{pmatrix} \\;,
+        \begin{pmatrix}
+        w_1(z_1) \Delta z_1 & w_2(z_1) \, \Delta z_1 & \cdots \\
+        w_1(z_2) \Delta z_2 & w_2(z_2) \, \Delta z_2 & \cdots \\
+        \vdots & \vdots & \ddots \\
+        \hline
+        \lambda & \lambda & \cdots
+        \end{pmatrix} \, \begin{pmatrix}
+        x_1 \\ x_2 \\ \vdots
+        \end{pmatrix} = \begin{pmatrix}
+        f(z_1) \, \Delta z_1 \\ f(z_2) \, \Delta z_2 \\ \vdots
+        \\ \hline \lambda \int \! f(z) \, dz
+        \end{pmatrix} \;,
 
-    where :math:`\\lambda` is a multiplier to enforce the integral
+    where :math:`\lambda` is a multiplier to enforce the integral
     constraints.
 
     The :func:`partition()` function implements a number of methods to
@@ -599,9 +599,9 @@ def combine(
     r"""
     Evaluate a linear combination of window functions.
 
-    Takes a vector of weights :math:`x_1, x_2, \\ldots` and computes the
+    Takes a vector of weights :math:`x_1, x_2, \ldots` and computes the
     weighted sum of normalised radial window functions :math:`f(z) = x_1
-    \\, w_1(z) + x_2 \\, w_2(z) + \\ldots` in the given redshifts
+    \, w_1(z) + x_2 \, w_2(z) + \ldots` in the given redshifts
     :math:`z`.
 
     The window functions are given by the sequence *shells* of


### PR DESCRIPTION
Single backslash is for latex commands, double backslash is for newline. I don't know when or how the behavior changed, [but their latest docs still say](https://sphinx-rtd-trial.readthedocs.io/en/latest/ext/math.html#module-sphinx.ext.mathbase) -

> Keep in mind that when you put math markup in Python docstrings read by [autodoc](https://sphinx-rtd-trial.readthedocs.io/en/latest/ext/autodoc.html#module-sphinx.ext.autodoc), you either have to double all backslashes, or use Python raw strings (r"raw").

Closes: #352 
