### PR TITLE
gh-594: split PyPI and TestPyPI deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,20 +38,14 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@v2
 
-  publish:
+  publish-pypi:
+    if: >-
+      github.event_name == 'release' && github.event.action == 'published'
     needs: dist
     runs-on: ubuntu-latest
     environment:
-      name: >-
-        ${{ (github.event_name == 'release' &&
-         github.event.action == 'published') &&
-         'publish' ||
-         'test-publish' }}
-      url: >-
-        ${{ (github.event_name == 'release' &&
-         github.event.action == 'published') &&
-         'https://pypi.org/project/glass' ||
-         'https://test.pypi.org/project/glass' }}
+      name: publish
+      url: https://pypi.org/project/glass
     permissions:
       id-token: write
     steps:
@@ -65,12 +59,28 @@ jobs:
         run: ls -l dist/
 
       - name: Publish to PyPI
-        if: >-
-          github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  publish-test-pypi:
+    if: github.event_name == 'workflow_dispatch'
+    needs: dist
+    runs-on: ubuntu-latest
+    environment:
+      name: test-publish
+      url: https://test.pypi.org/project/glass
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: List distributions to be deployed
+        run: ls -l dist/
+
       - name: Publish to TestPyPI
-        if: github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
# Description

PyPI and TestPyPI deployments should be separate now.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #594

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
