### PR TITLE
gh-540: add all contributors config

### DIFF
--- a/.all-contributorsrc.json
+++ b/.all-contributorsrc.json
@@ -1,5 +1,7 @@
 {
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"https://images.weserv.nl/?url=<%= contributor.avatar_url %>&h=<%= options.imageSize %>&w=<%= options.imageSize %>&fit=cover&mask=circle&maxage=7d\" alt=\"<%= contributor.name %>\"/>",
   "linkToUsage": false,
   "projectName": "glass",
-  "projectOwner": "glass-dev"
+  "projectOwner": "glass-dev",
+  "wrapperTemplate": "<p><%= bodyContent %></p>"
 }

--- a/.all-contributorsrc.json
+++ b/.all-contributorsrc.json
@@ -1,0 +1,4 @@
+{
+  "projectName": "glass",
+  "projectOwner": "glass-dev"
+}

--- a/.all-contributorsrc.json
+++ b/.all-contributorsrc.json
@@ -1,4 +1,5 @@
 {
+  "linkToUsage": false,
   "projectName": "glass",
   "projectOwner": "glass-dev"
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 [![GitHub Discussions](https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github)](https://github.com/orgs/glass-dev/discussions)
 [![Slack](https://img.shields.io/badge/join-Slack-4A154B)](https://glass-dev.github.io/slack)
-[![All Contributors](https://img.shields.io/github/all-contributors/projectOwner/projectName?color=ee8449&style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/glass-dev/glass?color=ee8449&style=flat-square)](#contributors)
 
 This is the core library for GLASS, the Generator for Large Scale Structure. For
 more information, see the full [documentation]. There are a number of [examples]

--- a/README.md
+++ b/README.md
@@ -91,3 +91,14 @@ We also have a public [Slack workspace] for discussions about the project.
 [examples]: https://glass.readthedocs.io/stable/examples.html
 [Discussions]: https://github.com/orgs/glass-dev/discussions
 [Slack workspace]: https://glass-dev.github.io/slack
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 [![GitHub Discussions](https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github)](https://github.com/orgs/glass-dev/discussions)
 [![Slack](https://img.shields.io/badge/join-Slack-4A154B)](https://glass-dev.github.io/slack)
+[![All Contributors](https://img.shields.io/github/all-contributors/projectOwner/projectName?color=ee8449&style=flat-square)](#contributors)
 
 This is the core library for GLASS, the Generator for Large Scale Structure. For
 more information, see the full [documentation]. There are a number of [examples]


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
This adds https://github.com/all-contributors/all-contributors as a way to add contributors to the README. As per request, I have taken inspiration from this discussion https://github.com/all-contributors/all-contributors/issues/85 for a minimal configuration. Specifically, this repository has an example that I think satisfies the requirement https://github.com/jdalrymple/gitbeaker. In particular, [these template lines](https://github.com/jdalrymple/gitbeaker/blob/cccf261448125d94ce26258ed7e5599a35463733/.all-contributorsrc#L15-L17). This will take a bit of experimenting.

@ntessore as per the docs https://allcontributors.org/docs/en/bot/installation can you install the app https://github.com/apps/allcontributors/installations/select_target for this repository?

I think to then add people we can do in issues/PRs, i.e.

> @all-contributors please add @ntessore for code

it doesn't matter what the `<contributions` here is, `code` is just an example. Whatever it is should be suppressed using the templates. 

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #520

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Added: A list of contributors to the project README

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
