### PR TITLE
gh-421: fix TestPyPI deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,16 @@ jobs:
     needs: dist
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.event_name == 'release' && 'publish' || 'test-publish' }}
+      name: >-
+        ${{ (github.event_name == 'release' &&
+         github.event.action == 'published') &&
+         'publish' ||
+         'test-publish' }}
       url: >-
-        ${{ github.event_name == 'release' && 'https://pypi.org/project/glass'
-        || 'https://test.pypi.org/project/glass' }}
+        ${{ (github.event_name == 'release' &&
+         github.event.action == 'published') &&
+         'https://pypi.org/project/glass' ||
+         'https://test.pypi.org/project/glass' }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
         run: ls -l dist/
 
       - name: Publish to PyPI
-        if: github.event_name == 'release'
+        if: >-
+          github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish to TestPyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,10 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      target:
-        default: testpypi
-        description: Deployment target. Can be pypi or testpypi.
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   dist:
@@ -36,8 +32,10 @@ jobs:
     needs: dist
     runs-on: ubuntu-latest
     environment:
-      name: publish
-      url: https://pypi.org/p/glass
+      name: ${{ github.event_name == 'release' && 'publish' || 'test-publish' }}
+      url: >-
+        ${{ github.event_name == 'release' && 'https://pypi.org/project/glass'
+        || 'https://test.pypi.org/project/glass' }}
     permissions:
       id-token: write
     steps:
@@ -51,13 +49,11 @@ jobs:
         run: ls -l dist/
 
       - name: Publish to PyPI
-        if: >-
-          github.event.inputs.target == 'pypi' || (github.event_name ==
-          'release' && github.event.action == 'published')
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish to TestPyPI
-        if: github.event.inputs.target == 'testpypi'
+        if: github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Closes #421. Allows one to use `workflow_dispatch` to deploy the current setup to TestPyPI, this should allow us to test things work as expected.

However, it still ensures that the `publish` workflow is still protected by the GitHub environment. This is achieved by changing the name of the job to `test-publish` when called with called by `workflow_dispatch`.