### PR TITLE
gh-280: add `mypy` to codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,9 @@ repos:
     rev: v1.7.3
     hooks:
       - id: actionlint
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - numpy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ html_static_path = ["_static"]
 
 html_logo = "_static/logo.png"
 html_favicon = "_static/favicon.ico"
-html_css_files = []
+html_css_files = []  # type: ignore[var-annotated]
 
 
 # -- Intersphinx -------------------------------------------------------------

--- a/glass/core/array.py
+++ b/glass/core/array.py
@@ -72,7 +72,7 @@ def trapz_product(f, *ff, axis=-1):  # type: ignore[no-untyped-def]
     y = np.interp(x, *f)
     for f_ in ff:
         y *= np.interp(x, *f_)
-    return np.trapz(y, x, axis=axis)
+    return np.trapz(y, x, axis=axis)  # type: ignore[attr-defined]
 
 
 def cumtrapz(f, x, dtype=None, out=None):  # type: ignore[no-untyped-def]

--- a/glass/core/array.py
+++ b/glass/core/array.py
@@ -5,14 +5,14 @@ from functools import partial
 import numpy as np
 
 
-def broadcast_first(*arrays):
+def broadcast_first(*arrays):  # type: ignore[no-untyped-def]
     """Broadcast arrays, treating the first axis as common."""
     arrays = tuple(np.moveaxis(a, 0, -1) if np.ndim(a) else a for a in arrays)
     arrays = np.broadcast_arrays(*arrays)
     return tuple(np.moveaxis(a, -1, 0) if np.ndim(a) else a for a in arrays)
 
 
-def broadcast_leading_axes(*args):
+def broadcast_leading_axes(*args):  # type: ignore[no-untyped-def]
     """
     Broadcast all but the last N axes.
 
@@ -49,7 +49,7 @@ def broadcast_leading_axes(*args):
     return (dims, *arrs)
 
 
-def ndinterp(x, xp, fp, axis=-1, left=None, right=None, period=None):  # noqa: PLR0913
+def ndinterp(x, xp, fp, axis=-1, left=None, right=None, period=None):  # type: ignore[no-untyped-def] # noqa: PLR0913
     """Interpolate multi-dimensional array over axis."""
     return np.apply_along_axis(
         partial(np.interp, x, xp),
@@ -61,7 +61,7 @@ def ndinterp(x, xp, fp, axis=-1, left=None, right=None, period=None):  # noqa: P
     )
 
 
-def trapz_product(f, *ff, axis=-1):
+def trapz_product(f, *ff, axis=-1):  # type: ignore[no-untyped-def]
     """Trapezoidal rule for a product of functions."""
     x, _ = f
     for x_, _ in ff:
@@ -75,7 +75,7 @@ def trapz_product(f, *ff, axis=-1):
     return np.trapz(y, x, axis=axis)
 
 
-def cumtrapz(f, x, dtype=None, out=None):
+def cumtrapz(f, x, dtype=None, out=None):  # type: ignore[no-untyped-def]
     """Cumulative trapezoidal rule along last axis."""
     if out is None:
         out = np.empty_like(f, dtype=dtype)

--- a/glass/ext/__init__.py
+++ b/glass/ext/__init__.py
@@ -7,7 +7,7 @@ packages that provide a "glass" module.
 """
 
 
-def _extend_path(path, name) -> list:
+def _extend_path(path, name) -> list:  # type: ignore[no-untyped-def, type-arg]
     import os.path
     from pkgutil import extend_path
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -38,7 +38,9 @@ from gaussiancl import gaussiancl
 # types
 Size = typing.Optional[typing.Union[int, tuple[int, ...]]]
 Iternorm = tuple[typing.Optional[int], npt.NDArray[typing.Any], npt.NDArray[typing.Any]]
