### PR TITLE
gh-592: use `--doctest-plus-generate-diff=overwrite`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,7 @@ def coverage(session: nox.Session) -> None:
 def doctests(session: nox.Session) -> None:
     """Run the doctests."""
     session.posargs.append("--doctest-plus")
+    session.posargs.append("--doctest-plus-generate-diff=overwrite")
     session.posargs.append("glass")
     tests(session)
 


### PR DESCRIPTION
# Description

Add `--doctest-plus-generate-diff=overwrite` to the `doctests` Nox session so that the outputs are fixed on the fly.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #592

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
