### PR TITLE
gh-673: all-contributors needs leading line

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .all-contributorsrc
+docs/CONTRIBUTORS.md

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
+
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->


### PR DESCRIPTION
# Description

The `CONTRIBUTORS.md` file cannot start with the template block or the code fails. That was caused by prettier, which I have disabled for the file.

Fixes: #673

## Checks

- [X] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
