### PR TITLE
gh-424: add a simple PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Description
+
+<!-- describe you changes here
+make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
+solving -->
+
+<!-- for user facing bugs -->
+<!-- Fixes: # (issue) -->
+
+<!-- for other issues -->
+<!-- Closes: # (issue) -->
+
+<!-- referring some issue -->
+<!-- Refs: # (issue) -->
+
+## Changelog entry
+
+<!-- add a one liner changelog entry here if this PR makes any user-facing change
+Added: Some new feature
+Changed: Some change in existing functionality
+Deprecated: Some soon-to-be removed feature
+Removed: Some now removed feature
+Fixed: Some bug fix
+Security: Some vulnerability was fixed
+-->
+
+## Checks
+
+- [ ] Is your code passing linting?
+- [ ] Is your code passing tests?
+- [ ] Have you added additional tests (if required)?
+- [ ] Have you modified/extended the documentation (if required)?
+- [ ] Have you added a one-liner changelog entry above (if required)?


### PR DESCRIPTION
Adds a PR template to make the CHANGELOG compiling process easier.

Closes: #424 