### PR TITLE
gh-161: bump coverage for galaxies and shapes

### DIFF
--- a/tests/test_galaxies.py
+++ b/tests/test_galaxies.py
@@ -21,7 +21,7 @@ def test_redshifts(mocker):  # type: ignore[no-untyped-def]
     assert z.shape == (10,)
 
 
-def test_redshifts_from_nz(rng):  # type: ignore[no-untyped-def]
+def test_redshifts_from_nz(rng: np.random.Generator) -> None:
     # test sampling
 
     redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0], warn=False)
@@ -135,7 +135,7 @@ def test_galaxy_shear(rng):  # type: ignore[no-untyped-def]
     assert np.shape(shear) == (512,)
 
 
-def test_gaussian_phz(rng):  # type: ignore[no-untyped-def]
+def test_gaussian_phz(rng: np.random.Generator) -> None:
     # test sampling
 
     # case: zero variance

--- a/tests/test_galaxies.py
+++ b/tests/test_galaxies.py
@@ -21,7 +21,7 @@ def test_redshifts(mocker):  # type: ignore[no-untyped-def]
     assert z.shape == (10,)
 
 
-def test_redshifts_from_nz():  # type: ignore[no-untyped-def]
+def test_redshifts_from_nz(rng):  # type: ignore[no-untyped-def]
     # test sampling
 
     redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [1, 0, 0, 0, 0], warn=False)
@@ -34,6 +34,13 @@ def test_redshifts_from_nz():  # type: ignore[no-untyped-def]
     assert np.all((3 <= redshifts) & (redshifts <= 4))  # noqa: SIM300
 
     redshifts = redshifts_from_nz(10, [0, 1, 2, 3, 4], [0, 0, 1, 1, 1], warn=False)
+    assert not np.any(redshifts <= 1)
+
+    # test with rng
+
+    redshifts = redshifts_from_nz(
+        10, [0, 1, 2, 3, 4], [0, 0, 1, 1, 1], warn=False, rng=rng
+    )
     assert not np.any(redshifts <= 1)
 
     # test interface
@@ -128,7 +135,7 @@ def test_galaxy_shear(rng):  # type: ignore[no-untyped-def]
     assert np.shape(shear) == (512,)
 
 
-def test_gaussian_phz():  # type: ignore[no-untyped-def]
+def test_gaussian_phz(rng):  # type: ignore[no-untyped-def]
     # test sampling
 
     # case: zero variance
@@ -137,6 +144,12 @@ def test_gaussian_phz():  # type: ignore[no-untyped-def]
     sigma_0 = 0.0
 
     phz = gaussian_phz(z, sigma_0)
+
+    np.testing.assert_array_equal(z, phz)
+
+    # test with rng
+
+    phz = gaussian_phz(z, sigma_0, rng=rng)
 
     np.testing.assert_array_equal(z, phz)
 
@@ -202,3 +215,16 @@ def test_gaussian_phz():  # type: ignore[no-untyped-def]
 
     assert phz.shape == (11, 10)
     np.testing.assert_array_equal(np.broadcast_to(z, (11, 10)), phz)
+
+    # test resampling
+
+    phz = gaussian_phz(np.array(0.0), np.array(1.0), lower=np.array([0]))
+    assert isinstance(phz, float)  # type: ignore[unreachable]
+
+    phz = gaussian_phz(np.array(0.0), np.array(1.0), upper=np.array([1]))  # type: ignore[unreachable]
+    assert isinstance(phz, float)
+
+    # test error
+
+    with pytest.raises(ValueError, match="requires lower < upper"):
+        phz = gaussian_phz(z, sigma_0, lower=np.array([1]), upper=np.array([0]))

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -46,10 +46,15 @@ def test_triaxial_axis_ratio(rng):  # type: ignore[no-untyped-def]
     assert np.all((qmax >= q) & (q >= qmin))
 
 
-def test_ellipticity_ryden04():  # type: ignore[no-untyped-def]
+def test_ellipticity_ryden04(rng):  # type: ignore[no-untyped-def]
     # single ellipticity
 
     e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056)  # type: ignore[no-untyped-call]
+    assert np.isscalar(e)
+
+    # test with rng
+
+    e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056, rng=rng)  # type: ignore[no-untyped-call]
     assert np.isscalar(e)
 
     # many ellipticities
@@ -84,10 +89,16 @@ def test_ellipticity_ryden04():  # type: ignore[no-untyped-def]
     assert np.all((e.real >= -1.0) & (e.real <= 1.0))
 
 
-def test_ellipticity_gaussian():  # type: ignore[no-untyped-def]
+def test_ellipticity_gaussian(rng):  # type: ignore[no-untyped-def]
     n = 1_000_000
 
     eps = ellipticity_gaussian(n, 0.256)
+
+    assert eps.shape == (n,)
+
+    # test with rng
+
+    eps = ellipticity_gaussian(n, 0.256, rng=rng)
 
     assert eps.shape == (n,)
 
@@ -108,10 +119,16 @@ def test_ellipticity_gaussian():  # type: ignore[no-untyped-def]
     np.testing.assert_allclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
 
 
-def test_ellipticity_intnorm():  # type: ignore[no-untyped-def]
+def test_ellipticity_intnorm(rng):  # type: ignore[no-untyped-def]
     n = 1_000_000
 
     eps = ellipticity_intnorm(n, 0.256)
+
+    assert eps.shape == (n,)
+
+    # test with rng
+
+    eps = ellipticity_intnorm(n, 0.256, rng=rng)
 
     assert eps.shape == (n,)
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -46,7 +46,7 @@ def test_triaxial_axis_ratio(rng):  # type: ignore[no-untyped-def]
     assert np.all((qmax >= q) & (q >= qmin))
 
 
-def test_ellipticity_ryden04(rng):  # type: ignore[no-untyped-def]
+def test_ellipticity_ryden04(rng: np.random.Generator) -> None:
     # single ellipticity
 
     e = ellipticity_ryden04(-1.85, 0.89, 0.222, 0.056)  # type: ignore[no-untyped-call]
@@ -89,7 +89,7 @@ def test_ellipticity_ryden04(rng):  # type: ignore[no-untyped-def]
     assert np.all((e.real >= -1.0) & (e.real <= 1.0))
 
 
-def test_ellipticity_gaussian(rng):  # type: ignore[no-untyped-def]
+def test_ellipticity_gaussian(rng: np.random.Generator) -> None:
     n = 1_000_000
 
     eps = ellipticity_gaussian(n, 0.256)
@@ -119,7 +119,7 @@ def test_ellipticity_gaussian(rng):  # type: ignore[no-untyped-def]
     np.testing.assert_allclose(np.std(eps.imag[n:]), 0.256, atol=1e-3, rtol=0)
 
 
-def test_ellipticity_intnorm(rng):  # type: ignore[no-untyped-def]
+def test_ellipticity_intnorm(rng: np.random.Generator) -> None:
     n = 1_000_000
 
     eps = ellipticity_intnorm(n, 0.256)


### PR DESCRIPTION
The coverage went down when branch coverage was turned on. This PR brings it back to 100% for these two files.

Refs: #161