### PR TITLE
gh-418: add variable names for `Yields` vars

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -62,7 +62,12 @@ def iternorm(
 
     Yields
     ------
-        The index, vector, and standard deviation for iterative sampling.
+    index
+        The index for iterative sampling.
+    vector
+        The vector for iterative sampling.
+    standard_deviation
+        The standard deviation for iterative sampling.
 
     Raises
     ------
@@ -144,6 +149,7 @@ def cls2cov(
 
     Yields
     ------
+    matrix
         The covariance matrix for iterative sampling.
 
     Raises
@@ -361,6 +367,7 @@ def generate_gaussian(
 
     Yields
     ------
+    fields
         The Gaussian random fields.
 
     Raises
@@ -450,6 +457,7 @@ def generate_lognormal(
 
     Yields
     ------
+    fields
         The lognormal random fields.
 
     """

--- a/glass/points.py
+++ b/glass/points.py
@@ -342,11 +342,11 @@ def uniform_positions(
 
     Yields
     ------
-    lon:
+    lon
         Columns of longitudes for the sampled points.
-    lat:
+    lat
         Columns of latitudes for the sampled points.
-    count:
+    count
         The number of sampled points. For array inputs, an array of
         counts with the same shape is returned.
 

--- a/glass/user.py
+++ b/glass/user.py
@@ -190,6 +190,7 @@ def write_catalog(
 
     Yields
     ------
+    writer
         The writer object.
 
     """


### PR DESCRIPTION
Closes #418. Without these names, they render as "special-cased".