### PR TITLE
gh-363: use pytest-rerunfailures for flaky test_ellipticity_gaussian

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "pytest-cov",
     "pytest-doctestplus",
     "pytest-mock",
+    "pytest-rerunfailures",
     "scipy",
 ]
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -84,6 +84,7 @@ def test_ellipticity_ryden04():  # type: ignore[no-untyped-def]
     assert np.all((e.real >= -1.0) & (e.real <= 1.0))
 
 
+@pytest.mark.flaky(rerun=5, only_rerun=["AssertionError"])
 def test_ellipticity_gaussian():  # type: ignore[no-untyped-def]
     n = 1_000_000
 
@@ -94,7 +95,7 @@ def test_ellipticity_gaussian():  # type: ignore[no-untyped-def]
     np.testing.assert_array_less(np.abs(eps), 1)
 
     np.testing.assert_allclose(np.std(eps.real), 0.256, atol=1e-3, rtol=0)
-    np.testing.assert_allclose(np.std(eps.imag), 0.256, atol=1e-2, rtol=0)
+    np.testing.assert_allclose(np.std(eps.imag), 0.256, atol=1e-3, rtol=0)
 
     eps = ellipticity_gaussian([n, n], [0.128, 0.256])
 


### PR DESCRIPTION
Rerun the flaky test if it fails. See https://github.com/glass-dev/glass/pull/364#issuecomment-2414422872

Closes: #363