### PR TITLE
gh-342: explicit libbz2-dev installation is not required now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,6 @@ jobs:
       - name: Install nox and coverage.py
         run: python -m pip install coverage[toml] nox
 
-      - name: Install ubuntu dependencies for fitsio
-        run: |-
-          sudo apt-get update
-          sudo apt-get install -y libbz2-dev
-
       - name: Run doctests
         run: nox -s doctests-${{ matrix.python-version }} --verbose
         env:


### PR DESCRIPTION
None of the available Ubuntu images - [Ubuntu 20.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#installed-apt-packages), [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#installed-apt-packages), and [Ubuntu 24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#installed-apt-packages) - list it as an installed `apt` package so I am not sure how or when this was fixed.

Refs: #342 