### PR TITLE
gh-558: regenerate contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ We also have a public [Slack workspace] for discussions about the project.
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
-<table>
-  <tbody>
+<p>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://ntessore.page"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/3993688?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Nicolas Tessore"/></td>
       <td align="center" valign="top" width="14.28%"><a href="https://paddyroddy.github.io"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/15052188?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Patrick J. Roddy"/></td>
@@ -108,11 +107,12 @@ We also have a public [Slack workspace] for discussions about the project.
       <td align="center" valign="top" width="14.28%"><a href="http://arthurmloureiro.github.io"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/6471279?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Arthur Loureiro"/></td>
       <td align="center" valign="top" width="14.28%"><a href="https://mwiet.github.io"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/49800039?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Maximilian von Wietersheim-Kramsta"/></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/joachimi"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/4989590?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="joachimi"/></td>
+    </tr><br />
+    <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://nialljeffrey.github.io/"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/15345794?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Niall Jeffrey"/></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ARCHER2-HPC"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/60643641?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="ARCHER2, UK National Supercomputing Service"/></td>
     </tr>
-  </tbody>
-</table>
+</p>
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ We also have a public [Slack workspace] for discussions about the project.
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
-<p>
+<table>
+  <tbody>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://ntessore.page"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/3993688?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Nicolas Tessore"/></td>
       <td align="center" valign="top" width="14.28%"><a href="https://paddyroddy.github.io"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/15052188?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Patrick J. Roddy"/></td>
@@ -112,7 +113,8 @@ We also have a public [Slack workspace] for discussions about the project.
       <td align="center" valign="top" width="14.28%"><a href="https://nialljeffrey.github.io/"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/15345794?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="Niall Jeffrey"/></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ARCHER2-HPC"><img src="https://images.weserv.nl/?url=https://avatars.githubusercontent.com/u/60643641?v=4&h=100&w=100&fit=cover&mask=circle&maxage=7d" alt="ARCHER2, UK National Supercomputing Service"/></td>
     </tr>
-</p>
+  </tbody>
+</table>
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
# Description

Regenerated the table using `yarn all-contributors generate`.

I am guessing this happened because we triggered several bot requests, and the bot added every new person in the first row and the last column of the table. Ideally, this should not happen again, give that running the CLI locally fixed it.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #558

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
