### PR TITLE
gh-506: cache dependencies correctly

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -32,18 +32,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache nox
-        uses: actions/cache@v4
-        with:
-          key: test-${{ hashFiles('pyproject.toml') }}
-          path: .nox
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           cache-dependency-path: pyproject.toml
           cache: pip
           python-version: 3.x
+
+      - name: Cache nox
+        uses: actions/cache@v4
+        with:
+          key:
+            examples-${{ hashFiles('pyproject.toml') }}-${{
+            hashFiles('noxfile.py') }}-${{ env.pythonLocation }}
+          path: .nox
 
       - name: Install nox
         run: python -m pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,18 +35,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache nox
-        uses: actions/cache@v4
-        with:
-          key: test-${{ hashFiles('pyproject.toml') }}-${{ env.pythonLocation }}
-          path: .nox
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           cache-dependency-path: pyproject.toml
           cache: pip
           python-version: ${{ matrix.python-version }}
+
+      - name: Cache nox
+        uses: actions/cache@v4
+        with:
+          key:
+            tests-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('noxfile.py')
+            }}-${{ env.pythonLocation }}
+          path: .nox
 
       - name: Install nox and coverage.py
         run: python -m pip install coverage[toml] nox


### PR DESCRIPTION
# Description

- The nox environment should be cached after setup-python cache (as setup-python exposes env.pythonLocation which is used in nox cache)
- noxfile's hash should be used in the key while caching nox environments
- env.pythonLocation should be used in the cache key to not confuse the runners between system-wide and environment-specific python

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #506 

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

<!-- add a one liner changelog entry here if this PR makes any user-facing change
Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [X] Have you added additional tests (if required)?
- [X] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
