### PR TITLE
gh-447: make sure `dz` gives the same results as `nbins`

### DIFF
--- a/glass/observations.py
+++ b/glass/observations.py
@@ -226,7 +226,7 @@ def fixed_zbins(
     if nbins is not None and dz is None:
         zbinedges = np.linspace(zmin, zmax, nbins + 1)
     elif nbins is None and dz is not None:
-        zbinedges = np.arange(zmin, zmax + dz, dz)
+        zbinedges = np.arange(zmin, np.nextafter(zmax + dz, zmax), dz)
     else:
         msg = "exactly one of nbins and dz must be given"
         raise ValueError(msg)

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -226,7 +226,7 @@ def fixed_zbins(
     if nbins is not None and dz is None:
         zbinedges = np.linspace(zmin, zmax, nbins + 1)
     elif nbins is None and dz is not None:
-        zbinedges = np.arange(zmin, zmax, dz)
+        zbinedges = np.arange(zmin, zmax + dz, dz)
     else:
         msg = "exactly one of nbins and dz must be given"
         raise ValueError(msg)


### PR DESCRIPTION
Closes #447. Discovered in #436.

> Values are generated within the half-open interval [start, stop)

Due to the use of `np.arange` one needs to add the step to `zmax` in the function call.