### PR TITLE
gh-431: switch from `license.file` to `license.text`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ maintainers = [
 name = "glass"
 readme = "README.md"
 requires-python = ">=3.9"
-license.file = "LICENSE"
+license.text = "MIT License"
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
From https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the classifiers starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)