### PR TITLE
gh-399: hide `kappa_ia_nla`

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -19,9 +19,9 @@ from glass.fields import (
     transform_cls,
 )
 from glass.galaxies import (
+    _kappa_ia_nla,
     galaxy_shear,
     gaussian_phz,
-    kappa_ia_nla,
     redshifts,
     redshifts_from_nz,
 )

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -296,7 +296,7 @@ def gaussian_phz(
     return zphot
 
 
-def kappa_ia_nla(  # noqa: PLR0913
+def _kappa_ia_nla(  # noqa: PLR0913
     delta: npt.NDArray[np.float64],
     zeff: float,
     a_ia: float,

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -15,10 +15,6 @@ Functions
 .. autofunction:: galaxy_shear
 .. autofunction:: gaussian_phz
 
-Intrinsic alignments
---------------------
-.. autofunction:: kappa_ia_nla
-
 """  # noqa: D205, D400
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #399. Hides the `kappa_ia_nla` function introduced in #21. This appeared to depend on functionality in https://github.com/glass-dev/cosmology that has not made it into the latest (now deprecated) release. It has been discussed that we should keep it but don't make it publicly available. Needed for #390.