### PR TITLE
gh-430: fix for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Replace stable version with the release version
+        if: github.event_name == 'release' && github.event.action == 'published'
         run: |-
           # store the release tag
           tag="${{ github.ref_name }}"
@@ -35,6 +36,9 @@ jobs:
             --expression "$badge_pattern" \
             --expression "$url_pattern" \
             ${{ github.workspace }}/README.md
+
+          # store the tag since the git checkout is now dirty
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${tag}" >> $GITHUB_ENV
 
       - name: Build SDist and wheel
         run: pipx run build


### PR DESCRIPTION
This should fix the release action. The git tag is stored into the environment after the README.md is made dirty, where setuptools-scm picks it up as the current version.

Closes: #430