### PR TITLE
gh-453: don't run PR title checker on dependabot PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check-pr-title:
-    if: github.actor != 'pre-commit-ci[bot]'
+    if: github.actor != 'pre-commit-ci[bot]' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Enfore PR title format

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   check-pr-title:
-    if: github.actor != 'pre-commit-ci[bot]' && github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'pre-commit-ci[bot]' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Enfore PR title format


### PR DESCRIPTION
Dependabot PRs will now be ignore in the workflow.

Fixes: #453