### PR TITLE
Disable PLC0415 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ lint.per-file-ignores = {"__init__.py" = [
     "D103", # TODO: undocumented-public-function
     "D104", # undocumented-public-package
     "INP001", # implicit-namespace-package
+    "PLC0415", # import-outside-top-level
     "PLR2004", # magic-value-comparison
     "S101", # assert
     "SLF001", # private-member-access


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
Disables `PLC0415` in tests. This is done in cases where a given dependency (like `fitsio`) is only used if the user has it installed.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
