### PR TITLE
gh-621: bump `array-api-strict` version to `2024.12`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def _import_and_add_array_api_strict(
 
     _check_version("array_api_strict", "2.0.0")
     xp_available_backends.update({"array_api_strict": array_api_strict})
-    array_api_strict.set_array_api_strict_flags(api_version="2023.12")
+    array_api_strict.set_array_api_strict_flags(api_version="2024.12")
 
 
 def _import_and_add_jax(xp_available_backends: dict[str, types.ModuleType]) -> None:


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
Bumps the `array-api-strict` version in the tests to `2024.12` as all the features we are currently using in NumPy/JAX are supported already

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #621

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
