### PR TITLE
gh-509: new inv_triangle_number popped up in another PR

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -308,7 +308,7 @@ def lognormal_gls(
         The Gaussian angular power spectra for a lognormal random field.
 
     """
-    n = inv_triangle_number(len(cls))
+    n = nfields_from_nspectra(len(cls))
     fields = [glass.grf.Lognormal(shift) for _ in range(n)]
     return solve_gaussian_spectra(fields, cls)
 
@@ -457,7 +457,7 @@ def generate_gaussian(
         If all gls are empty.
 
     """
-    n = inv_triangle_number(len(gls))
+    n = nfields_from_nspectra(len(gls))
     fields = [glass.grf.Normal() for _ in range(n)]
     yield from generate(fields, gls, nside, ncorr=ncorr, rng=rng)
 
@@ -497,7 +497,7 @@ def generate_lognormal(
         The lognormal random fields.
 
     """
-    n = inv_triangle_number(len(gls))
+    n = nfields_from_nspectra(len(gls))
     fields = [glass.grf.Lognormal(shift) for _ in range(n)]
     yield from generate(fields, gls, nside, ncorr=ncorr, rng=rng)
 


### PR DESCRIPTION
# Description

My bad. #523 introduced some occurrences of `inv_triangle_number` which went unnoticed. Prime example of why you should make your PRs "up-to-date" before merging.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
Refs: #509

## Changelog entry

<!-- add a one liner changelog entry here if this PR makes any user-facing change
Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [X] Have you added additional tests (if required)?
- [X] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
