### PR TITLE
gh-578: mutable argument should be empty list rather than `None`

### DIFF
--- a/examples/2-advanced/legacy-mode.ipynb
+++ b/examples/2-advanced/legacy-mode.ipynb
@@ -63,6 +63,9 @@
    "outputs": [],
    "source": [
     "def plot_spectra(*spectra, labels=None, log=True):\n",
+    "    if labels is None:\n",
+    "        labels = []\n",
+    "\n",
     "    nspec = max(len(cls) for cls in spectra)\n",
     "    nfields = glass.nfields_from_nspectra(nspec)\n",
     "    fig, ax = plt.subplots(\n",


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
The `labels` argument was initially set to `[]` which is bad practice https://docs.astral.sh/ruff/rules/mutable-argument-default. This should be set to `None` and then within the function should be set to the initial empty list.

<!-- for user facing bugs -->
Fixes: #578

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: A mutable argument bug in the legacy mode notebook

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
