### PR TITLE
gh-491: use try-except for __version__

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -63,11 +63,10 @@ __all__ = [
 ]
 
 
-import contextlib
-from importlib.metadata import PackageNotFoundError
-
-with contextlib.suppress(PackageNotFoundError):
-    from ._version import __version__, __version_tuple__
+try:  # noqa: SIM105
+    from ._version import __version__
+except ModuleNotFoundError:
+    pass
 
 # modules
 from glass import grf


### PR DESCRIPTION
# Description

Use a `try-except` block instead of `contextlib.suppress` so that the `glass` namespace is not polluted.

Also, the error we should be looking for is `ModuleNotFoundError` and not `PackageNotFoundError`.

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #491

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

<!-- add a one liner changelog entry here if this PR makes any user-facing change
Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
