### PR TITLE
gh-654: add `types` for the labelled examples workflow

### DIFF
--- a/.github/workflows/test-examples-on-label.yml
+++ b/.github/workflows/test-examples-on-label.yml
@@ -3,6 +3,12 @@ name: Test examples
 
 on:
   pull_request:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
 
 jobs:
   test-examples-on-label:


### PR DESCRIPTION
# Description

Currently, nothing gets run unless the `run-examples` label is added at the point the PR was first opened. This PR adds some extra events to ensure it is run when intended.

Tested adding the `run-examples` to this PR retrospectively and it worked.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #654

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
