### PR TITLE
gh-666: make docs fail on warnings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -102,7 +102,14 @@ def docs(session: nox.Session) -> None:
     """Build the docs. Pass "serve" to serve."""
     session.install("-e", ".", "--group", "docs")
     session.chdir("docs")
-    session.run("sphinx-build", "-M", "html", ".", "_build")
+    session.run(
+        "sphinx-build",
+        "-M",
+        "html",
+        ".",
+        "_build",
+        "--fail-on-warning",
+    )
 
     port = 8001
 


### PR DESCRIPTION
# Description

This PR simply makes sure documentation cannot build with warnings. This will fail as the docs are currently broken.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #666

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
