### PR TITLE
Fix Sphinx configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,3 +12,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Fixes #472. According to this [blog post](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config) it is required to specify the configuration file.