### PR TITLE
gh-569: enforce large file check with exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,13 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
+        args:
+          - --enforce-all
+        exclude: |-
+          (?x)^(
+            docs/_static/.*\.png|
+            examples/.*\.ipynb
+          )$
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
Currently, the large file @pre-commit check only runs when that file is first added. This changes it to always run, which could be useful if something got snuck in.

As per suggestion, I have excluded `.ipynb` in the `examples` folder. I have also excluded `.png` from `docs/_static` as we already have some that are over (narrowly).

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #569

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
