### PR TITLE
gh-611: xp fixture for array API tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,16 +85,19 @@ GLASS_ARRAY_BACKEND=jax python -m pytest
 GLASS_ARRAY_BACKEND=all python -m pytest
 ```
 
-Moreover, one can mark a test to be compatible with the array API standard by
-decorating it with `@array_api_compatible`. This will `parameterize` the test to
-run on every array library specified through `GLASS_ARRAY_BACKEND` -
+Moreover, one can test if a function is compatible with the array API standard
+by using the `xp` fixture. This will `parametrize` the test to run on every
+array library specified through `GLASS_ARRAY_BACKEND` -
 
 ```python
-import types
-from tests.conftest import array_api_compatible
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import types
 
 
-@array_api_compatible
 def test_something(xp: types.ModuleType):
     # use `xp.` to access the array library functionality
     ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,22 @@
+from __future__ import annotations
+
 import contextlib
 import importlib.metadata
 import os
-import types
+from typing import TYPE_CHECKING
 
 import numpy as np
 import packaging.version
 import pytest
-from numpy.typing import NDArray
-
-from cosmology import Cosmology
 
 import glass
+
+if TYPE_CHECKING:
+    import types
+
+    from numpy.typing import NDArray
+
+    from cosmology import Cosmology
 
 # Handling of array backends, inspired by-
 # https://github.com/scipy/scipy/blob/36e349b6afbea057cb713fc314296f10d55194cc/scipy/conftest.py#L139
@@ -95,11 +101,18 @@ else:
     msg = f"unsupported array backend: {GLASS_ARRAY_BACKEND}"
     raise ValueError(msg)
 
-# use this as a decorator for tests involving array API compatible functions
-array_api_compatible = pytest.mark.parametrize("xp", xp_available_backends.values())
-
 
 # Pytest fixtures
+@pytest.fixture(params=xp_available_backends.values(), scope="session")
+def xp(request: pytest.FixtureRequest) -> types.ModuleType:
+    """
+    Fixture for array backend.
+
+    Access array library functions using `xp.` in tests.
+    """
+    return request.param
+
+
 @pytest.fixture(scope="session")
 def cosmo() -> Cosmology:
     class MockCosmology:


### PR DESCRIPTION
# Description

Remove `@array_api_compatible` decorator and introduce `xp` fixture.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #611

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
