### PR TITLE
gh-612: handle NoneType in `get_namespace`

### DIFF
--- a/glass/_array_api_utils.py
+++ b/glass/_array_api_utils.py
@@ -16,7 +16,11 @@ def get_namespace(*arrays: NDArray[Any] | Array) -> ModuleType:
     if they do not.
     """
     namespace = arrays[0].__array_namespace__()
-    if not all(array.__array_namespace__() == namespace for array in arrays):
+    if any(
+        array.__array_namespace__() != namespace
+        for array in arrays
+        if array is not None
+    ):
         msg = "input arrays should belong to the same array library"
         raise ValueError(msg)
 


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
Make sure that the `get_namespace` method can be used even if one of the inputs is `None`.

I've also simplified the logic, so have changed `not all(==` to `any(!=`. 

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #612

<!-- referring some issue -->
Refs: #606

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
