### PR TITLE
gh-700: remove `typing-extensions` dependency

### DIFF
--- a/glass/jax.py
+++ b/glass/jax.py
@@ -11,10 +11,10 @@ import jax.numpy as jnp
 import jax.random
 import jax.scipy
 from jax.typing import ArrayLike
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from jaxtyping import Array, Integer, PRNGKeyArray, Shaped
+    from typing_extensions import Self
 
     RealArray: TypeAlias = Array
     Size: TypeAlias = int | tuple[int, ...] | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "healpix>=2022.11.1",
     "healpy>=1.15.0",
     "transformcl>=2022.8.9",
-    "typing-extensions>=4.13.2",
 ]
 description = "Generator for Large Scale Structure"
 dynamic = [


### PR DESCRIPTION
# Description

Previously `typing-extensions` was required, but not any more. Not sure why `ruff` didn't pick up that `typing_extensions` should be in a `TYPE_CHECKING` block.

<!-- for user facing bugs -->
Fixes: #700

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Removed: `typing-extensions` dependency

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
