### PR TITLE
gh-286: replace `stable` in docs with tag for `sdist`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Replace stable version with the release version
         run: |-
           # store the release tag
-          tag="${{ github.event.release.tag_name }}"
+          tag="${{ github.ref_name }}"
 
           # files to search for
           md_rst_files=$(find . -type f \( -name "*.md" -o -name "*.rst" \))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,15 @@ jobs:
           # store the release tag
           tag="${{ github.ref_name }}"
 
-          # files to search for
-          md_rst_files=$(find . -type f \( -name "*.md" -o -name "*.rst" \))
-
           # regex patterns
           badge_pattern="s#(readthedocs\.org/projects/glass/badge/\?version=)stable#\1${tag}#g"
           url_pattern="s#(glass\.readthedocs\.io.*?)/stable#\1/${tag}#g"
 
           # perform the replacements
-          for file in $md_rst_files; do
-            sed -E -i "$badge_pattern; $url_pattern" "$file"
-          done
+          sed --in-place --regexp-extended \
+            --expression "$badge_pattern" \
+            --expression "$url_pattern" \
+            ${{ github.workspace }}/README.md
 
       - name: Build SDist and wheel
         run: pipx run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,23 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Replace stable version with the release version
+        run: |-
+          # store the release tag
+          tag="${{ github.event.release.tag_name }}"
+
+          # files to search for
+          md_rst_files=$(find . -type f \( -name "*.md" -o -name "*.rst" \))
+
+          # regex patterns
+          badge_pattern="s#(readthedocs\.org/projects/glass/badge/\?version=)stable#\1${tag}#g"
+          url_pattern="s#(glass\.readthedocs\.io.*?)/stable#\1/${tag}#g"
+
+          # perform the replacements
+          for file in $md_rst_files; do
+            sed -E -i "$badge_pattern; $url_pattern" "$file"
+          done
+
       - name: Build SDist and wheel
         run: pipx run build
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "GLASS: Generator for Large Scale Structure"
 message: >-
   If you use GLASS in your research, please cite the associated paper.
 repository-code: "https://github.com/glass-dev/glass"
-url: "https://glass.readthedocs.io"
+url: "https://glass.readthedocs.io/stable"
 license: MIT
 preferred-citation:
   authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "GLASS: Generator for Large Scale Structure"
 message: >-
   If you use GLASS in your research, please cite the associated paper.
 repository-code: "https://github.com/glass-dev/glass"
-url: "https://glass.readthedocs.io/stable"
+url: "https://glass.readthedocs.io"
 license: MIT
 preferred-citation:
   authors:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ rendering documentation on its website. The configuration file (`conf.py`) for
 `sphinx` can be found
 [under the `docs` folder](https://github.com/glass-dev/glass/blob/main/docs/conf.py).
 The documentation is deployed on <https://readthedocs.io>
-[here](https://glass.readthedocs.io/en/latest).
+[here](https://glass.readthedocs.io/latest/).
 
 Ideally, with the addition of every new feature to _GLASS_, documentation should
 be added using comments, docstrings, and `.rst` files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ rendering documentation on its website. The configuration file (`conf.py`) for
 `sphinx` can be found
 [under the `docs` folder](https://github.com/glass-dev/glass/blob/main/docs/conf.py).
 The documentation is deployed on <https://readthedocs.io>
-[here](https://glass.readthedocs.io/en/latest/).
+[here](https://glass.readthedocs.io/en/latest).
 
 Ideally, with the addition of every new feature to _GLASS_, documentation should
 be added using comments, docstrings, and `.rst` files.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- Essentials -->
 
 [![PyPI](https://img.shields.io/pypi/v/glass)](https://pypi.org/project/glass)
-[![Documentation](https://readthedocs.org/projects/glass/badge/?version=latest)](https://glass.readthedocs.io/latest)
+[![Documentation](https://readthedocs.org/projects/glass/badge/?version=stable)](https://glass.readthedocs.io/stable)
 [![LICENSE](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 <!-- Code -->
@@ -80,7 +80,7 @@ e.g. a design decision or API change, you can use our [Discussions] page.
 
 We also have a public [Slack workspace] for discussions about the project.
 
-[documentation]: https://glass.readthedocs.io/
-[examples]: https://glass.readthedocs.io/projects/examples/
+[documentation]: https://glass.readthedocs.io/stable
+[examples]: https://glass.readthedocs.io/projects/examples/stable
 [Discussions]: https://github.com/orgs/glass-dev/discussions
 [Slack workspace]: https://glass-dev.github.io/slack

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ e.g. a design decision or API change, you can use our [Discussions] page.
 We also have a public [Slack workspace] for discussions about the project.
 
 [documentation]: https://glass.readthedocs.io/stable
-[examples]: https://glass.readthedocs.io/projects/examples/stable
+[examples]: https://glass.readthedocs.io/stable/examples.html
 [Discussions]: https://github.com/orgs/glass-dev/discussions
 [Slack workspace]: https://glass-dev.github.io/slack

--- a/docs/manual/first-steps.rst
+++ b/docs/manual/first-steps.rst
@@ -1,6 +1,6 @@
 First steps
 ===========
 
-The best way to get started with *GLASS* is to follow the examples__.
+The best way to get started with *GLASS* is to follow the :doc:`/examples`.
 
 __ https://glass.readthedocs.io/projects/examples/stable

--- a/docs/manual/first-steps.rst
+++ b/docs/manual/first-steps.rst
@@ -2,5 +2,3 @@ First steps
 ===========
 
 The best way to get started with *GLASS* is to follow the :doc:`/examples`.
-
-__ https://glass.readthedocs.io/projects/examples/stable

--- a/docs/manual/first-steps.rst
+++ b/docs/manual/first-steps.rst
@@ -3,4 +3,4 @@ First steps
 
 The best way to get started with *GLASS* is to follow the examples__.
 
-__ https://glass.readthedocs.io/projects/examples/
+__ https://glass.readthedocs.io/projects/examples/stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test = [
 
 [project.urls]
 Changelog = "https://glass.readthedocs.io/stable/manual/releases.html"
-Documentation = "https://glass.readthedocs.io/"
+Documentation = "https://glass.readthedocs.io/stable"
 Homepage = "https://github.com/glass-dev/glass"
 Issues = "https://github.com/glass-dev/glass/issues"
 


### PR DESCRIPTION
Closes #286. Upon building the `sdist` we can replace `stable` with the relevant tag.

Have also used `stable` as the default throughout. This wasn't possible when issue #286 was created, as the `stable` tag didn't exist.