### PR TITLE
gh-602: pin python version and numpy for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
       - id: mypy
         files: ^glass/
         additional_dependencies:
-          - numpy>=2.2.3
+          - numpy~=2.2.4
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
       - id: mypy
         files: ^glass/
         additional_dependencies:
-          - numpy==2.2.4
+          - numpy~=2.2.4
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ ci:
   autoupdate_commit_msg: "pre-commit.ci: update pre-commit hooks"
   autoupdate_schedule: monthly
 
+default_language_version:
+  python: python3.13
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
       - id: mypy
         files: ^glass/
         additional_dependencies:
-          - numpy~=2.2.4
+          - numpy==2.2.4
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
 try:
-    from warnings import deprecated  # type: ignore[attr-defined]
+    from warnings import deprecated
 except ImportError:
     if TYPE_CHECKING:
         from typing import ParamSpec, TypeVar
@@ -35,7 +35,7 @@ except ImportError:
         _P = ParamSpec("_P")
         _R = TypeVar("_R")
 
-    def deprecated(msg: str, /) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    def deprecated(msg: str, /) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:  # type: ignore[no-redef]
         """Backport of Python's warnings.deprecated()."""
         from functools import wraps
         from warnings import warn


### PR DESCRIPTION
# Description

I finally got it. The mypy error Python 3.13, but pre-commit.ci is for some reason not using Python 3.13.

I finally get the error on CI here - https://results.pre-commit.ci/run/github/357271805/1744297435.iNZbr3uAQbKHw8dma-TZww

This PR pins the Python version and adds a soft pin to the NumPy version (recommended).

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #602

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
