### PR TITLE
gh-629: temporarily pin `array-api-strict`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ examples = [
     "matplotlib",
 ]
 test = [
-    "array_api_strict<2.4",
+    "array_api_strict>=2.0,<2.4",
     "fitsio",
     "jax>=0.4.32",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ examples = [
     "matplotlib",
 ]
 test = [
-    "array_api_strict>=2",
+    "array_api_strict<2.4",
     "fitsio",
     "jax>=0.4.32",
     "pytest",


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->
A recent change (see #629) is causing the tests to fail. Following this suggestion idea https://github.com/data-apis/array-api-extra/pull/343#issuecomment-3020606203 and not wanting to drop `Python<3.12` this is a compromise.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
