### PR TITLE
gh-676: Remove references to UnifiedGenerator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import contextlib
 import importlib.metadata
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
 import packaging.version
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from cosmology import Cosmology
+
+    UnifiedGenerator: TypeAlias = (
+        np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator
+    )
 
 
 # Handling of array backends, inspired by-
@@ -131,9 +135,7 @@ def uxpx(xp: types.ModuleType) -> glass._array_api_utils.XPAdditions:
 
 
 @pytest.fixture(scope="session")
-def urng(
-    xp: types.ModuleType,
-) -> np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator:
+def urng(xp: types.ModuleType) -> UnifiedGenerator:
     """
     Fixture for a unified RNG interface.
 

--- a/tests/grf/test_transformations.py
+++ b/tests/grf/test_transformations.py
@@ -4,25 +4,21 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-import glass._array_api_utils as utils
 import glass.grf
 
 if TYPE_CHECKING:
     import types
 
+    from conftest import UnifiedGenerator
 
-def test_normal(
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+
+def test_normal(urng: UnifiedGenerator) -> None:
     t = glass.grf.Normal()
     x = urng.standard_normal(10)
     np.testing.assert_array_equal(t(x, 1.0), x)
 
 
-def test_lognormal(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+def test_lognormal(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     for lam in 1.0, urng.uniform():
         var = urng.uniform()
         t = glass.grf.Lognormal(lam)
@@ -31,10 +27,7 @@ def test_lognormal(
         np.testing.assert_array_equal(t(x, var), y)
 
 
-def test_sqnormal(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+def test_sqnormal(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     for lam in 1.0, urng.uniform():
         var = urng.uniform()
         a = xp.sqrt(1 - var)
@@ -44,10 +37,7 @@ def test_sqnormal(
         np.testing.assert_array_equal(t(x, var), y)
 
 
-def test_normal_normal(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+def test_normal_normal(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     t1 = glass.grf.Normal()
     t2 = glass.grf.Normal()
     x = urng.random(10)
@@ -56,10 +46,7 @@ def test_normal_normal(
     np.testing.assert_array_equal(glass.grf.dcorr(t1, t2, x), xp.ones_like(x))
 
 
-def test_lognormal_lognormal(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+def test_lognormal_lognormal(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     lam1 = urng.uniform()
     t1 = glass.grf.Lognormal(lam1)
 
@@ -75,10 +62,7 @@ def test_lognormal_lognormal(
     np.testing.assert_array_equal(glass.grf.dcorr(t1, t2, x), dy)
 
 
-def test_lognormal_normal(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+def test_lognormal_normal(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     lam1 = urng.uniform()
     t1 = glass.grf.Lognormal(lam1)
 
@@ -93,10 +77,7 @@ def test_lognormal_normal(
     np.testing.assert_array_equal(glass.grf.dcorr(t1, t2, x), dy)
 
 
-def test_sqnormal_sqnormal(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | utils.Generator,
-) -> None:
+def test_sqnormal_sqnormal(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     lam1, var1 = urng.uniform(size=2)
     a1 = xp.sqrt(1 - var1)
     t1 = glass.grf.SquaredNormal(a1, lam1)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -5,19 +5,16 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-import glass._array_api_utils as _utils
 import glass.algorithm
 
 if TYPE_CHECKING:
     import types
 
     import pytest_mock
+    from conftest import UnifiedGenerator
 
 
-def test_nnls(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | _utils.Generator,
-) -> None:
+def test_nnls(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     """Unit tests for glass.algorithm.nnls."""
     if xp.__name__ == "jax.numpy":
         pytest.skip("Arrays in nnls are not immutable, so do not support jax")
@@ -54,10 +51,7 @@ def test_nnls(
         glass.algorithm.nnls(a.T, b)
 
 
-def test_cov_clip(
-    xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | _utils.Generator,
-) -> None:
+def test_cov_clip(xp: types.ModuleType, urng: UnifiedGenerator) -> None:
     # prepare a random matrix
     m = urng.random((4, 4))
 
@@ -113,7 +107,7 @@ def test_nearcorr(xp: types.ModuleType) -> None:
 
 def test_cov_nearest(
     xp: types.ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | _utils.Generator,
+    urng: UnifiedGenerator,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     # prepare a random matrix

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     import pytest_mock
+    from conftest import UnifiedGenerator
     from numpy.typing import NDArray
 
 
@@ -60,10 +61,7 @@ def test_effective_bias(xp: ModuleType, mocker: pytest_mock.MockerFixture) -> No
     assert glass.effective_bias(z, bz, w) == pytest.approx(0.25)
 
 
-def test_linear_bias(
-    xp: ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator,
-) -> None:
+def test_linear_bias(xp: ModuleType, urng: UnifiedGenerator) -> None:
     # test with 0 delta
 
     delta = xp.zeros((2, 2))
@@ -86,10 +84,7 @@ def test_linear_bias(
     assert glass.linear_bias(delta, b) == pytest.approx(b * delta)
 
 
-def test_loglinear_bias(
-    xp: ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator,
-) -> None:
+def test_loglinear_bias(xp: ModuleType, urng: UnifiedGenerator) -> None:
     # test with 0 delta
 
     delta = xp.zeros((2, 2))
@@ -276,10 +271,7 @@ def test_uniform_positions(rng: np.random.Generator) -> None:
     assert lon.shape == lat.shape == (cnt.sum(),)
 
 
-def test_position_weights(
-    xp: ModuleType,
-    urng: np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator,
-) -> None:
+def test_position_weights(xp: ModuleType, urng: UnifiedGenerator) -> None:
     """Unit tests for glass.points.position_weights."""
     for bshape in None, (), (100,), (100, 1):
         for cshape in (100,), (100, 50), (100, 3, 2):


### PR DESCRIPTION
# Description

> this was split out from [PR-677](https://github.com/glass-dev/glass/pull/677)

<!-- for other issues -->
Fixes: #676 


## Changelog entry

Fixed: Removed the references to UnifiedGenerator which no longer exists (https://github.com/glass-dev/glass/issues/676)

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
