### PR TITLE
gh-568: convert `_weight` funcs to classes for `_windows` funcs

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -1,6 +1,7 @@
 """GLASS package."""
 
 __all__ = [
+    "DensityWeight",
     "DistanceWeight",
     "MultiPlaneConvergence",
     "RadialWindow",
@@ -13,7 +14,6 @@ __all__ = [
     "cov_from_spectra",
     "cubic_windows",
     "deflect",
-    "density_weight",
     "discretized_cls",
     "distance_grid",
     "effective_bias",
@@ -137,12 +137,12 @@ from glass.shapes import (
     triaxial_axis_ratio,
 )
 from glass.shells import (
+    DensityWeight,
     DistanceWeight,
     RadialWindow,
     VolumeWeight,
     combine,
     cubic_windows,
-    density_weight,
     distance_grid,
     linear_windows,
     partition,

--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "DistanceWeight",
     "MultiPlaneConvergence",
     "RadialWindow",
+    "VolumeWeight",
     "algorithm",
     "check_posdef_spectra",
     "cls2cov",
@@ -64,7 +65,6 @@ __all__ = [
     "triaxial_axis_ratio",
     "uniform_positions",
     "vmap_galactic_ecliptic",
-    "volume_weight",
     "write_catalog",
 ]
 
@@ -139,6 +139,7 @@ from glass.shapes import (
 from glass.shells import (
     DistanceWeight,
     RadialWindow,
+    VolumeWeight,
     combine,
     cubic_windows,
     density_weight,
@@ -148,6 +149,5 @@ from glass.shells import (
     redshift_grid,
     restrict,
     tophat_windows,
-    volume_weight,
 )
 from glass.user import load_cls, save_cls, write_catalog

--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -1,6 +1,7 @@
 """GLASS package."""
 
 __all__ = [
+    "DistanceWeight",
     "MultiPlaneConvergence",
     "RadialWindow",
     "algorithm",
@@ -14,7 +15,6 @@ __all__ = [
     "density_weight",
     "discretized_cls",
     "distance_grid",
-    "distance_weight",
     "effective_bias",
     "effective_cls",
     "ellipticity_gaussian",
@@ -137,12 +137,12 @@ from glass.shapes import (
     triaxial_axis_ratio,
 )
 from glass.shells import (
+    DistanceWeight,
     RadialWindow,
     combine,
     cubic_windows,
     density_weight,
     distance_grid,
-    distance_weight,
     linear_windows,
     partition,
     redshift_grid,

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -39,7 +39,7 @@ Weight functions
 
 .. autoclass:: DistanceWeight
 .. autoclass:: VolumeWeight
-.. autofunction:: DensityWeight
+.. autoclass:: DensityWeight
 
 """  # noqa: D400
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -39,7 +39,7 @@ Weight functions
 
 .. autoclass:: DistanceWeight
 .. autoclass:: VolumeWeight
-.. autofunction:: density_weight
+.. autofunction:: DensityWeight
 
 """  # noqa: D400
 
@@ -126,26 +126,35 @@ class VolumeWeight:
         return self.cosmo.xm(z) ** 2 / self.cosmo.ef(z)  # type: ignore[no-any-return]
 
 
-def density_weight(
-    z: NDArray[np.float64],
-    cosmo: Cosmology,
-) -> NDArray[np.float64]:
+@dataclasses.dataclass
+class DensityWeight:
     """
     Uniform weight in matter density.
 
-    Parameters
+    Attributes
     ----------
-    z
-        The redshifts at which to evaluate the weight.
     cosmo
         Cosmology instance.
 
-    Returns
-    -------
-        The weight function evaluated at redshifts *z*.
-
     """
-    return cosmo.rho_m_z(z) * cosmo.xm(z) ** 2 / cosmo.ef(z)  # type: ignore[no-any-return]
+
+    cosmo: Cosmology
+
+    def __call__(self, z: NDArray[np.float64]) -> NDArray[np.float64]:
+        """
+        Uniform weight in comoving distance.
+
+        Parameters
+        ----------
+        z
+            The redshifts at which to evaluate the weight.
+
+        Returns
+        -------
+            The weight function evaluated at redshifts *z*.
+
+        """
+        return self.cosmo.rho_m_z(z) * self.cosmo.xm(z) ** 2 / self.cosmo.ef(z)  # type: ignore[no-any-return]
 
 
 class RadialWindow(NamedTuple):

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -37,7 +37,7 @@ Redshift grids
 Weight functions
 ----------------
 
-.. autofunction:: distance_weight
+.. autoclass:: DistanceWeight
 .. autofunction:: volume_weight
 .. autofunction:: density_weight
 
@@ -45,6 +45,7 @@ Weight functions
 
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import warnings
 from typing import TYPE_CHECKING, NamedTuple
@@ -65,26 +66,34 @@ if TYPE_CHECKING:
     WeightFunc = Callable[[ArrayLike1D], NDArray[np.float64]]
 
 
-def distance_weight(
-    z: NDArray[np.float64],
-    cosmo: Cosmology,
-) -> NDArray[np.float64]:
-    """
-    Uniform weight in comoving distance.
+@dataclasses.dataclass
+class DistanceWeight:
+    """Uniform weight in comoving distance.
 
-    Parameters
+    Attributes
     ----------
-    z
-        The redshifts at which to evaluate the weight.
     cosmo
         Cosmology instance.
 
-    Returns
-    -------
-        The weight function evaluated at redshifts *z*.
-
     """
-    return 1 / cosmo.ef(z)  # type: ignore[no-any-return]
+
+    cosmo: Cosmology
+
+    def __call__(self, z: NDArray[np.float64]) -> NDArray[np.float64]:
+        """
+        Uniform weight in comoving distance.
+
+        Parameters
+        ----------
+        z
+            The redshifts at which to evaluate the weight.
+
+        Returns
+        -------
+            The weight function evaluated at redshifts *z*.
+
+        """
+        return 1 / self.cosmo.ef(z)  # type: ignore[no-any-return]
 
 
 def volume_weight(

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -38,7 +38,7 @@ Weight functions
 ----------------
 
 .. autoclass:: DistanceWeight
-.. autofunction:: volume_weight
+.. autoclass:: VolumeWeight
 .. autofunction:: density_weight
 
 """  # noqa: D400
@@ -96,26 +96,34 @@ class DistanceWeight:
         return 1 / self.cosmo.ef(z)  # type: ignore[no-any-return]
 
 
-def volume_weight(
-    z: NDArray[np.float64],
-    cosmo: Cosmology,
-) -> NDArray[np.float64]:
-    """
-    Uniform weight in comoving volume.
+@dataclasses.dataclass
+class VolumeWeight:
+    """Uniform weight in comoving volume.
 
-    Parameters
+    Attributes
     ----------
-    z
-        The redshifts at which to evaluate the weight.
     cosmo
         Cosmology instance.
 
-    Returns
-    -------
-        The weight function evaluated at redshifts *z*.
-
     """
-    return cosmo.xm(z) ** 2 / cosmo.ef(z)  # type: ignore[no-any-return]
+
+    cosmo: Cosmology
+
+    def __call__(self, z: NDArray[np.float64]) -> NDArray[np.float64]:
+        """
+        Uniform weight in comoving distance.
+
+        Parameters
+        ----------
+        z
+            The redshifts at which to evaluate the weight.
+
+        Returns
+        -------
+            The weight function evaluated at redshifts *z*.
+
+        """
+        return self.cosmo.xm(z) ** 2 / self.cosmo.ef(z)  # type: ignore[no-any-return]
 
 
 def density_weight(

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -24,13 +24,13 @@ def test_DistanceWeight(cosmo: Cosmology) -> None:  # noqa: N802
     np.testing.assert_array_less(w[1:], w[:-1])
 
 
-def test_volume_weight(cosmo: Cosmology) -> None:
-    """Add unit tests for :func:`glass.volume_weight`."""
+def test_VolumeWeight(cosmo: Cosmology) -> None:  # noqa: N802
+    """Add unit tests for :func:`glass.VolumeWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.volume_weight(z, cosmo)
+    w = glass.VolumeWeight(cosmo)(z)
     np.testing.assert_array_equal(w.shape, z.shape)
 
     # check first value is 0

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -25,7 +25,7 @@ def test_DistanceWeight(cosmo: Cosmology) -> None:  # noqa: N802
 
 
 def test_VolumeWeight(cosmo: Cosmology) -> None:  # noqa: N802
-    """Add unit tests for :func:`glass.VolumeWeight`."""
+    """Add unit tests for :class:`glass.VolumeWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
@@ -61,7 +61,7 @@ def test_DensityWeight(cosmo: Cosmology) -> None:  # noqa: N802
 
 
 def test_tophat_windows() -> None:
-    """Add unit tests for :class:`glass.tophat_windows`."""
+    """Add unit tests for :func:`glass.tophat_windows`."""
     zb = np.array([0.0, 0.1, 0.2, 0.5, 1.0, 2.0])
     dz = 0.005
 

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -42,13 +42,13 @@ def test_VolumeWeight(cosmo: Cosmology) -> None:  # noqa: N802
     np.testing.assert_array_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo: Cosmology) -> None:
-    """Add unit tests for :func:`glass.density_weight`."""
+def test_DensityWeight(cosmo: Cosmology) -> None:  # noqa: N802
+    """Add unit tests for :func:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.density_weight(z, cosmo)
+    w = glass.DensityWeight(cosmo)(z)
     np.testing.assert_array_equal(w.shape, z.shape)
 
     # check first value is 0

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -6,13 +6,13 @@ from cosmology import Cosmology
 import glass
 
 
-def test_distance_weight(cosmo: Cosmology) -> None:
-    """Add unit tests for :func:`glass.distance_weight`."""
+def test_DistanceWeight(cosmo: Cosmology) -> None:  # noqa: N802
+    """Add unit tests for :class:`glass.DistanceWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.distance_weight(z, cosmo)
+    w = glass.DistanceWeight(cosmo)(z)
     np.testing.assert_array_equal(w.shape, z.shape)
 
     # check first value is 1

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -43,7 +43,7 @@ def test_VolumeWeight(cosmo: Cosmology) -> None:  # noqa: N802
 
 
 def test_DensityWeight(cosmo: Cosmology) -> None:  # noqa: N802
-    """Add unit tests for :func:`glass.DensityWeight`."""
+    """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
@@ -61,7 +61,7 @@ def test_DensityWeight(cosmo: Cosmology) -> None:  # noqa: N802
 
 
 def test_tophat_windows() -> None:
-    """Add unit tests for :func:`glass.tophat_windows`."""
+    """Add unit tests for :class:`glass.tophat_windows`."""
     zb = np.array([0.0, 0.1, 0.2, 0.5, 1.0, 2.0])
     dz = 0.005
 

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -6,7 +6,7 @@ from cosmology import Cosmology
 import glass
 
 
-def test_DistanceWeight(cosmo: Cosmology) -> None:  # noqa: N802
+def test_distance_weight(cosmo: Cosmology) -> None:
     """Add unit tests for :class:`glass.DistanceWeight`."""
     z = np.linspace(0, 1, 6)
 
@@ -24,7 +24,7 @@ def test_DistanceWeight(cosmo: Cosmology) -> None:  # noqa: N802
     np.testing.assert_array_less(w[1:], w[:-1])
 
 
-def test_VolumeWeight(cosmo: Cosmology) -> None:  # noqa: N802
+def test_volume_weight(cosmo: Cosmology) -> None:
     """Add unit tests for :class:`glass.VolumeWeight`."""
     z = np.linspace(0, 1, 6)
 
@@ -42,7 +42,7 @@ def test_VolumeWeight(cosmo: Cosmology) -> None:  # noqa: N802
     np.testing.assert_array_less(w[:-1], w[1:])
 
 
-def test_DensityWeight(cosmo: Cosmology) -> None:  # noqa: N802
+def test_density_weight(cosmo: Cosmology) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
The weight functions (`distance_weight`/`volume_weight`/`density_weight`) have been changed to callable classes (`DistanceWeight`/`VolumeWeight`/`DensityWeight`). The logic here being that the weight functions will now have compatible typing signatures to `tophat_windows`/`linear_windows`/`cubic_windows`, which expect `Callable[[ArrayLike1D], NDArray[np.float64]] | None`.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #568

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Changed: The weight functions have been changed to callable classes

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
