### PR TITLE
gh-275: add tests for `glass.lensing`

### DIFF
--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -10,55 +10,22 @@ from glass import (
     MultiPlaneConvergence,
     RadialWindow,
     deflect,
+    from_convergence,  # noqa: F401
     multi_plane_matrix,
     multi_plane_weights,
+    shear_from_convergence,  # noqa: F401
 )
 
 if typing.TYPE_CHECKING:
     from cosmology import Cosmology
 
 
-@pytest.mark.parametrize("usecomplex", [True, False])
-def test_deflect_nsew(usecomplex: bool) -> None:  # noqa: FBT001
-    d = 5.0
-    r = np.radians(d)
-
-    def alpha(re: float, im: float, *, usecomplex: bool) -> complex | list[float]:
-        return re + 1j * im if usecomplex else [re, im]
-
-    # north
-    lon, lat = deflect(0.0, 0.0, alpha(r, 0, usecomplex=usecomplex))
-    np.testing.assert_allclose([lon, lat], [0.0, d], atol=1e-15)
-
-    # south
-    lon, lat = deflect(0.0, 0.0, alpha(-r, 0, usecomplex=usecomplex))
-    np.testing.assert_allclose([lon, lat], [0.0, -d], atol=1e-15)
-
-    # east
-    lon, lat = deflect(0.0, 0.0, alpha(0, r, usecomplex=usecomplex))
-    np.testing.assert_allclose([lon, lat], [-d, 0.0], atol=1e-15)
-
-    # west
-    lon, lat = deflect(0.0, 0.0, alpha(0, -r, usecomplex=usecomplex))
-    np.testing.assert_allclose([lon, lat], [d, 0.0], atol=1e-15)
+def test_from_convergence() -> None:
+    """Add unit tests for :func:`from_convergence`."""
 
 
-def test_deflect_many(rng: np.random.Generator) -> None:
-    n = 1000
-    abs_alpha = rng.uniform(0, 2 * np.pi, size=n)
-    arg_alpha = rng.uniform(-np.pi, np.pi, size=n)
-
-    lon_ = np.degrees(rng.uniform(-np.pi, np.pi, size=n))
-    lat_ = np.degrees(np.arcsin(rng.uniform(-1, 1, size=n)))
-
-    lon, lat = deflect(lon_, lat_, abs_alpha * np.exp(1j * arg_alpha))
-
-    x_, y_, z_ = healpix.ang2vec(lon_, lat_, lonlat=True)
-    x, y, z = healpix.ang2vec(lon, lat, lonlat=True)
-
-    dotp = x * x_ + y * y_ + z * z_
-
-    np.testing.assert_allclose(dotp, np.cos(abs_alpha))
+def test_shear_from_convergence() -> None:
+    """Add unit tests for :func:`shear_from_convergence`."""
 
 
 def test_multi_plane_matrix(
@@ -107,3 +74,46 @@ def test_multi_plane_weights(
     wmat = multi_plane_weights(weights, shells, cosmo)
 
     np.testing.assert_allclose(np.einsum("ij,ik", wmat, deltas), kappa)
+
+
+@pytest.mark.parametrize("usecomplex", [True, False])
+def test_deflect_nsew(usecomplex: bool) -> None:  # noqa: FBT001
+    d = 5.0
+    r = np.radians(d)
+
+    def alpha(re: float, im: float, *, usecomplex: bool) -> complex | list[float]:
+        return re + 1j * im if usecomplex else [re, im]
+
+    # north
+    lon, lat = deflect(0.0, 0.0, alpha(r, 0, usecomplex=usecomplex))
+    np.testing.assert_allclose([lon, lat], [0.0, d], atol=1e-15)
+
+    # south
+    lon, lat = deflect(0.0, 0.0, alpha(-r, 0, usecomplex=usecomplex))
+    np.testing.assert_allclose([lon, lat], [0.0, -d], atol=1e-15)
+
+    # east
+    lon, lat = deflect(0.0, 0.0, alpha(0, r, usecomplex=usecomplex))
+    np.testing.assert_allclose([lon, lat], [-d, 0.0], atol=1e-15)
+
+    # west
+    lon, lat = deflect(0.0, 0.0, alpha(0, -r, usecomplex=usecomplex))
+    np.testing.assert_allclose([lon, lat], [d, 0.0], atol=1e-15)
+
+
+def test_deflect_many(rng: np.random.Generator) -> None:
+    n = 1000
+    abs_alpha = rng.uniform(0, 2 * np.pi, size=n)
+    arg_alpha = rng.uniform(-np.pi, np.pi, size=n)
+
+    lon_ = np.degrees(rng.uniform(-np.pi, np.pi, size=n))
+    lat_ = np.degrees(np.arcsin(rng.uniform(-1, 1, size=n)))
+
+    lon, lat = deflect(lon_, lat_, abs_alpha * np.exp(1j * arg_alpha))
+
+    x_, y_, z_ = healpix.ang2vec(lon_, lat_, lonlat=True)
+    x, y, z = healpix.ang2vec(lon, lat, lonlat=True)
+
+    dotp = x * x_ + y * y_ + z * z_
+
+    np.testing.assert_allclose(dotp, np.cos(abs_alpha))

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -51,11 +51,9 @@ def test_from_convergence(rng: np.random.Generator) -> None:
     np.testing.assert_array_equal(len(results), 2)
 
     results = from_convergence(kappa, deflection=True, shear=True)
-
     np.testing.assert_array_equal(len(results), 2)
 
     results = from_convergence(kappa, potential=True, deflection=True, shear=True)
-
     np.testing.assert_array_equal(len(results), 3)
 
 

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -10,7 +10,7 @@ from glass import (
     MultiPlaneConvergence,
     RadialWindow,
     deflect,
-    from_convergence,  # noqa: F401
+    from_convergence,
     multi_plane_matrix,
     multi_plane_weights,
     shear_from_convergence,  # noqa: F401
@@ -20,8 +20,34 @@ if typing.TYPE_CHECKING:
     from cosmology import Cosmology
 
 
-def test_from_convergence() -> None:
+def test_from_convergence(rng: np.random.Generator) -> None:
     """Add unit tests for :func:`from_convergence`."""
+    # l_max = 32  # noqa: ERA001
+    n_side = 4
+
+    # create a convergence map
+    kappa = rng.integers(10, size=healpix.nside2npix(n_side))
+
+    # check with all False
+
+    results = from_convergence(kappa)
+    np.testing.assert_array_equal(results, ())
+
+    # check all combinations of potential, deflection, shear being True
+
+    results = from_convergence(kappa, potential=True)
+
+    results = from_convergence(kappa, deflection=True)
+
+    results = from_convergence(kappa, shear=True)
+
+    results = from_convergence(kappa, potential=True, deflection=True)
+
+    results = from_convergence(kappa, potential=True, shear=True)
+
+    results = from_convergence(kappa, deflection=True, shear=True)
+
+    results = from_convergence(kappa, potential=True, deflection=True, shear=True)
 
 
 def test_shear_from_convergence() -> None:

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -22,8 +22,8 @@ if typing.TYPE_CHECKING:
 
 def test_from_convergence(rng: np.random.Generator) -> None:
     """Add unit tests for :func:`from_convergence`."""
-    # l_max = 32  # noqa: ERA001
-    n_side = 4
+    # l_max = 100  # noqa: ERA001
+    n_side = 32
 
     # create a convergence map
     kappa = rng.integers(10, size=healpix.nside2npix(n_side))
@@ -36,18 +36,27 @@ def test_from_convergence(rng: np.random.Generator) -> None:
     # check all combinations of potential, deflection, shear being True
 
     results = from_convergence(kappa, potential=True)
+    np.testing.assert_array_equal(len(results), 1)
 
     results = from_convergence(kappa, deflection=True)
+    np.testing.assert_array_equal(len(results), 1)
 
     results = from_convergence(kappa, shear=True)
+    np.testing.assert_array_equal(len(results), 1)
 
     results = from_convergence(kappa, potential=True, deflection=True)
+    np.testing.assert_array_equal(len(results), 2)
 
     results = from_convergence(kappa, potential=True, shear=True)
+    np.testing.assert_array_equal(len(results), 2)
 
     results = from_convergence(kappa, deflection=True, shear=True)
 
+    np.testing.assert_array_equal(len(results), 2)
+
     results = from_convergence(kappa, potential=True, deflection=True, shear=True)
+
+    np.testing.assert_array_equal(len(results), 3)
 
 
 def test_shear_from_convergence() -> None:

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -1,3 +1,4 @@
+import healpix
 import numpy as np
 import pytest
 
@@ -9,7 +10,6 @@ from glass import (
     tomo_nz_gausserr,
     vmap_galactic_ecliptic,
 )
-import healpix
 
 
 def test_vmap_galactic_ecliptic() -> None:

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -9,6 +9,7 @@ from glass import (
     tomo_nz_gausserr,
     vmap_galactic_ecliptic,
 )
+import healpix
 
 
 def test_vmap_galactic_ecliptic() -> None:
@@ -18,7 +19,7 @@ def test_vmap_galactic_ecliptic() -> None:
     # check shape
 
     vmap = vmap_galactic_ecliptic(n_side)
-    np.testing.assert_array_equal(len(vmap), 12 * n_side**2)
+    np.testing.assert_array_equal(len(vmap), healpix.nside2npix(n_side))
 
     # no rotation
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+import healpix
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -14,7 +15,6 @@ from glass import (
     positions_from_delta,
     uniform_positions,
 )
-import healpix
 
 if typing.TYPE_CHECKING:
     import collections.abc

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -14,6 +14,7 @@ from glass import (
     positions_from_delta,
     uniform_positions,
 )
+import healpix
 
 if typing.TYPE_CHECKING:
     import collections.abc
@@ -115,7 +116,7 @@ def test_loglinear_bias(rng: np.random.Generator) -> None:
 def test_positions_from_delta(rng: np.random.Generator) -> None:  # noqa: PLR0915
     # create maps that saturate the batching in the function
     nside = 128
-    npix = 12 * nside**2
+    npix = healpix.nside2npix(nside)
 
     # case: single-dimensional input
 


### PR DESCRIPTION
Closes #275. Adds tests for the `glass.shells` module. Coverage going up - 88.9%.

Worked on this before the pause. Can't remember where I got to, but makes sense to merge. We can always improve the tests later.