### PR TITLE
gh-580: examples should run in the CI if they are modified

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,11 +5,13 @@ on:
   push:
     paths:
       - glass/**
+      - examples/**
     branches:
       - main
   pull_request:
     paths:
       - glass/**
+      - examples/**
     types:
       - opened
       - ready_for_review


### PR DESCRIPTION
# Description

At the moment, the example notebooks do not run in the CI if files in the `examples/` directory are modified.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #580

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
