### PR TITLE
gh-575: bring back inv_triangle_number

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -51,6 +51,16 @@ except ImportError:
         return decorator
 
 
+def _is_inv_triangle_number(triangle_number: int) -> tuple[int, bool]:
+    r"""
+    The :math:`n`-th triangle number is :math:`T_n = n \, (n+1)/2`.  If
+    the argument is :math:`T_n`, then :math:`n` is returned. Otherwise,
+    a :class:`ValueError` is raised.
+    """
+    n = math.floor(math.sqrt(2 * triangle_number))
+    return n, n * (n + 1) // 2 == triangle_number
+
+
 def nfields_from_nspectra(nspectra: int) -> int:
     r"""
     Returns the number of fields for a number of spectra.
@@ -58,8 +68,8 @@ def nfields_from_nspectra(nspectra: int) -> int:
     Given the number of spectra *nspectra*, returns the number of
     fields *n* such that ``n * (n + 1) // 2 == nspectra``.
     """
-    n = math.floor(math.sqrt(2 * nspectra))
-    if n * (n + 1) // 2 != nspectra:
+    n, is_inv_triangle = _is_inv_triangle_number(nspectra)
+    if not is_inv_triangle:
         msg = f"invalid number of spectra: {nspectra}"
         raise ValueError(msg)
     return n

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -404,6 +404,18 @@ def test_getcl() -> None:
             np.testing.assert_array_equal(result[2:], expected)
 
 
+def test_is_inv_triangle_number():
+    for n in range(10_000):
+        new_n, _ = glass.fields._is_inv_triangle_number(n * (n + 1) // 2)
+        assert new_n == n
+
+    not_triangle_numbers = [2, 4, 5, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19, 20]
+
+    for t in not_triangle_numbers:
+        _, _is_inv_triangle = glass.fields._is_inv_triangle_number(t)
+        assert not _is_inv_triangle
+
+
 def test_nfields_from_nspectra():
     for n in range(10_000):
         assert glass.nfields_from_nspectra(n * (n + 1) // 2) == n


### PR DESCRIPTION
# Description

Add `_is_inv_triangle_number` to check for triangle numbers and use it internally in `nfields_from_nspectra`.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #575

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [X] Have you added additional tests (if required)?
- [X] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
