### PR TITLE
gh-465: enable installing glass through git archives

### DIFF
--- a/git_archival.txt
+++ b/git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/gitattributes.txt
+++ b/gitattributes.txt
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst


### PR DESCRIPTION
This is required if glass is installed through the files in GitHub releases.

Closes: #465 