### PR TITLE
gh-480: fix union1d typing error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
       - id: mypy
         files: ^glass/
         additional_dependencies:
-          - numpy>=2.2.2
+          - numpy>=2.2.3
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -569,7 +569,7 @@ def partition_lstsq(
     # compute the union of all given redshift grids
     zp = z
     for w in shells:
-        zp = np.union1d(zp, w.za)  # type: ignore[assignment]
+        zp = np.union1d(zp, w.za)
 
     # get extra leading axes of fz
     *dims, _ = np.shape(fz)
@@ -633,7 +633,7 @@ def partition_nnls(
     # compute the union of all given redshift grids
     zp = z
     for w in shells:
-        zp = np.union1d(zp, w.za)  # type: ignore[assignment]
+        zp = np.union1d(zp, w.za)
 
     # get extra leading axes of fz
     *dims, _ = np.shape(fz)


### PR DESCRIPTION
# Description

NumPy 2.2.3 fixes the return signature of `union1d`. See https://github.com/numpy/numpy/issues/28239 for more discussion.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #480 

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

<!-- add a one liner changelog entry here if this PR makes any user-facing change
Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
