### PR TITLE
gh-639: fix compute_gaussian_spectra() for empty spectra

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -768,7 +768,7 @@ def compute_gaussian_spectra(fields: Fields, spectra: Cls) -> Cls:
 
     gls = []
     for i, j, cl in enumerate_spectra(spectra):
-        gl = glass.grf.compute(cl, fields[i], fields[j])
+        gl = glass.grf.compute(cl, fields[i], fields[j]) if cl.size > 0 else 0 * cl
         gls.append(gl)
     return gls
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -505,6 +505,22 @@ def test_compute_gaussian_spectra(mocker):
         glass.compute_gaussian_spectra(fields, spectra[:2])
 
 
+def test_compute_gaussian_spectra_gh639(mocker):
+    """Test compute_gaussian_spectra() with an empty input."""
+    mock = mocker.patch("glass.grf.compute")
+
+    fields = [glass.grf.Normal(), glass.grf.Normal()]
+    spectra = [np.zeros(10), np.zeros(10), np.zeros(0)]
+
+    gls = glass.compute_gaussian_spectra(fields, spectra)
+
+    assert mock.call_count == 2
+    assert mock.call_args_list[0] == mocker.call(spectra[0], fields[0], fields[0])
+    assert mock.call_args_list[1] == mocker.call(spectra[1], fields[1], fields[1])
+    assert gls[:2] == [mock.return_value, mock.return_value]
+    assert gls[2].size == 0
+
+
 def test_solve_gaussian_spectra(mocker):
     mock = mocker.patch("glass.grf.solve")
 


### PR DESCRIPTION
Fix bug where `compute_gaussian_spectra()` did not skip over empty spectra.

Fixes: #639