### PR TITLE
gh-460: update notebooks inplace when running nox -s examples

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -72,6 +72,7 @@ def examples(session: nox.Session) -> None:
         session.run(
             "jupyter",
             "execute",
+            "--inplace",
             *Path().glob("examples/**/*.ipynb"),
             *session.posargs,
         )


### PR DESCRIPTION
`nox -s examples` now updates the notebooks inplace.

Closes: #460 