### PR TITLE
gh-469: @pre-commit.ci shouldn't break title checking

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,8 +12,9 @@ on:
 
 jobs:
   check-pr-title:
-    if:
-      github.actor != 'pre-commit-ci[bot]' || github.actor != 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login != 'pre-commit-ci[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Enforce PR title format

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
       github.actor != 'pre-commit-ci[bot]' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Enfore PR title format
+      - name: Enforce PR title format
         uses: thehanimo/pr-title-checker@v1.4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check-pr-title:
     if:
-      github.actor != 'pre-commit-ci[bot]' && github.actor != 'dependabot[bot]'
+      github.actor != 'pre-commit-ci[bot]' || github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Enforce PR title format


### PR DESCRIPTION
Fixes #469. In https://github.com/glass-dev/glass/pull/467 the title workflow was successfully skipped, but then I made a change and it failed. The check should be changed for the PR author instead using `github.event.pull_request.user.login`.