### PR TITLE
gh-571: add a 20 min timeout to example runs

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Run examples
         run: nox -s examples
+        timeout-minutes: 20
         env:
           FORCE_COLOR: 1
 


### PR DESCRIPTION
# Description

The examples roughly take 12-13 minutes to run. A 20 minutes timeout on this particular step should be good!

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #571

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
