### PR TITLE
gh-547: comment out CHANGELOG entry by default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,9 @@ solving -->
 <!-- referring some issue -->
 <!-- Refs: # (issue) -->
 
+<!-- add a one liner changelog entry here if this PR makes any user-facing change
 ## Changelog entry
 
-<!-- add a one liner changelog entry here if this PR makes any user-facing change
 Added: Some new feature
 Changed: Some change in existing functionality
 Deprecated: Some soon-to-be removed feature


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
Hides the CHANGELOG entry by default.

<!-- for user facing bugs -->
Fixes: #547

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
