### PR TITLE
gh-519: test array API compliance of legacy mode functions

### DIFF
--- a/glass/algorithm.py
+++ b/glass/algorithm.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    from jaxtyping import Array
     from numpy.typing import NDArray
 
 
@@ -93,9 +94,9 @@ def nnls(
 
 
 def cov_clip(
-    cov: NDArray[np.float64],
+    cov: NDArray[np.float64] | Array,
     rtol: float | None = None,
-) -> NDArray[np.float64]:
+) -> NDArray[np.float64] | Array:
     """
     Covariance matrix from clipping non-positive eigenvalues.
 
@@ -130,16 +131,15 @@ def cov_clip(
     # put matrix back together
     # enforce symmetry
     v = xp.sqrt(w[..., None, :]) * v
-    cov_clipped: NDArray[np.float64] = xp.matmul(v, xp.matrix_transpose(v))
-    return cov_clipped
+    return xp.matmul(v, xp.matrix_transpose(v))
 
 
 def nearcorr(
-    a: NDArray[np.float64],
+    a: NDArray[np.float64] | Array,
     *,
     tol: float | None = None,
     niter: int = 100,
-) -> NDArray[np.float64]:
+) -> NDArray[np.float64] | Array:
     """
     Compute the nearest correlation matrix.
 
@@ -177,7 +177,7 @@ def nearcorr(
         tol = n * xp.finfo(a.dtype).eps
 
     # current result, flatten leading dimensions
-    y = a.reshape(-1, n, n)
+    y = xp.reshape(a, (-1, n, n))
 
     # initial correction is zero
     ds = xp.zeros_like(a)
@@ -204,14 +204,14 @@ def nearcorr(
             break
 
     # return result in original shape
-    return y.reshape(*dim, n, n)
+    return xp.reshape(y, (*dim, n, n))
 
 
 def cov_nearest(
-    cov: NDArray[np.float64],
+    cov: NDArray[np.float64] | Array,
     tol: float | None = None,
     niter: int = 100,
-) -> NDArray[np.float64]:
+) -> NDArray[np.float64] | Array:
     """
     Covariance matrix from nearest correlation matrix.
 
@@ -245,7 +245,7 @@ def cov_nearest(
         raise ValueError(msg)
 
     # store the normalisation of the matrix
-    norm: NDArray[np.float64] = xp.sqrt(diag)
+    norm = xp.sqrt(diag)
     norm = norm[..., None, :] * norm[..., :, None]
 
     # find nearest correlation matrix

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -46,7 +46,7 @@ def test_nnls(rng: np.random.Generator) -> None:
 
 def test_cov_clip(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     # prepare a random matrix
-    m = xp.asarray(urng.random((4, 4)))
+    m = urng.random((4, 4))
 
     # symmetric matrix
     a = (m + m.T) / 2

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1,5 +1,9 @@
+import types
+
 import numpy as np
 import pytest
+import pytest_mock
+from tests.conftest import array_api_compatible
 
 import glass.algorithm
 
@@ -33,9 +37,10 @@ def test_nnls(rng: np.random.Generator) -> None:
         glass.algorithm.nnls(a.T, b)
 
 
-def test_cov_clip(rng):
+@array_api_compatible
+def test_cov_clip(rng: np.random.Generator, xp: types.ModuleType):
     # prepare a random matrix
-    m = rng.random((4, 4))
+    m = xp.asarray(rng.random((4, 4)))
 
     # symmetric matrix
     a = (m + m.T) / 2
@@ -44,26 +49,27 @@ def test_cov_clip(rng):
     cov = glass.algorithm.cov_clip(a)
 
     # make sure all eigenvalues are positive
-    assert np.all(np.linalg.eigvalsh(cov) >= 0)
+    assert xp.all(xp.linalg.eigvalsh(cov) >= 0)
 
     # fix by clipping negative eigenvalues
     cov = glass.algorithm.cov_clip(a, rtol=1.0)
 
     # make sure all eigenvalues are positive
-    h = np.linalg.eigvalsh(a).max()
-    np.testing.assert_allclose(np.linalg.eigvalsh(cov), h)
+    h = xp.linalg.eigvalsh(a).max()
+    np.testing.assert_allclose(xp.linalg.eigvalsh(cov), h)
 
 
-def test_nearcorr():
+@array_api_compatible
+def test_nearcorr(xp: types.ModuleType):
     # from Higham (2002)
-    a = np.array(
+    a = xp.array(
         [
             [1.0, 1.0, 0.0],
             [1.0, 1.0, 1.0],
             [0.0, 1.0, 1.0],
         ],
     )
-    b = np.array(
+    b = xp.array(
         [
             [1.0000, 0.7607, 0.1573],
             [0.7607, 1.0000, 0.7607],
@@ -84,15 +90,18 @@ def test_nearcorr():
 
     # non-square matrix should raise
     with pytest.raises(ValueError, match="non-square matrix"):
-        glass.algorithm.nearcorr(np.zeros((4, 3)))
+        glass.algorithm.nearcorr(xp.zeros((4, 3)))
 
 
-def test_cov_nearest(rng, mocker):
+@array_api_compatible
+def test_cov_nearest(
+    rng: np.random.Generator, xp: types.ModuleType, mocker: pytest_mock.MockerFixture
+):
     # prepare a random matrix
-    m = rng.random((4, 4))
+    m = xp.asarray(rng.random((4, 4)))
 
     # symmetric matrix
-    a = np.eye(4) + (m + m.T) / 2
+    a = xp.eye(4) + (m + m.T) / 2
 
     # spy on the call to nearcorr
     nearcorr = mocker.spy(glass.algorithm, "nearcorr")
@@ -101,19 +110,19 @@ def test_cov_nearest(rng, mocker):
     cov = glass.algorithm.cov_nearest(a)
 
     # make sure all eigenvalues are positive
-    assert np.all(np.linalg.eigvalsh(cov) >= 0)
+    assert xp.all(xp.linalg.eigvalsh(cov) >= 0)
 
     # get normalisation
-    sq_d = np.sqrt(a.diagonal())
-    norm = np.outer(sq_d, sq_d)
+    sq_d = xp.sqrt(a.diagonal())
+    norm = xp.outer(sq_d, sq_d)
 
     # make sure nearcorr was called with correct input
     nearcorr.assert_called_once()
     np.testing.assert_array_almost_equal_nulp(
         nearcorr.call_args_list[0].args[0],
-        np.divide(a, norm, where=(norm > 0), out=np.zeros_like(a)),
+        xp.divide(a, norm),
     )
 
     # cannot deal with negative variances
     with pytest.raises(ValueError, match="negative values"):
-        glass.algorithm.cov_nearest(np.diag([1, 1, -1]))
+        glass.algorithm.cov_nearest(xp.diag(xp.array([1, 1, -1])))


### PR DESCRIPTION
# Description

Add array API tests for legacy mode functions added in `glass.algorithm`. The functions added in other modules do not fully support the array API standard; therefore, those functions can be dealt with once we add full support.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #519

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [X] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