-ClTransform = typing.Union[str, typing.Callable[[npt.NDArray[typing.Any]], npt.NDArray[typing.Any]]]
+ClTransform = typing.Union[
+    str, typing.Callable[[npt.NDArray[typing.Any]], npt.NDArray[typing.Any]]
+]
 Cls = collections.abc.Sequence[
     typing.Union[npt.NDArray[typing.Any], collections.abc.Sequence[float]]
 ]

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -116,7 +116,7 @@ def cls2cov(
         begin, end = end, end + j + 1
         for i, cl in enumerate(cls[begin:end][: nc + 1]):
             if cl is None:
-                cov[:, i] = 0
+                cov[:, i] = 0  # type: ignore[unreachable]
             else:
                 if i == 0 and np.any(np.less(cl, 0)):
                     msg = "negative values in cl"
@@ -128,20 +128,20 @@ def cls2cov(
         yield cov
 
 
-def multalm(alm: Alms, bl: npt.NDArray[typing.Any], *, inplace: bool = False) -> Alms:  # type: ignore[valid-type]
+def multalm(alm: Alms, bl: npt.NDArray[typing.Any], *, inplace: bool = False) -> Alms:
     """Multiply alm by bl."""
     n = len(bl)
     out = np.asanyarray(alm) if inplace else np.copy(alm)
     for m in range(n):
         out[m * n - m * (m - 1) // 2 : (m + 1) * n - m * (m + 1) // 2] *= bl[m:]
-    return out  # type: ignore[no-any-return]
+    return out
 
 
 def transform_cls(cls: Cls, tfm: ClTransform, pars: tuple[typing.Any, ...] = ()) -> Cls:
     """Transform Cls to Gaussian Cls."""
     gls = []
     for cl in cls:
-        if cl is not None and len(cl) > 0:
+        if cl is not None and len(cl) > 0:  # type: ignore[redundant-expr]
             monopole = 0.0 if cl[0] == 0 else None
             gl, info, _, _ = gaussiancl(cl, tfm, pars, monopole=monopole)
             if info == 0:
@@ -186,7 +186,7 @@ def gaussian_gls(
 
     gls = []
     for cl in cls:
-        if cl is not None and len(cl) > 0:
+        if cl is not None and len(cl) > 0:  # type: ignore[redundant-expr]
             if lmax is not None:
                 cl = cl[: lmax + 1]  # noqa: PLW2901
             if nside is not None:
@@ -252,7 +252,7 @@ def generate_gaussian(
         ncorr = ngrf - 1
 
     # number of modes
-    n = max((len(gl) for gl in gls if gl is not None), default=0)
+    n = max((len(gl) for gl in gls if gl is not None), default=0)  # type: ignore[redundant-expr]
     if n == 0:
         msg = "all gls are empty"
         raise ValueError(msg)
@@ -279,15 +279,15 @@ def generate_gaussian(
 
         # add the mean of the conditional distribution
         for i in range(ncorr):
-            alm += multalm(y[:, i], a[:, i])  # type: ignore[operator]
+            alm += multalm(y[:, i], a[:, i])
 
         # store the standard normal in y array at the indicated index
         if j is not None:
             y[:, j] = z
 
         # modes with m = 0 are real-valued and come first in array
-        alm[:n].real += alm[:n].imag  # type: ignore[index]
-        alm[:n].imag[:] = 0  # type: ignore[index]
+        alm[:n].real += alm[:n].imag
+        alm[:n].imag[:] = 0
 
         # transform alm to maps
         # can be performed in place on the temporary alm array

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -116,7 +116,7 @@ def redshifts_from_nz(
     dims, count, z, nz = broadcast_leading_axes((count, 0), (z, 1), (nz, 1))  # type: ignore[no-untyped-call]
 
     # list of results for all dimensions
-    redshifts = np.empty(count.sum())
+    redshifts = np.empty(count.sum())  # type: ignore[union-attr]
 
     # keep track of the number of sampled redshifts
     total = 0
@@ -124,16 +124,16 @@ def redshifts_from_nz(
     # go through extra dimensions; also works if dims is empty
     for k in np.ndindex(dims):
         # compute the CDF of each galaxy population
-        cdf = cumtrapz(nz[k], z[k], dtype=float)  # type: ignore[no-untyped-call]
+        cdf = cumtrapz(nz[k], z[k], dtype=float)  # type: ignore[call-overload, index, no-untyped-call]
         cdf /= cdf[-1]
 
         # sample redshifts and store result
-        redshifts[total : total + count[k]] = np.interp(
-            rng.uniform(0, 1, size=count[k]),
+        redshifts[total : total + count[k]] = np.interp(  # type: ignore[call-overload, index, misc, operator]
+            rng.uniform(0, 1, size=count[k]),  # type: ignore[arg-type, call-overload, index]
             cdf,
-            z[k],
+            z[k],  # type: ignore[arg-type, call-overload, index]
         )
-        total += count[k]
+        total += count[k]  # type: ignore[assignment, call-overload, index, operator]
 
     assert total == redshifts.size  # noqa: S101
 
@@ -266,25 +266,25 @@ def gaussian_phz(
     sigma = np.add(1, z) * sigma_0
     dims = np.shape(sigma)
 
-    zphot = rng.normal(z, sigma)
+    zphot = rng.normal(z, sigma)  # type: ignore[arg-type]
 
     if lower is None:
         lower = 0.0
     if upper is None:
         upper = np.inf
 
-    if not np.all(lower < upper):
+    if not np.all(lower < upper):  # type: ignore[operator]
         msg = "requires lower < upper"
         raise ValueError(msg)
 
     if not dims:
-        while zphot < lower or zphot > upper:
-            zphot = rng.normal(z, sigma)  # type: ignore[org-type]
+        while zphot < lower or zphot > upper:  # type: ignore[operator]
+            zphot = rng.normal(z, sigma)  # type: ignore[arg-type]
     else:
         z = np.broadcast_to(z, dims)
         trunc = np.where((zphot < lower) | (zphot > upper))[0]  # type: ignore[operator]
         while trunc.size:
-            znew = rng.normal(z[trunc], sigma[trunc])  # type: ignore[org-type]
+            znew = rng.normal(z[trunc], sigma[trunc])  # type: ignore[arg-type]
             zphot[trunc] = znew  # type: ignore[index]
             trunc = trunc[(znew < lower) | (znew > upper)]  # type: ignore[operator]
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -19,6 +19,7 @@ Functions
 
 from __future__ import annotations
 
+import typing
 import warnings
 from typing import TYPE_CHECKING
 
@@ -38,7 +39,7 @@ def redshifts(
     w: RadialWindow,
     *,
     rng: np.random.Generator | None = None,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     """
     Sample redshifts from a radial window function.
 
@@ -68,7 +69,7 @@ def redshifts_from_nz(
     *,
     rng: np.random.Generator | None = None,
     warn: bool = True,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     """
     Generate galaxy redshifts from a source distribution.
 
@@ -112,7 +113,7 @@ def redshifts_from_nz(
         rng = np.random.default_rng()
 
     # bring inputs' leading axes into common shape
-    dims, count, z, nz = broadcast_leading_axes((count, 0), (z, 1), (nz, 1))
+    dims, count, z, nz = broadcast_leading_axes((count, 0), (z, 1), (nz, 1))  # type: ignore[no-untyped-call]
 
     # list of results for all dimensions
     redshifts = np.empty(count.sum())
@@ -123,7 +124,7 @@ def redshifts_from_nz(
     # go through extra dimensions; also works if dims is empty
     for k in np.ndindex(dims):
         # compute the CDF of each galaxy population
-        cdf = cumtrapz(nz[k], z[k], dtype=float)
+        cdf = cumtrapz(nz[k], z[k], dtype=float)  # type: ignore[no-untyped-call]
         cdf /= cdf[-1]
 
         # sample redshifts and store result
@@ -140,15 +141,15 @@ def redshifts_from_nz(
 
 
 def galaxy_shear(  # noqa: PLR0913
-    lon: npt.NDArray,
-    lat: npt.NDArray,
-    eps: npt.NDArray,
-    kappa: npt.NDArray,
-    gamma1: npt.NDArray,
-    gamma2: npt.NDArray,
+    lon: npt.NDArray[typing.Any],
+    lat: npt.NDArray[typing.Any],
+    eps: npt.NDArray[typing.Any],
+    kappa: npt.NDArray[typing.Any],
+    gamma1: npt.NDArray[typing.Any],
+    gamma2: npt.NDArray[typing.Any],
     *,
     reduced_shear: bool = True,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     """
     Observed galaxy shears from weak lensing.
 
@@ -213,7 +214,7 @@ def gaussian_phz(
     lower: npt.ArrayLike | None = None,
     upper: npt.ArrayLike | None = None,
     rng: np.random.Generator | None = None,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Photometric redshifts assuming a Gaussian error.
 
@@ -278,13 +279,13 @@ def gaussian_phz(
 
     if not dims:
         while zphot < lower or zphot > upper:
-            zphot = rng.normal(z, sigma)
+            zphot = rng.normal(z, sigma)  # type: ignore[org-type]
     else:
         z = np.broadcast_to(z, dims)
-        trunc = np.where((zphot < lower) | (zphot > upper))[0]
+        trunc = np.where((zphot < lower) | (zphot > upper))[0]  # type: ignore[operator]
         while trunc.size:
-            znew = rng.normal(z[trunc], sigma[trunc])
-            zphot[trunc] = znew
-            trunc = trunc[(znew < lower) | (znew > upper)]
+            znew = rng.normal(z[trunc], sigma[trunc])  # type: ignore[org-type]
+            zphot[trunc] = znew  # type: ignore[index]
+            trunc = trunc[(znew < lower) | (znew > upper)]  # type: ignore[operator]
 
-    return zphot
+    return zphot  # type: ignore[return-value]

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -266,7 +266,7 @@ def shear_from_convergence(
     hp.almxfl(alm, fl, inplace=True)
 
     # transform to shear maps
-    return hp.alm2map_spin([alm, blm], nside, 2, lmax)
+    return hp.alm2map_spin([alm, blm], nside, 2, lmax)  # type: ignore[no-any-return]
 
 
 class MultiPlaneConvergence:
@@ -295,7 +295,7 @@ class MultiPlaneConvergence:
 
         """
         zsrc = w.zeff
-        lens_weight = np.trapz(w.wa, w.za) / np.interp(zsrc, w.za, w.wa)
+        lens_weight = np.trapz(w.wa, w.za) / np.interp(zsrc, w.za, w.wa)  # type: ignore[attr-defined]
 
         self.add_plane(delta, zsrc, lens_weight)
 
@@ -415,7 +415,7 @@ def multi_plane_weights(
     weights = weights / np.sum(weights, axis=0)
     # combine weights and the matrix of lensing contributions
     mat = multi_plane_matrix(shells, cosmo)
-    return np.matmul(mat.T, weights)
+    return np.matmul(mat.T, weights)  # type: ignore[no-any-return, union-attr]
 
 
 def deflect(
@@ -474,4 +474,4 @@ def deflect(
 
     d = np.arctan2(sa * sg, st * ca - ct * sa * cg)
 
-    return lon - np.degrees(d), np.degrees(tp)
+    return lon - np.degrees(d), np.degrees(tp)  # type: ignore[return-value]

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -31,6 +31,7 @@ Applying lensing
 
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 import healpy as hp
@@ -47,14 +48,14 @@ if TYPE_CHECKING:
 
 
 def from_convergence(  # noqa: PLR0913
-    kappa: npt.NDArray,
+    kappa: npt.NDArray[typing.Any],
     lmax: int | None = None,
     *,
     potential: bool = False,
     deflection: bool = False,
     shear: bool = False,
     discretized: bool = True,
-) -> tuple[npt.NDArray, ...]:
+) -> tuple[npt.NDArray[typing.Any], ...]:
     r"""
     Compute other weak lensing maps from the convergence.
 
@@ -181,7 +182,7 @@ def from_convergence(  # noqa: PLR0913
     # if potential is requested, compute map and add to output
     if potential:
         psi = hp.alm2map(alm, nside, lmax=lmax)
-        results += (psi,)
+        results += (psi,)  # type: ignore[assignment]
 
     # if no spin-weighted maps are requested, stop here
     if not (deflection or shear):
@@ -200,7 +201,7 @@ def from_convergence(  # noqa: PLR0913
     if deflection:
         alpha = hp.alm2map_spin([alm, blm], nside, 1, lmax)
         alpha = alpha[0] + 1j * alpha[1]
-        results += (alpha,)
+        results += (alpha,)  # type: ignore[assignment]
 
     # if no shear is requested, stop here
     if not shear:
@@ -218,18 +219,18 @@ def from_convergence(  # noqa: PLR0913
     # transform to shear maps
     gamma = hp.alm2map_spin([alm, blm], nside, 2, lmax)
     gamma = gamma[0] + 1j * gamma[1]
-    results += (gamma,)
+    results += (gamma,)  # type: ignore[assignment]
 
     # all done
     return results
 
 
 def shear_from_convergence(
-    kappa: npt.NDArray,
+    kappa: npt.NDArray[typing.Any],
     lmax: int | None = None,
     *,
     discretized: bool = True,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Weak lensing shear from convergence.
 
@@ -281,11 +282,11 @@ class MultiPlaneConvergence:
         self.x3: float = 0.0
         self.w3: float = 0.0
         self.r23: float = 1.0
-        self.delta3: npt.NDArray = np.array(0.0)
-        self.kappa2: npt.NDArray | None = None
-        self.kappa3: npt.NDArray | None = None
+        self.delta3: npt.NDArray[typing.Any] = np.array(0.0)
+        self.kappa2: npt.NDArray[typing.Any] | None = None
+        self.kappa3: npt.NDArray[typing.Any] | None = None
 
-    def add_window(self, delta: npt.NDArray, w: RadialWindow) -> None:
+    def add_window(self, delta: npt.NDArray[typing.Any], w: RadialWindow) -> None:
         """
         Add a mass plane from a window function to the convergence.
 
@@ -298,7 +299,9 @@ class MultiPlaneConvergence:
 
         self.add_plane(delta, zsrc, lens_weight)
 
-    def add_plane(self, delta: npt.NDArray, zsrc: float, wlens: float = 1.0) -> None:
+    def add_plane(
+        self, delta: npt.NDArray[typing.Any], zsrc: float, wlens: float = 1.0
+    ) -> None:
         """Add a mass plane at redshift ``zsrc`` to the convergence."""
         if zsrc <= self.z3:
             msg = "source redshift must be increasing"
@@ -347,12 +350,12 @@ class MultiPlaneConvergence:
         return self.z3
 
     @property
-    def kappa(self) -> npt.NDArray | None:
+    def kappa(self) -> npt.NDArray[typing.Any] | None:
         """The current convergence plane."""
         return self.kappa3
 
     @property
-    def delta(self) -> npt.NDArray:
+    def delta(self) -> npt.NDArray[typing.Any]:
         """The current matter plane."""
         return self.delta3
 
@@ -417,7 +420,7 @@ def multi_plane_weights(
 
 def deflect(
     lon: npt.ArrayLike, lat: npt.ArrayLike, alpha: npt.ArrayLike
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Apply deflections to positions.
 

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -29,6 +29,7 @@ Visibility
 from __future__ import annotations
 
 import math
+import typing
 
 import healpy as hp
 import numpy as np

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -84,7 +84,7 @@ def vmap_galactic_ecliptic(
     m[hp.query_strip(nside, *galactic)] = 0
     m = hp.Rotator(coord="GC").rotate_map_pixel(m)
     m[hp.query_strip(nside, *ecliptic)] = 0
-    return hp.Rotator(coord="CE").rotate_map_pixel(m)
+    return hp.Rotator(coord="CE").rotate_map_pixel(m)  # type: ignore[no-any-return]
 
 
 def gaussian_nz(
@@ -124,12 +124,12 @@ def gaussian_nz(
     sigma = np.reshape(sigma, np.shape(sigma) + (1,) * np.ndim(z))
 
     nz = np.exp(-(((z - mean) / sigma) ** 2) / 2)
-    nz /= np.trapz(nz, z, axis=-1)[..., np.newaxis]
+    nz /= np.trapz(nz, z, axis=-1)[..., np.newaxis]  # type: ignore[attr-defined]
 
     if norm is not None:
         nz *= norm
 
-    return nz
+    return nz  # type: ignore[no-any-return]
 
 
 def smail_nz(
@@ -186,12 +186,12 @@ def smail_nz(
     beta = np.asanyarray(beta)[..., np.newaxis]
 
     pz = z**alpha * np.exp(-alpha / beta * (z / z_mode) ** beta)
-    pz /= np.trapz(pz, z, axis=-1)[..., np.newaxis]
+    pz /= np.trapz(pz, z, axis=-1)[..., np.newaxis]  # type: ignore[attr-defined]
 
     if norm is not None:
         pz *= norm
 
-    return pz
+    return pz  # type: ignore[no-any-return]
 
 
 def fixed_zbins(
@@ -337,4 +337,4 @@ def tomo_nz_gausserr(
     binned_nz /= 1 + erf(z / sz)
     binned_nz *= nz
 
-    return binned_nz
+    return binned_nz  # type: ignore[no-any-return]

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -29,6 +29,7 @@ Visibility
 from __future__ import annotations
 
 import math
+import typing
 from typing import TYPE_CHECKING
 
 import healpy as hp
@@ -44,7 +45,7 @@ def vmap_galactic_ecliptic(
     nside: int,
     galactic: tuple[float, float] = (30, 90),
     ecliptic: tuple[float, float] = (20, 80),
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     """
     Visibility map masking galactic and ecliptic plane.
 
@@ -87,12 +88,12 @@ def vmap_galactic_ecliptic(
 
 
 def gaussian_nz(
-    z: npt.NDArray,
+    z: npt.NDArray[typing.Any],
     mean: npt.ArrayLike,
     sigma: npt.ArrayLike,
     *,
     norm: npt.ArrayLike | None = None,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Gaussian redshift distribution.
 
@@ -132,13 +133,13 @@ def gaussian_nz(
 
 
 def smail_nz(
-    z: npt.NDArray,
+    z: npt.NDArray[typing.Any],
     z_mode: npt.ArrayLike,
     alpha: npt.ArrayLike,
     beta: npt.ArrayLike,
     *,
     norm: npt.ArrayLike | None = None,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Redshift distribution following Smail et al. (1994).
 
@@ -235,8 +236,8 @@ def fixed_zbins(
 
 
 def equal_dens_zbins(
-    z: npt.NDArray,
-    nz: npt.NDArray,
+    z: npt.NDArray[typing.Any],
+    nz: npt.NDArray[typing.Any],
     nbins: int,
 ) -> list[tuple[float, float]]:
     """
@@ -264,7 +265,7 @@ def equal_dens_zbins(
     # first compute the cumulative integral (by trapezoidal rule)
     # then normalise: the first z is at CDF = 0, the last z at CDF = 1
     # interpolate to find the z values at CDF = i/nbins for i = 0, ..., nbins
-    cuml_nz = cumtrapz(nz, z)
+    cuml_nz = cumtrapz(nz, z)  # type: ignore[no-untyped-call]
     cuml_nz /= cuml_nz[[-1]]
     zbinedges = np.interp(np.linspace(0, 1, nbins + 1), cuml_nz, z)
 
@@ -272,11 +273,11 @@ def equal_dens_zbins(
 
 
 def tomo_nz_gausserr(
-    z: npt.NDArray,
-    nz: npt.NDArray,
+    z: npt.NDArray[typing.Any],
+    nz: npt.NDArray[typing.Any],
     sigma_0: float,
     zbins: list[tuple[float, float]],
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     """
     Tomographic redshift bins with a Gaussian redshift error.
 
@@ -318,7 +319,7 @@ def tomo_nz_gausserr(
 
     """
     # converting zbins into an array:
-    zbins_arr = np.asanyarray(zbins)  # type: ignore[no-redef]
+    zbins_arr = np.asanyarray(zbins)
 
     # bin edges and adds a new axis
     z_lower = zbins_arr[:, 0, np.newaxis]

--- a/glass/points.py
+++ b/glass/points.py
@@ -70,7 +70,7 @@ def effective_bias(z, bz, w):  # type: ignore[no-untyped-def]
         \\;.
 
     """
-    norm = np.trapz(w.wa, w.za)
+    norm = np.trapz(w.wa, w.za)  # type: ignore[attr-defined]
     return trapz_product((z, bz), (w.za, w.wa)) / norm  # type: ignore[no-untyped-call]
 
 
@@ -215,7 +215,7 @@ def positions_from_delta(  # type: ignore[no-untyped-def] # noqa: PLR0912, PLR09
             cmask = np.zeros(dims, dtype=int)
             cmask[k] = 1
         else:
-            cmask = 1
+            cmask = 1  # type: ignore[assignment]
 
         # sample the map in batches
         step = 1000
@@ -296,7 +296,7 @@ def uniform_positions(ngal, *, rng=None):  # type: ignore[no-untyped-def]
             count = np.zeros(dims, dtype=int)
             count[k] = ngal[k]
         else:
-            count = int(ngal[k])
+            count = int(ngal[k])  # type: ignore[assignment]
 
         yield lon, lat, count
 

--- a/glass/points.py
+++ b/glass/points.py
@@ -37,7 +37,7 @@ from glass.core.array import broadcast_first, broadcast_leading_axes, trapz_prod
 ARCMIN2_SPHERE = 60**6 // 100 / np.pi
 
 
-def effective_bias(z, bz, w):
+def effective_bias(z, bz, w):  # type: ignore[no-untyped-def]
     r"""
     Effective bias parameter from a redshift-dependent bias function.
 
@@ -71,15 +71,15 @@ def effective_bias(z, bz, w):
 
     """
     norm = np.trapz(w.wa, w.za)
-    return trapz_product((z, bz), (w.za, w.wa)) / norm
+    return trapz_product((z, bz), (w.za, w.wa)) / norm  # type: ignore[no-untyped-call]
 
 
-def linear_bias(delta, b):
+def linear_bias(delta, b):  # type: ignore[no-untyped-def]
     r"""Linear bias model :math:`\\delta_g = b \\, \\delta`."""
     return b * delta
 
 
-def loglinear_bias(delta, b):
+def loglinear_bias(delta, b):  # type: ignore[no-untyped-def]
     r"""log-linear bias model :math:`\\ln(1 + \\delta_g) = b \\ln(1 + \\delta)`."""
     delta_g = np.log1p(delta)
     delta_g *= b
@@ -87,7 +87,7 @@ def loglinear_bias(delta, b):
     return delta_g
 
 
-def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
+def positions_from_delta(  # type: ignore[no-untyped-def] # noqa: PLR0912, PLR0913, PLR0915
     ngal,
     delta,
     bias=None,
@@ -171,7 +171,7 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
         inputs += [(bias, 0)]
     if vis is not None:
         inputs += [(vis, 1)]
-    dims, ngal, delta, *rest = broadcast_leading_axes(*inputs)
+    dims, ngal, delta, *rest = broadcast_leading_axes(*inputs)  # type: ignore[no-untyped-call]
     if bias is not None:
         bias, *rest = rest
     if vis is not None:
@@ -248,7 +248,7 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
         assert np.sum(n[stop:]) == 0  # noqa: S101
 
 
-def uniform_positions(ngal, *, rng=None):
+def uniform_positions(ngal, *, rng=None):  # type: ignore[no-untyped-def]
     """
     Generate positions uniformly over the sphere.
 
@@ -301,7 +301,7 @@ def uniform_positions(ngal, *, rng=None):
         yield lon, lat, count
 
 
-def position_weights(densities, bias=None):
+def position_weights(densities, bias=None):  # type: ignore[no-untyped-def]
     r"""
     Compute relative weights for angular clustering.
 
@@ -329,7 +329,7 @@ def position_weights(densities, bias=None):
     """
     # bring densities and bias into the same shape
     if bias is not None:
-        densities, bias = broadcast_first(densities, bias)
+        densities, bias = broadcast_first(densities, bias)  # type: ignore[no-untyped-call]
     # normalise densities after shape has been fixed
     densities = densities / np.sum(densities, axis=0)
     # apply bias after normalisation

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -24,6 +24,8 @@ Utilities
 
 from __future__ import annotations
 
+import typing
+
 import numpy as np
 import numpy.typing as npt
 

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -24,6 +24,7 @@ Utilities
 
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
 
-def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
+def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):  # type: ignore[no-untyped-def]
     r"""
     Axis ratio of a randomly projected triaxial ellipsoid.
 
@@ -97,7 +98,7 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):
     )
 
 
-def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None):  # noqa: PLR0913
+def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None):  # type: ignore[no-untyped-def] # noqa: PLR0913
     r"""
     Ellipticity distribution following Ryden (2004).
 
@@ -160,7 +161,7 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     xi = (1 - gam) * zeta
 
     # random projection of random triaxial ellipsoid
-    q = triaxial_axis_ratio(zeta, xi, rng=rng)
+    q = triaxial_axis_ratio(zeta, xi, rng=rng)  # type: ignore[no-untyped-call]
 
     # assemble ellipticity with random complex phase
     e = np.exp(1j * rng.uniform(0, 2 * np.pi, size=np.shape(q)))
@@ -175,7 +176,7 @@ def ellipticity_gaussian(
     sigma: npt.ArrayLike,
     *,
     rng: np.random.Generator | None = None,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Sample Gaussian galaxy ellipticities.
 
@@ -232,7 +233,7 @@ def ellipticity_intnorm(
     sigma: npt.ArrayLike,
     *,
     rng: np.random.Generator | None = None,
-) -> npt.NDArray:
+) -> npt.NDArray[typing.Any]:
     r"""
     Sample galaxy ellipticities with intrinsic normal distribution.
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -44,6 +44,7 @@ Weight functions
 
 from __future__ import annotations
 
+import typing
 import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable, NamedTuple, Union
@@ -57,21 +58,21 @@ if TYPE_CHECKING:
     from cosmology import Cosmology
 
 # types
-ArrayLike1D = Union[Sequence[float], npt.NDArray]
-WeightFunc = Callable[[ArrayLike1D], npt.NDArray]
+ArrayLike1D = Union[Sequence[float], npt.NDArray[typing.Any]]
+WeightFunc = Callable[[ArrayLike1D], npt.NDArray[typing.Any]]
 
 
-def distance_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray:
+def distance_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray[typing.Any]:
     """Uniform weight in comoving distance."""
     return 1 / cosmo.ef(z)
 
 
-def volume_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray:
+def volume_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray[typing.Any]:
     """Uniform weight in comoving volume."""
     return cosmo.xm(z) ** 2 / cosmo.ef(z)
 
 
-def density_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray:
+def density_weight(z: npt.ArrayLike, cosmo: Cosmology) -> npt.NDArray[typing.Any]:
     """Uniform weight in matter density."""
     return cosmo.rho_m_z(z) * cosmo.xm(z) ** 2 / cosmo.ef(z)
 
@@ -299,7 +300,7 @@ def restrict(
     z: ArrayLike1D,
     f: ArrayLike1D,
     w: RadialWindow,
-) -> tuple[npt.NDArray, npt.NDArray]:
+) -> tuple[npt.NDArray[typing.Any], npt.NDArray[typing.Any]]:
     """
     Restrict a function to a redshift window.
 
@@ -331,7 +332,7 @@ def restrict(
     """
     z_ = np.compress(np.greater(z, w.za[0]) & np.less(z, w.za[-1]), z)
     zr = np.union1d(w.za, z_)
-    fr = ndinterp(zr, z, f, left=0.0, right=0.0) * ndinterp(zr, w.za, w.wa)
+    fr = ndinterp(zr, z, f, left=0.0, right=0.0) * ndinterp(zr, w.za, w.wa)  # type: ignore[no-untyped-call]
     return zr, fr
 
 
@@ -474,7 +475,7 @@ def partition_lstsq(
     a = a * dz
 
     # create the target vector of distribution values
-    b = ndinterp(zp, z, fz, left=0.0, right=0.0)
+    b = ndinterp(zp, z, fz, left=0.0, right=0.0)  # type: ignore[no-untyped-call]
     b = b * dz
 
     # append a constraint for the integral
@@ -486,7 +487,7 @@ def partition_lstsq(
     # and b is a matrix of shape (*dims, len(zp) + 1)
     # need to find weights x such that b == x @ a over all axes of b
     # do the least-squares fit over partially flattened b, then reshape
-    x = np.linalg.lstsq(a.T, b.reshape(-1, zp.size + 1).T, rcond=None)[0]
+    x = np.linalg.lstsq(a.T, b.reshape(-1, zp.size + 1).T, rcond=None)[0]  # type: ignore[attr-defined]
     x = x.T.reshape(*dims, len(shells))
     # roll the last axis of size len(shells) to the front
     return np.moveaxis(x, -1, 0)
@@ -528,7 +529,7 @@ def partition_nnls(
     a = a * dz
 
     # create the target vector of distribution values
-    b = ndinterp(zp, z, fz, left=0.0, right=0.0)
+    b = ndinterp(zp, z, fz, left=0.0, right=0.0)  # type: ignore[no-untyped-call]
     b = b * dz
 
     # append a constraint for the integral
@@ -541,7 +542,7 @@ def partition_nnls(
     # for each dim, find non-negative weights x such that b == a.T @ x
 
     # reduce the dimensionality of the problem using a thin QR decomposition
-    q, r = np.linalg.qr(a.T)
+    q, r = np.linalg.qr(a.T)  # type: ignore[attr-defined]
     y = np.einsum("ji,...j", q, b)
 
     # for each dim, find non-negative weights x such that y == r @ x
@@ -566,7 +567,7 @@ def partition_restrict(
     return part
 
 
-def redshift_grid(zmin, zmax, *, dz=None, num=None):
+def redshift_grid(zmin, zmax, *, dz=None, num=None):  # type: ignore[no-untyped-def]
     """Redshift grid with uniform spacing in redshift."""
     if dz is not None and num is None:
         z = np.arange(zmin, np.nextafter(zmax + dz, zmax), dz)
@@ -578,7 +579,7 @@ def redshift_grid(zmin, zmax, *, dz=None, num=None):
     return z
 
 
-def distance_grid(cosmo, zmin, zmax, *, dx=None, num=None):
+def distance_grid(cosmo, zmin, zmax, *, dx=None, num=None):  # type: ignore[no-untyped-def]
     """Redshift grid with uniform spacing in comoving distance."""
     xmin, xmax = cosmo.dc(zmin), cosmo.dc(zmax)
     if dx is not None and num is None:

--- a/glass/user.py
+++ b/glass/user.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 import numpy as np
 
 
-def save_cls(filename, cls) -> None:
+def save_cls(filename, cls) -> None:  # type: ignore[no-untyped-def]
     """
     Save a list of Cls to file.
 
@@ -35,7 +35,7 @@ def save_cls(filename, cls) -> None:
     np.savez(filename, values=values, split=split)
 
 
-def load_cls(filename):
+def load_cls(filename):  # type: ignore[no-untyped-def]
     """
     Load a list of Cls from file.
 
@@ -55,12 +55,12 @@ class _FitsWriter:
     Initialised with the fits object and extension name.
     """
 
-    def __init__(self, fits, ext=None) -> None:
+    def __init__(self, fits, ext=None) -> None:  # type: ignore[no-untyped-def]
         """Create a new, uninitialised writer."""
         self.fits = fits
         self.ext = ext
 
-    def _append(self, data, names=None) -> None:
+    def _append(self, data, names=None) -> None:  # type: ignore[no-untyped-def]
         """Write the FITS file."""
         if self.ext is None or self.ext not in self.fits:
             self.fits.write_table(data, names=names, extname=self.ext)
@@ -71,7 +71,7 @@ class _FitsWriter:
             # not using hdu.append here because of incompatibilities
             hdu.write(data, names=names, firstrow=hdu.get_nrows())
 
-    def write(self, data=None, /, **columns) -> None:
+    def write(self, data=None, /, **columns) -> None:  # type: ignore[no-untyped-def]
         """
         Write to FITS by calling the internal _append method.
 
@@ -89,7 +89,7 @@ class _FitsWriter:
 
 
 @contextmanager
-def write_catalog(filename, *, ext=None):
+def write_catalog(filename, *, ext=None):  # type: ignore[no-untyped-def]
     """
     Write a catalogue into a FITS file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,19 @@ build.targets.sdist.exclude = [
 ]
 version.source = "vcs"
 
+[tool.mypy]
+disallow_untyped_decorators = false
+enable_error_code = [
+    "ignore-without-code",
+    "redundant-expr",
+    "truthy-bool",
+]
+plugins = [
+    "numpy.typing.mypy_plugin",
+]
+strict = true
+warn_unreachable = true
+
 [tool.pytest.ini_options]
 addopts = [
     "--strict-config",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def rng():
+def rng():  # type: ignore[no-untyped-def]
     import numpy as np
 
     return np.random.default_rng(seed=42)

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -10,7 +10,7 @@ HAVE_SCIPY = importlib.util.find_spec("scipy") is not None
 
 
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")
-def test_nnls(rng):
+def test_nnls(rng):  # type: ignore[no-untyped-def]
     from scipy.optimize import nnls as nnls_scipy
 
     # cross-check output with scipy's nnls

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -21,7 +21,7 @@ def test_nnls(rng):  # type: ignore[no-untyped-def]
     x_glass = nnls_glass(a, b)
     x_scipy, _ = nnls_scipy(a, b)
 
-    np.testing.assert_allclose(x_glass, x_scipy)
+    np.testing.assert_allclose(x_glass, x_scipy)  # type: ignore[arg-type]
 
     # check matrix and vector's shape
 

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -15,13 +15,13 @@ from glass.core.array import (
 HAVE_SCIPY = importlib.util.find_spec("scipy") is not None
 
 
-def test_broadcast_first():
+def test_broadcast_first():  # type: ignore[no-untyped-def]
     a = np.ones((2, 3, 4))
     b = np.ones((2, 1))
 
     # arrays with shape ((3, 4, 2)) and ((1, 2)) are passed
     # to np.broadcast_arrays; hence it works
-    a_a, b_a = broadcast_first(a, b)
+    a_a, b_a = broadcast_first(a, b)  # type: ignore[no-untyped-call]
     assert a_a.shape == (2, 3, 4)
     assert b_a.shape == (2, 3, 4)
 
@@ -35,7 +35,7 @@ def test_broadcast_first():
     b = np.ones((5, 6))
 
     with pytest.raises(ValueError, match="shape mismatch"):
-        broadcast_first(a, b)
+        broadcast_first(a, b)  # type: ignore[no-untyped-call]
 
     # plain np.broadcast_arrays will work
     a_a, b_a = np.broadcast_arrays(a, b)
@@ -44,56 +44,56 @@ def test_broadcast_first():
     assert b_a.shape == (4, 5, 6)
 
 
-def test_broadcast_leading_axes():
+def test_broadcast_leading_axes():  # type: ignore[no-untyped-def]
     a = 0
     b = np.zeros((4, 10))
     c = np.zeros((3, 1, 5, 6))
 
-    dims, a, b, c = broadcast_leading_axes((a, 0), (b, 1), (c, 2))
+    dims, a, b, c = broadcast_leading_axes((a, 0), (b, 1), (c, 2))  # type: ignore[no-untyped-call]
 
     assert dims == (3, 4)
-    assert a.shape == (3, 4)
+    assert a.shape == (3, 4)  # type: ignore[attr-defined]
     assert b.shape == (3, 4, 10)
     assert c.shape == (3, 4, 5, 6)
 
 
-def test_ndinterp():
+def test_ndinterp():  # type: ignore[no-untyped-def]
     # test 1d interpolation
 
     xp = [0, 1, 2, 3, 4]
     yp = [1.1, 1.2, 1.3, 1.4, 1.5]
 
     x = 0.5
-    y = ndinterp(x, xp, yp)
+    y = ndinterp(x, xp, yp)  # type: ignore[no-untyped-call]
     assert np.shape(y) == ()
     np.testing.assert_allclose(y, 1.15, atol=1e-15)
 
-    x = [0.5, 1.5, 2.5]
-    y = ndinterp(x, xp, yp)
+    x = [0.5, 1.5, 2.5]  # type: ignore[assignment]
+    y = ndinterp(x, xp, yp)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (3,)
     np.testing.assert_allclose(y, [1.15, 1.25, 1.35], atol=1e-15)
 
-    x = [[0.5, 1.5], [2.5, 3.5]]
-    y = ndinterp(x, xp, yp)
+    x = [[0.5, 1.5], [2.5, 3.5]]  # type: ignore[assignment]
+    y = ndinterp(x, xp, yp)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2, 2)
     np.testing.assert_allclose(y, [[1.15, 1.25], [1.35, 1.45]], atol=1e-15)
 
     # test nd interpolation in final axis
 
-    yp = [[1.1, 1.2, 1.3, 1.4, 1.5], [2.1, 2.2, 2.3, 2.4, 2.5]]
+    yp = [[1.1, 1.2, 1.3, 1.4, 1.5], [2.1, 2.2, 2.3, 2.4, 2.5]]  # type: ignore[list-item]
 
     x = 0.5
-    y = ndinterp(x, xp, yp)
+    y = ndinterp(x, xp, yp)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2,)
     np.testing.assert_allclose(y, [1.15, 2.15], atol=1e-15)
 
-    x = [0.5, 1.5, 2.5]
-    y = ndinterp(x, xp, yp)
+    x = [0.5, 1.5, 2.5]  # type: ignore[assignment]
+    y = ndinterp(x, xp, yp)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2, 3)
     np.testing.assert_allclose(y, [[1.15, 1.25, 1.35], [2.15, 2.25, 2.35]], atol=1e-15)
 
-    x = [[0.5, 1.5], [2.5, 3.5]]
-    y = ndinterp(x, xp, yp)
+    x = [[0.5, 1.5], [2.5, 3.5]]  # type: ignore[assignment]
+    y = ndinterp(x, xp, yp)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2, 2, 2)
     np.testing.assert_allclose(
         y,
@@ -103,15 +103,15 @@ def test_ndinterp():
 
     # test nd interpolation in middle axis
 
-    yp = [[[1.1], [1.2], [1.3], [1.4], [1.5]], [[2.1], [2.2], [2.3], [2.4], [2.5]]]
+    yp = [[[1.1], [1.2], [1.3], [1.4], [1.5]], [[2.1], [2.2], [2.3], [2.4], [2.5]]]  # type: ignore[list-item]
 
     x = 0.5
-    y = ndinterp(x, xp, yp, axis=1)
+    y = ndinterp(x, xp, yp, axis=1)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2, 1)
     np.testing.assert_allclose(y, [[1.15], [2.15]], atol=1e-15)
 
-    x = [0.5, 1.5, 2.5]
-    y = ndinterp(x, xp, yp, axis=1)
+    x = [0.5, 1.5, 2.5]  # type: ignore[assignment]
+    y = ndinterp(x, xp, yp, axis=1)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2, 3, 1)
     np.testing.assert_allclose(
         y,
@@ -119,8 +119,8 @@ def test_ndinterp():
         atol=1e-15,
     )
 
-    x = [[0.5, 1.5, 2.5, 3.5], [3.5, 2.5, 1.5, 0.5], [0.5, 3.5, 1.5, 2.5]]
-    y = ndinterp(x, xp, yp, axis=1)
+    x = [[0.5, 1.5, 2.5, 3.5], [3.5, 2.5, 1.5, 0.5], [0.5, 3.5, 1.5, 2.5]]  # type: ignore[assignment]
+    y = ndinterp(x, xp, yp, axis=1)  # type: ignore[no-untyped-call]
     assert np.shape(y) == (2, 3, 4, 1)
     np.testing.assert_allclose(
         y,
@@ -140,20 +140,20 @@ def test_ndinterp():
     )
 
 
-def test_trapz_product():
+def test_trapz_product():  # type: ignore[no-untyped-def]
     x1 = np.linspace(0, 2, 100)
     f1 = np.full_like(x1, 2.0)
 
     x2 = np.linspace(1, 2, 10)
     f2 = np.full_like(x2, 0.5)
 
-    s = trapz_product((x1, f1), (x2, f2))
+    s = trapz_product((x1, f1), (x2, f2))  # type: ignore[no-untyped-call]
 
     np.testing.assert_allclose(s, 1.0)
 
 
 @pytest.mark.skipif(not HAVE_SCIPY, reason="test requires SciPy")
-def test_cumtrapz():
+def test_cumtrapz():  # type: ignore[no-untyped-def]
     from scipy.integrate import cumulative_trapezoid
 
     # 1D f and x
@@ -163,18 +163,18 @@ def test_cumtrapz():
 
     # default dtype (int - not supported by scipy)
 
-    glass_ct = cumtrapz(f, x)
+    glass_ct = cumtrapz(f, x)  # type: ignore[no-untyped-call]
     np.testing.assert_allclose(glass_ct, np.array([0, 1, 4, 7]))
 
     # explicit dtype (float)
 
-    glass_ct = cumtrapz(f, x, dtype=float)
+    glass_ct = cumtrapz(f, x, dtype=float)  # type: ignore[no-untyped-call]
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
     np.testing.assert_allclose(glass_ct, scipy_ct)
 
     # explicit return array
 
-    result = cumtrapz(f, x, dtype=float, out=np.zeros((4,)))
+    result = cumtrapz(f, x, dtype=float, out=np.zeros((4,)))  # type: ignore[no-untyped-call]
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
     np.testing.assert_allclose(result, scipy_ct)
 
@@ -185,17 +185,17 @@ def test_cumtrapz():
 
     # default dtype (int - not supported by scipy)
 
-    glass_ct = cumtrapz(f, x)
+    glass_ct = cumtrapz(f, x)  # type: ignore[no-untyped-call]
     np.testing.assert_allclose(glass_ct, np.array([[0, 2, 12, 31], [0, 2, 8, 17]]))
 
     # explicit dtype (float)
 
-    glass_ct = cumtrapz(f, x, dtype=float)
+    glass_ct = cumtrapz(f, x, dtype=float)  # type: ignore[no-untyped-call]
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
     np.testing.assert_allclose(glass_ct, scipy_ct)
 
     # explicit return array
 
-    glass_ct = cumtrapz(f, x, dtype=float, out=np.zeros((2, 4)))
+    glass_ct = cumtrapz(f, x, dtype=float, out=np.zeros((2, 4)))  # type: ignore[no-untyped-call]
     scipy_ct = cumulative_trapezoid(f, x, initial=0)
     np.testing.assert_allclose(glass_ct, scipy_ct)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,10 +1,10 @@
 from glass.fields import getcl
 
 
-def test_getcl():
+def test_getcl():  # type: ignore[no-untyped-def]
     # make a mock Cls array with the index pairs as entries
     cls = [{i, j} for i in range(10) for j in range(i, -1, -1)]
     # make sure indices are retrieved correctly
     for i in range(10):
         for j in range(10):
-            assert getcl(cls, i, j) == {i, j}
+            assert getcl(cls, i, j) == {i, j}  # type: ignore[no-untyped-call]

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -9,7 +9,7 @@ from glass import user
 HAVE_FITSIO = importlib.util.find_spec("fitsio") is not None
 
 
-def _test_append(fits, data, names):
+def _test_append(fits, data, names):  # type: ignore[no-untyped-def]
     """Write routine for FITS test cases."""
     cat_name = "CATALOG"
     if cat_name not in fits:
@@ -26,7 +26,7 @@ filename = "MyFile.Fits"
 
 
 @pytest.mark.skipif(not HAVE_FITSIO, reason="test requires fitsio")
-def test_basic_write(tmp_path):
+def test_basic_write(tmp_path):  # type: ignore[no-untyped-def]
     import fitsio
 
     filename_gfits = "gfits.fits"  # what GLASS creates
@@ -42,7 +42,7 @@ def test_basic_write(tmp_path):
             out.write(RA=array, RB=array2)
             arrays = [array, array2]
             names = ["RA", "RB"]
-            _test_append(my_fits, arrays, names)
+            _test_append(my_fits, arrays, names)  # type: ignore[no-untyped-call]
 
     with (
         fitsio.FITS(tmp_path / filename_gfits) as g_fits,
@@ -55,7 +55,7 @@ def test_basic_write(tmp_path):
 
 
 @pytest.mark.skipif(not HAVE_FITSIO, reason="test requires fitsio")
-def test_write_exception(tmp_path):
+def test_write_exception(tmp_path):  # type: ignore[no-untyped-def]
     try:
         with user.write_catalog(tmp_path / filename, ext="CATALOG") as out:
             for i in range(my_max):

--- a/tests/test_galaxies.py
+++ b/tests/test_galaxies.py
@@ -4,7 +4,7 @@ import pytest
 from glass.galaxies import galaxy_shear, gaussian_phz, redshifts, redshifts_from_nz
 
 
-def test_redshifts(mocker):
+def test_redshifts(mocker):  # type: ignore[no-untyped-def]
     # create a mock radial window function
     w = mocker.Mock()
     w.za = np.linspace(0.0, 1.0, 20)
@@ -21,7 +21,7 @@ def test_redshifts(mocker):
     assert z.shape == (10,)
 
 
-def test_redshifts_from_nz():
+def test_redshifts_from_nz():  # type: ignore[no-untyped-def]
     # test sampling
 
     redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0], warn=False)
@@ -51,7 +51,7 @@ def test_redshifts_from_nz():
 
     # case: extra dimensions from count
 
-    count = [10, 20, 30]
+    count = [10, 20, 30]  # type: ignore[assignment]
     z = np.linspace(0, 1, 100)
     nz = z * (1 - z)
 
@@ -63,7 +63,7 @@ def test_redshifts_from_nz():
 
     count = 10
     z = np.linspace(0, 1, 100)
-    nz = [z * (1 - z), (z - 0.5) ** 2]
+    nz = [z * (1 - z), (z - 0.5) ** 2]  # type: ignore[assignment]
 
     redshifts = redshifts_from_nz(count, z, nz, warn=False)
 
@@ -71,9 +71,9 @@ def test_redshifts_from_nz():
 
     # case: extra dimensions from count and nz
 
-    count = [[10], [20], [30]]
+    count = [[10], [20], [30]]  # type: ignore[assignment]
     z = np.linspace(0, 1, 100)
-    nz = [z * (1 - z), (z - 0.5) ** 2]
+    nz = [z * (1 - z), (z - 0.5) ** 2]  # type: ignore[assignment]
 
     redshifts = redshifts_from_nz(count, z, nz, warn=False)
 
@@ -81,9 +81,9 @@ def test_redshifts_from_nz():
 
     # case: incompatible input shapes
 
-    count = [10, 20, 30]
+    count = [10, 20, 30]  # type: ignore[assignment]
     z = np.linspace(0, 1, 100)
-    nz = [z * (1 - z), (z - 0.5) ** 2]
+    nz = [z * (1 - z), (z - 0.5) ** 2]  # type: ignore[assignment]
 
     with pytest.raises(ValueError):
         redshifts_from_nz(count, z, nz, warn=False)
@@ -92,7 +92,7 @@ def test_redshifts_from_nz():
         redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0])
 
 
-def test_galaxy_shear(rng):
+def test_galaxy_shear(rng):  # type: ignore[no-untyped-def]
     # check shape of the output
 
     kappa, gamma1, gamma2 = (
@@ -101,7 +101,7 @@ def test_galaxy_shear(rng):
         rng.normal(size=(12,)),
     )
 
-    shear = galaxy_shear([], [], [], kappa, gamma1, gamma2)
+    shear = galaxy_shear([], [], [], kappa, gamma1, gamma2)  # type: ignore[arg-type]
     np.testing.assert_equal(shear, [])
 
     gal_lon, gal_lat, gal_eps = (
@@ -114,7 +114,7 @@ def test_galaxy_shear(rng):
 
     # shape with no reduced shear
 
-    shear = galaxy_shear([], [], [], kappa, gamma1, gamma2, reduced_shear=False)
+    shear = galaxy_shear([], [], [], kappa, gamma1, gamma2, reduced_shear=False)  # type: ignore[arg-type]
     np.testing.assert_equal(shear, [])
 
     gal_lon, gal_lat, gal_eps = (
@@ -128,7 +128,7 @@ def test_galaxy_shear(rng):
     assert np.shape(shear) == (512,)
 
 
-def test_gaussian_phz():
+def test_gaussian_phz():  # type: ignore[no-untyped-def]
     # test sampling
 
     # case: zero variance
@@ -142,8 +142,8 @@ def test_gaussian_phz():
 
     # case: truncated normal
 
-    z = 0.0
-    sigma_0 = np.ones(100)
+    z = 0.0  # type: ignore[assignment]
+    sigma_0 = np.ones(100)  # type: ignore[assignment]
 
     phz = gaussian_phz(z, sigma_0)
 
@@ -152,8 +152,8 @@ def test_gaussian_phz():
 
     # case: upper and lower bound
 
-    z = 1.0
-    sigma_0 = np.ones(100)
+    z = 1.0  # type: ignore[assignment]
+    sigma_0 = np.ones(100)  # type: ignore[assignment]
 
     phz = gaussian_phz(z, sigma_0, lower=0.5, upper=1.5)
 
@@ -165,7 +165,7 @@ def test_gaussian_phz():
 
     # case: scalar redshift, scalar sigma_0
 
-    z = 1.0
+    z = 1.0  # type: ignore[assignment]
     sigma_0 = 0.0
 
     phz = gaussian_phz(z, sigma_0)
@@ -185,8 +185,8 @@ def test_gaussian_phz():
 
     # case: scalar redshift, array sigma_0
 
-    z = 1.0
-    sigma_0 = np.zeros(10)
+    z = 1.0  # type: ignore[assignment]
+    sigma_0 = np.zeros(10)  # type: ignore[assignment]
 
     phz = gaussian_phz(z, sigma_0)
 
@@ -196,7 +196,7 @@ def test_gaussian_phz():
     # case: array redshift, array sigma_0
 
     z = np.linspace(0, 1, 10)
-    sigma_0 = np.zeros((11, 1))
+    sigma_0 = np.zeros((11, 1))  # type: ignore[assignment]
 
     phz = gaussian_phz(z, sigma_0)
 

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -12,7 +12,7 @@ from glass.shells import RadialWindow
 
 
 @pytest.fixture
-def shells():
+def shells():  # type: ignore[no-untyped-def]
     return [
         RadialWindow([0.0, 1.0, 2.0], [0.0, 1.0, 0.0], 1.0),
         RadialWindow([1.0, 2.0, 3.0], [0.0, 1.0, 0.0], 2.0),
@@ -23,16 +23,16 @@ def shells():
 
 
 @pytest.fixture
-def cosmo():
+def cosmo():  # type: ignore[no-untyped-def]
     class MockCosmology:
         @property
-        def omega_m(self):
+        def omega_m(self):  # type: ignore[no-untyped-def]
             return 0.3
 
-        def ef(self, z):
+        def ef(self, z):  # type: ignore[no-untyped-def]
             return (self.omega_m * (1 + z) ** 3 + 1 - self.omega_m) ** 0.5
 
-        def xm(self, z, z2=None):
+        def xm(self, z, z2=None):  # type: ignore[no-untyped-def]
             if z2 is None:
                 return np.array(z) * 1000
             return (np.array(z2) - np.array(z)) * 1000
@@ -41,37 +41,37 @@ def cosmo():
 
 
 @pytest.mark.parametrize("usecomplex", [True, False])
-def test_deflect_nsew(usecomplex):
+def test_deflect_nsew(usecomplex):  # type: ignore[no-untyped-def]
     d = 5.0
     r = np.radians(d)
 
     if usecomplex:
 
-        def alpha(re, im):
+        def alpha(re, im):  # type: ignore[no-untyped-def]
             return re + 1j * im
     else:
 
-        def alpha(re, im):
+        def alpha(re, im):  # type: ignore[no-untyped-def]
             return [re, im]
 
     # north
-    lon, lat = deflect(0.0, 0.0, alpha(r, 0))
+    lon, lat = deflect(0.0, 0.0, alpha(r, 0))  # type: ignore[no-untyped-call]
     np.testing.assert_allclose([lon, lat], [0.0, d], atol=1e-15)
 
     # south
-    lon, lat = deflect(0.0, 0.0, alpha(-r, 0))
+    lon, lat = deflect(0.0, 0.0, alpha(-r, 0))  # type: ignore[no-untyped-call]
     np.testing.assert_allclose([lon, lat], [0.0, -d], atol=1e-15)
 
     # east
-    lon, lat = deflect(0.0, 0.0, alpha(0, r))
+    lon, lat = deflect(0.0, 0.0, alpha(0, r))  # type: ignore[no-untyped-call]
     np.testing.assert_allclose([lon, lat], [-d, 0.0], atol=1e-15)
 
     # west
-    lon, lat = deflect(0.0, 0.0, alpha(0, -r))
+    lon, lat = deflect(0.0, 0.0, alpha(0, -r))  # type: ignore[no-untyped-call]
     np.testing.assert_allclose([lon, lat], [d, 0.0], atol=1e-15)
 
 
-def test_deflect_many(rng):
+def test_deflect_many(rng):  # type: ignore[no-untyped-def]
     n = 1000
     abs_alpha = rng.uniform(0, 2 * np.pi, size=n)
     arg_alpha = rng.uniform(-np.pi, np.pi, size=n)
@@ -89,7 +89,7 @@ def test_deflect_many(rng):
     np.testing.assert_allclose(dotp, np.cos(abs_alpha))
 
 
-def test_multi_plane_matrix(shells, cosmo, rng):
+def test_multi_plane_matrix(shells, cosmo, rng):  # type: ignore[no-untyped-def]
     mat = multi_plane_matrix(shells, cosmo)
 
     np.testing.assert_array_equal(mat, np.tril(mat))
@@ -101,12 +101,12 @@ def test_multi_plane_matrix(shells, cosmo, rng):
     kappas = []
     for shell, delta in zip(shells, deltas):
         convergence.add_window(delta, shell)
-        kappas.append(convergence.kappa.copy())
+        kappas.append(convergence.kappa.copy())  # type: ignore[union-attr]
 
     np.testing.assert_allclose(mat @ deltas, kappas)
 
 
-def test_multi_plane_weights(shells, cosmo, rng):
+def test_multi_plane_weights(shells, cosmo, rng):  # type: ignore[no-untyped-def]
     w_in = np.eye(len(shells))
     w_out = multi_plane_weights(w_in, shells, cosmo)
 
@@ -125,4 +125,4 @@ def test_multi_plane_weights(shells, cosmo, rng):
 
     wmat = multi_plane_weights(weights, shells, cosmo)
 
-    np.testing.assert_allclose(np.einsum("ij,ik", wmat, deltas), kappa)
+    np.testing.assert_allclose(np.einsum("ij,ik", wmat, deltas), kappa)  # type: ignore[arg-type]

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -3,8 +3,8 @@ import numpy as np
 from glass.points import position_weights, positions_from_delta, uniform_positions
 
 
-def catpos(pos):
-    lon, lat, cnt = [], [], 0
+def catpos(pos):  # type: ignore[no-untyped-def]
+    lon, lat, cnt = [], [], 0  # type: ignore[var-annotated]
     for lo, la, co in pos:
         lon = np.concatenate([lon, lo])
         lat = np.concatenate([lat, la])
@@ -12,7 +12,7 @@ def catpos(pos):
     return lon, lat, cnt
 
 
-def test_positions_from_delta():
+def test_positions_from_delta():  # type: ignore[no-untyped-def]
     # case: single-dimensional input
 
     ngal = 1e-3
@@ -20,19 +20,19 @@ def test_positions_from_delta():
     bias = 0.8
     vis = np.ones(12)
 
-    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))
+    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))  # type: ignore[no-untyped-call]
 
     assert isinstance(cnt, int)
     assert lon.shape == lat.shape == (cnt,)
 
     # case: multi-dimensional ngal
 
-    ngal = [1e-3, 2e-3]
+    ngal = [1e-3, 2e-3]  # type: ignore[assignment]
     delta = np.zeros(12)
     bias = 0.8
     vis = np.ones(12)
 
-    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))
+    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))  # type: ignore[no-untyped-call]
 
     assert cnt.shape == (2,)
     assert lon.shape == (cnt.sum(),)
@@ -45,7 +45,7 @@ def test_positions_from_delta():
     bias = 0.8
     vis = np.ones(12)
 
-    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))
+    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))  # type: ignore[no-untyped-call]
 
     assert cnt.shape == (3, 2)
     assert lon.shape == (cnt.sum(),)
@@ -53,54 +53,54 @@ def test_positions_from_delta():
 
     # case: multi-dimensional broadcasting
 
-    ngal = [1e-3, 2e-3]
+    ngal = [1e-3, 2e-3]  # type: ignore[assignment]
     delta = np.zeros((3, 1, 12))
     bias = 0.8
     vis = np.ones(12)
 
-    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))
+    lon, lat, cnt = catpos(positions_from_delta(ngal, delta, bias, vis))  # type: ignore[no-untyped-call]
 
     assert cnt.shape == (3, 2)
     assert lon.shape == (cnt.sum(),)
     assert lat.shape == (cnt.sum(),)
 
 
-def test_uniform_positions():
+def test_uniform_positions():  # type: ignore[no-untyped-def]
     # case: scalar input
 
     ngal = 1e-3
 
-    lon, lat, cnt = catpos(uniform_positions(ngal))
+    lon, lat, cnt = catpos(uniform_positions(ngal))  # type: ignore[no-untyped-call]
 
     assert isinstance(cnt, int)
     assert lon.shape == lat.shape == (cnt,)
 
     # case: 1-D array input
 
-    ngal = [1e-3, 2e-3, 3e-3]
+    ngal = [1e-3, 2e-3, 3e-3]  # type: ignore[assignment]
 
-    lon, lat, cnt = catpos(uniform_positions(ngal))
+    lon, lat, cnt = catpos(uniform_positions(ngal))  # type: ignore[no-untyped-call]
 
     assert cnt.shape == (3,)
     assert lon.shape == lat.shape == (cnt.sum(),)
 
     # case: 2-D array input
 
-    ngal = [[1e-3, 2e-3], [3e-3, 4e-3], [5e-3, 6e-3]]
+    ngal = [[1e-3, 2e-3], [3e-3, 4e-3], [5e-3, 6e-3]]  # type: ignore[assignment]
 
-    lon, lat, cnt = catpos(uniform_positions(ngal))
+    lon, lat, cnt = catpos(uniform_positions(ngal))  # type: ignore[no-untyped-call]
 
     assert cnt.shape == (3, 2)
     assert lon.shape == lat.shape == (cnt.sum(),)
 
 
-def test_position_weights(rng):
+def test_position_weights(rng):  # type: ignore[no-untyped-def]
     for bshape in None, (), (100,), (100, 1):
         for cshape in (100,), (100, 50), (100, 3, 2):
             counts = rng.random(cshape)
             bias = None if bshape is None else rng.random(bshape)
 
-            weights = position_weights(counts, bias)
+            weights = position_weights(counts, bias)  # type: ignore[no-untyped-call]
 
             expected = counts / counts.sum(axis=0, keepdims=True)
             if bias is not None:

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -6,8 +6,8 @@ from glass.points import position_weights, positions_from_delta, uniform_positio
 def catpos(pos):  # type: ignore[no-untyped-def]
     lon, lat, cnt = [], [], 0  # type: ignore[var-annotated]
     for lo, la, co in pos:
-        lon = np.concatenate([lon, lo])
-        lat = np.concatenate([lat, la])
+        lon = np.concatenate([lon, lo])  # type: ignore[assignment]
+        lat = np.concatenate([lat, la])  # type: ignore[assignment]
         cnt = cnt + co
     return lon, lat, cnt
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -9,31 +9,31 @@ from glass.shapes import (
 )
 
 
-def test_triaxial_axis_ratio():
+def test_triaxial_axis_ratio():  # type: ignore[no-untyped-def]
     # single axis ratio
 
-    q = triaxial_axis_ratio(0.8, 0.4)
+    q = triaxial_axis_ratio(0.8, 0.4)  # type: ignore[no-untyped-call]
     assert np.isscalar(q)
 
     # many axis ratios
 
-    q = triaxial_axis_ratio(0.8, 0.4, size=1000)
+    q = triaxial_axis_ratio(0.8, 0.4, size=1000)  # type: ignore[no-untyped-call]
     assert np.shape(q) == (1000,)
 
     # explicit shape
 
-    q = triaxial_axis_ratio(0.8, 0.4, size=(10, 10))
+    q = triaxial_axis_ratio(0.8, 0.4, size=(10, 10))  # type: ignore[no-untyped-call]
     assert np.shape(q) == (10, 10)
 
     # implicit size
 
-    q1 = triaxial_axis_ratio([0.8, 0.9], 0.4)
-    q2 = triaxial_axis_ratio(0.8, [0.4, 0.5])
+    q1 = triaxial_axis_ratio([0.8, 0.9], 0.4)  # type: ignore[no-untyped-call]
+    q2 = triaxial_axis_ratio(0.8, [0.4, 0.5])  # type: ignore[no-untyped-call]
     assert np.shape(q1) == np.shape(q2) == (2,)
 
     # broadcasting rule
 
-    q = triaxial_axis_ratio([[0.6, 0.7], [0.8, 0.9]], [0.4, 0.5])
+    q = triaxial_axis_ratio([[0.6, 0.7], [0.8, 0.9]], [0.4, 0.5])  # type: ignore[no-untyped-call]
     assert np.shape(q) == (2, 2)
 
     # random parameters and check that projection is
@@ -42,49 +42,49 @@ def test_triaxial_axis_ratio():
     zeta, xi = np.sort(np.random.uniform(0, 1, size=(2, 1000)), axis=0)
     qmin = np.min([zeta, xi, xi / zeta], axis=0)
     qmax = np.max([zeta, xi, xi / zeta], axis=0)
-    q = triaxial_axis_ratio(zeta, xi)
+    q = triaxial_axis_ratio(zeta, xi)  # type: ignore[no-untyped-call]
     assert np.all((qmax >= q) & (q >= qmin))
 
 
-def test_ellipticity_ryden04():
+def test_ellipticity_ryden04():  # type: ignore[no-untyped-def]
     # single ellipticity
 
-    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056)
+    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056)  # type: ignore[no-untyped-call]
     assert np.isscalar(e)
 
     # many ellipticities
 
-    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056, size=1000)
+    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056, size=1000)  # type: ignore[no-untyped-call]
     assert np.shape(e) == (1000,)
 
     # explicit shape
 
-    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056, size=(10, 10))
+    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056, size=(10, 10))  # type: ignore[no-untyped-call]
     assert np.shape(e) == (10, 10)
 
     # implicit size
 
-    e1 = ellipticity_ryden04(-1.85, 0.89, [0.222, 0.333], 0.056)
-    e2 = ellipticity_ryden04(-1.85, 0.89, 0.222, [0.056, 0.067])
-    e3 = ellipticity_ryden04([-1.85, -2.85], 0.89, 0.222, 0.056)
-    e4 = ellipticity_ryden04(-1.85, [0.89, 1.001], 0.222, 0.056)
+    e1 = ellipticity_ryden04(-1.85, 0.89, [0.222, 0.333], 0.056)  # type: ignore[no-untyped-call]
+    e2 = ellipticity_ryden04(-1.85, 0.89, 0.222, [0.056, 0.067])  # type: ignore[no-untyped-call]
+    e3 = ellipticity_ryden04([-1.85, -2.85], 0.89, 0.222, 0.056)  # type: ignore[no-untyped-call]
+    e4 = ellipticity_ryden04(-1.85, [0.89, 1.001], 0.222, 0.056)  # type: ignore[no-untyped-call]
     assert np.shape(e1) == np.shape(e2) == np.shape(e3) == np.shape(e4) == (2,)
 
     # broadcasting rule
 
-    e = ellipticity_ryden04([-1.9, -2.9], 0.9, [[0.2, 0.3], [0.4, 0.5]], 0.1)
+    e = ellipticity_ryden04([-1.9, -2.9], 0.9, [[0.2, 0.3], [0.4, 0.5]], 0.1)  # type: ignore[no-untyped-call]
     assert np.shape(e) == (2, 2)
 
     # check that result is in the specified range
 
-    e = ellipticity_ryden04(0.0, 1.0, 0.222, 0.056, size=10)
+    e = ellipticity_ryden04(0.0, 1.0, 0.222, 0.056, size=10)  # type: ignore[no-untyped-call]
     assert np.all((e.real >= -1.0) & (e.real <= 1.0))
 
-    e = ellipticity_ryden04(0.0, 1.0, 0.0, 1.0, size=10)
+    e = ellipticity_ryden04(0.0, 1.0, 0.0, 1.0, size=10)  # type: ignore[no-untyped-call]
     assert np.all((e.real >= -1.0) & (e.real <= 1.0))
 
 
-def test_ellipticity_gaussian():
+def test_ellipticity_gaussian():  # type: ignore[no-untyped-def]
     n = 1_000_000
 
     eps = ellipticity_gaussian(n, 0.256)
@@ -108,7 +108,7 @@ def test_ellipticity_gaussian():
     np.testing.assert_allclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
 
 
-def test_ellipticity_intnorm():
+def test_ellipticity_intnorm():  # type: ignore[no-untyped-def]
     n = 1_000_000
 
     eps = ellipticity_intnorm(n, 0.256)

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -4,7 +4,7 @@ import pytest
 from glass.shells import RadialWindow, partition, restrict, tophat_windows
 
 
-def test_tophat_windows():
+def test_tophat_windows():  # type: ignore[no-untyped-def]
     zb = [0.0, 0.1, 0.2, 0.5, 1.0, 2.0]
     dz = 0.005
 
@@ -18,16 +18,16 @@ def test_tophat_windows():
         zn <= z0 + len(w.za) * dz <= zn + dz for w, z0, zn in zip(ws, zb, zb[1:])
     )
 
-    assert all(np.all(w.wa == 1) for w in ws)
+    assert all(np.all(w.wa == 1) for w in ws)  # type: ignore[comparison-overlap]
 
 
-def test_restrict():
+def test_restrict():  # type: ignore[no-untyped-def]
     # Gaussian test function
     z = np.linspace(0.0, 5.0, 1000)
     f = np.exp(-(((z - 2.0) / 0.5) ** 2) / 2)
 
     # window for restriction
-    w = RadialWindow(za=[1.0, 2.0, 3.0, 4.0], wa=[0.0, 0.5, 0.5, 0.0], zeff=None)
+    w = RadialWindow(za=[1.0, 2.0, 3.0, 4.0], wa=[0.0, 0.5, 0.5, 0.0], zeff=None)  # type: ignore[arg-type]
 
     zr, fr = restrict(z, f, w)
 
@@ -49,7 +49,7 @@ def test_restrict():
 
 
 @pytest.mark.parametrize("method", ["lstsq", "nnls", "restrict"])
-def test_partition(method):
+def test_partition(method):  # type: ignore[no-untyped-def]
     shells = [
         RadialWindow(np.array([0.0, 1.0]), np.array([1.0, 0.0]), 0.0),
         RadialWindow(np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0, 0.0]), 0.5),

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -51,12 +51,32 @@ def test_restrict():  # type: ignore[no-untyped-def]
 @pytest.mark.parametrize("method", ["lstsq", "nnls", "restrict"])
 def test_partition(method):  # type: ignore[no-untyped-def]
     shells = [
-        RadialWindow(np.array([0.0, 1.0]), np.array([1.0, 0.0]), 0.0),
-        RadialWindow(np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0, 0.0]), 0.5),
-        RadialWindow(np.array([1.0, 2.0, 3.0]), np.array([0.0, 1.0, 0.0]), 1.5),
-        RadialWindow(np.array([2.0, 3.0, 4.0]), np.array([0.0, 1.0, 0.0]), 2.5),
-        RadialWindow(np.array([3.0, 4.0, 5.0]), np.array([0.0, 1.0, 0.0]), 3.5),
-        RadialWindow(np.array([4.0, 5.0]), np.array([0.0, 1.0]), 5.0),
+        RadialWindow(np.array([0.0, 1.0]), np.array([1.0, 0.0]), 0.0),  # type: ignore[arg-type]
+        RadialWindow(
+            np.array([0.0, 1.0, 2.0]),  # type: ignore[arg-type]
+            np.array([0.0, 1.0, 0.0]),  # type: ignore[arg-type]
+            0.5,
+        ),
+        RadialWindow(
+            np.array([1.0, 2.0, 3.0]),  # type: ignore[arg-type]
+            np.array([0.0, 1.0, 0.0]),  # type: ignore[arg-type]
+            1.5,
+        ),
+        RadialWindow(
+            np.array([2.0, 3.0, 4.0]),  # type: ignore[arg-type]
+            np.array([0.0, 1.0, 0.0]),  # type: ignore[arg-type]
+            2.5,
+        ),
+        RadialWindow(
+            np.array([3.0, 4.0, 5.0]),  # type: ignore[arg-type]
+            np.array([0.0, 1.0, 0.0]),  # type: ignore[arg-type]
+            3.5,
+        ),
+        RadialWindow(
+            np.array([4.0, 5.0]),  # type: ignore[arg-type]
+            np.array([0.0, 1.0]),  # type: ignore[arg-type]
+            5.0,
+        ),
     ]
 
     z = np.linspace(0.0, 5.0, 1000)
@@ -67,6 +87,6 @@ def test_partition(method):  # type: ignore[no-untyped-def]
 
     part = partition(z, fz, shells, method=method)
 
-    assert part.shape == (len(shells), 3, 2)
+    assert part.shape == (len(shells), 3, 2)  # type: ignore[union-attr]
 
-    np.testing.assert_allclose(part.sum(axis=0), np.trapz(fz, z))
+    np.testing.assert_allclose(part.sum(axis=0), np.trapz(fz, z))  # type: ignore[attr-defined, union-attr]


### PR DESCRIPTION
Adding `mypy` to a pre-existing codebase is never easy. I initially attempted this in #308, but have since split this up into separate issues:
- [x] #347
- [x] #356
- [ ] #358

In this PR, `mypy` is added but in order for CI to pass, the `# type: ignore[]` syntax is used throughout. I didn't want to tackle these here too (see #308) as it gets quite messy.

One thing I have done (following #356) is change every empty `npt.NDArray` to `npt.NDArray[typing.Any]` (see #330), as this actually results in fewer errors than leaving them all blank. Ideally, we'd like to fill in as many of the `typing.Any` as possible - they're a bit useless by themselves. However, that is not the priority for now. Plus, I expect typing to change when #67 is tackled.