### PR TITLE
Fix `Returns` in docstrings (I think entered in #357)

### DIFF
--- a/glass/observations.py
+++ b/glass/observations.py
@@ -50,6 +50,8 @@ def vmap_galactic_ecliptic(
     the galactic and ecliptic planes. The location of the stripes is set with
     optional parameters.
 
+    Returns a HEALPix :term:`visibility map`.
+
     Parameters
     ----------
     nside:
@@ -58,11 +60,6 @@ def vmap_galactic_ecliptic(
         The location of the galactic plane in the respective coordinate system.
     ecliptic:
         The location of the ecliptic plane in the respective coordinate system.
-
-    Returns
-    -------
-    vis:
-        A HEALPix :term:`visibility map`.
 
     Raises
     ------
@@ -100,6 +97,8 @@ def gaussian_nz(
     If ``mean`` or ``sigma`` are array_like, their axes will be the leading
     axes of the redshift distribution.
 
+    Returns the redshift distribution at the given ``z`` values.
+
     Parameters
     ----------
     z:
@@ -110,11 +109,6 @@ def gaussian_nz(
         Standard deviation(s) of the redshift distribution.
     norm:
         If given, the normalisation of the distribution.
-
-    Returns
-    -------
-    nz:
-        Redshift distribution at the given ``z`` values.
 
     """
     mean = np.reshape(mean, np.shape(mean) + (1,) * np.ndim(z))
@@ -142,6 +136,8 @@ def smail_nz(
 
     The redshift follows the Smail et al. [1] redshift distribution.
 
+    Returns the redshift distribution at the given ``z`` values.
+
     Parameters
     ----------
     z:
@@ -154,11 +150,6 @@ def smail_nz(
         Log-power law exponent exp[-(z/z0)^\beta], must be positive.
     norm:
         If given, the normalisation of the distribution.
-
-    Returns
-    -------
-    pz:
-        Redshift distribution at the given ``z`` values.
 
     Notes
     -----
@@ -204,6 +195,8 @@ def fixed_zbins(
     This function creates contiguous tomographic redshift bins of fixed size.
     It takes either the number or size of the bins.
 
+    Returns a list of redshift bin edges.
+
     Parameters
     ----------
     zmin:
@@ -214,11 +207,6 @@ def fixed_zbins(
         Number of redshift bins. Only one of ``nbins`` and ``dz`` can be given.
     dz:
         Size of redshift bin. Only one of ``nbins`` and ``dz`` can be given.
-
-    Returns
-    -------
-    zbins:
-        List of redshift bin edges.
 
     """
     if nbins is not None and dz is None:
@@ -243,6 +231,8 @@ def equal_dens_zbins(
     This function subdivides a source redshift distribution into ``nbins``
     tomographic redshift bins with equal density.
 
+    Returns a list of redshift bin edges.
+
     Parameters
     ----------
     z:
@@ -251,11 +241,6 @@ def equal_dens_zbins(
         The source redshift distribution. Must be one-dimensional.
     nbins:
         Number of redshift bins.
-
-    Returns
-    -------
-    zbins:
-        List of redshift bin edges.
 
     """
     # compute the normalised cumulative distribution function
@@ -285,6 +270,9 @@ def tomo_nz_gausserr(
     standard deviation of the Gaussian depends on redshift and is given by
     ``sigma(z) = sigma_0*(1 + z)``.
 
+    Returns the tomographic redshift bins convolved with a gaussian error.
+    Array has a shape (nbins, len(z))
+
     Parameters
     ----------
     z:
@@ -295,12 +283,6 @@ def tomo_nz_gausserr(
         Redshift error in the tomographic binning at zero redshift.
     zbins:
         List of redshift bin edges.
-
-    Returns
-    -------
-    binned_nz:
-        Tomographic redshift bins convolved with a gaussian error.
-        Array has a shape (nbins, len(z))
 
     See Also
     --------

--- a/glass/points.py
+++ b/glass/points.py
@@ -45,6 +45,8 @@ def effective_bias(z, bz, w):  # type: ignore[no-untyped-def]
     and computes an effective bias parameter :math:`\bar{b}` for a
     given window function :math:`w(z)`.
 
+    Returns the effective bias parameter for the window.
+
     Parameters
     ----------
     z:
@@ -53,11 +55,6 @@ def effective_bias(z, bz, w):  # type: ignore[no-untyped-def]
         Redshifts and values of the bias function :math:`b(z)`.
     w:
         The radial window function :math:`w(z)`.
-
-    Returns
-    -------
-    beff:
-        Effective bias parameter for the window.
 
     Notes
     -----
@@ -313,6 +310,8 @@ def position_weights(densities, bias=None):  # type: ignore[no-untyped-def]
     redshift distribution and bias factor :math:`n(z) \, b(z)` for the
     discretised shells.
 
+    Returns the relative weight of each shell for angular clustering.
+
     Parameters
     ----------
     densities:
@@ -320,11 +319,6 @@ def position_weights(densities, bias=None):  # type: ignore[no-untyped-def]
         against the number of shells, and is normalised internally.
     bias:
         Value or values of the linear bias parameter for each shell.
-
-    Returns
-    -------
-    weights:
-        Relative weight of each shell for angular clustering.
 
     """
     # bring densities and bias into the same shape

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -37,6 +37,8 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):  # type: ignore[no-un
     Given the two axis ratios `1 >= zeta >= xi` of a randomly oriented triaxial
     ellipsoid, computes the axis ratio `q` of the projection.
 
+    Returns the axis ratio of the randomly projected ellipsoid.
+
     Parameters
     ----------
     zeta:
@@ -48,11 +50,6 @@ def triaxial_axis_ratio(zeta, xi, size=None, *, rng=None):  # type: ignore[no-un
         other inputs.
     rng:
         Random number generator. If not given, a default RNG will be used.
-
-    Returns
-    -------
-    q:
-        Axis ratio of the randomly projected ellipsoid.
 
     Notes
     -----
@@ -106,6 +103,8 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
     standard deviation :math:`\sigma_\gamma` [2]. Both distributions are
     truncated to produce ratios in the range 0 to 1 using rejection sampling.
 
+    Returns an array of :term:`ellipticity` from projected axis ratios.
+
     Parameters
     ----------
     mu:
@@ -120,11 +119,6 @@ def ellipticity_ryden04(mu, sigma, gamma, sigma_gamma, size=None, *, rng=None): 
         Sample size. If ``None``, the size is inferred from the parameters.
     rng:
         Random number generator. If not given, a default RNG will be used.
-
-    Returns
-    -------
-    eps:
-        Array of :term:`ellipticity` from projected axis ratios.
 
     References
     ----------
@@ -186,6 +180,8 @@ def ellipticity_gaussian(
     this function with too large values of ``sigma``, or the sampling
     will become inefficient.
 
+    Returns an array of galaxy :term:`ellipticity`.
+
     Parameters
     ----------
     count:
@@ -194,11 +190,6 @@ def ellipticity_gaussian(
         Standard deviation in each component.
     rng:
         Random number generator. If not given, a default RNG is used.
-
-    Returns
-    -------
-    eps:
-        Array of galaxy :term:`ellipticity`.
 
     """
     # default RNG if not provided
@@ -240,6 +231,8 @@ def ellipticity_intnorm(
     The ellipticities are sampled from an intrinsic normal distribution
     with standard deviation ``sigma`` for each component.
 
+    Returns an array of galaxy :term:`ellipticity`.
+
     Parameters
     ----------
     count:
@@ -248,11 +241,6 @@ def ellipticity_intnorm(
         Standard deviation of the ellipticity in each component.
     rng:
         Random number generator. If not given, a default RNG is used.
-
-    Returns
-    -------
-    eps:
-        Array of galaxy :term:`ellipticity`.
 
     """
     # default RNG if not provided


### PR DESCRIPTION
I think due to development velocity, I accidentally brought these back in when addressing merge conflicts