### PR TITLE
gh-530: more permissive typing of GLASS/HEALPix order functions

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -17,12 +17,14 @@ import glass.grf
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
-    from typing import Any, Literal
+    from typing import Any, Literal, TypeVar
 
     from numpy.typing import NDArray
 
     Fields = Sequence[glass.grf.Transformation]
     Cls = Sequence[NDArray[Any]]
+
+    T = TypeVar("T")
 
 try:
     from warnings import deprecated  # type: ignore[attr-defined]
@@ -855,7 +857,7 @@ def generate(
         yield t(x, var)
 
 
-def glass_to_healpix_spectra(spectra: Cls) -> Cls:
+def glass_to_healpix_spectra(spectra: Sequence[T]) -> list[T]:
     """
     Reorder spectra from GLASS to HEALPix order.
 
@@ -878,7 +880,7 @@ def glass_to_healpix_spectra(spectra: Cls) -> Cls:
     return [spectra[comb.index((i + k, i))] for k in range(n) for i in range(n - k)]
 
 
-def healpix_to_glass_spectra(spectra: Cls) -> Cls:
+def healpix_to_glass_spectra(spectra: Sequence[T]) -> list[T]:
     """
     Reorder spectra from HEALPix to GLASS order.
 


### PR DESCRIPTION
# Description

Update the type annotation of `glass_to_healpix_spectra()` and `healpix_to_glass_spectra()` to reflect they work with arbitrary sequences.

Closes: #530

## Changelog entry

Changed: more permissive type hints for `glass_to_healpix_spectra()` and `healpix_to_glass_spectra()`

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
