### PR TITLE
gh-704: Remove isinstance(x, Number)

### DIFF
--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -31,7 +31,6 @@ Applying lensing
 
 from __future__ import annotations
 
-from numbers import Number
 from typing import TYPE_CHECKING, Literal, overload
 
 import healpy as hp
@@ -657,7 +656,7 @@ def deflect(
     arrays_to_check = tuple(
         x
         for x in (lon, lat, alpha)
-        if not isinstance(x, Number) and not isinstance(x, list)
+        if not isinstance(x, (float, int, complex)) and not isinstance(x, list)
     )
     if xp is None:
         if len(arrays_to_check) == 0:

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import itertools
 import math
-from numbers import Number
 from typing import TYPE_CHECKING
 
 import healpy as hp
@@ -126,7 +125,9 @@ def gaussian_nz(
 
     """
     arrays_to_check = tuple(
-        x for x in (z, mean, sigma, norm) if not (isinstance(x, Number) or x is None)
+        x
+        for x in (z, mean, sigma, norm)
+        if not (isinstance(x, (float, int)) or x is None)
     )
     xp = _utils.get_namespace(*arrays_to_check)
     uxpx = _utils.XPAdditions(xp)
@@ -192,7 +193,7 @@ def smail_nz(
     arrays_to_check = tuple(
         x
         for x in (z, z_mode, alpha, beta, norm)
-        if not (isinstance(x, Number) or x is None)
+        if not ((isinstance(x, (float, int))) or x is None)
     )
     xp = _utils.get_namespace(*arrays_to_check)
     uxpx = _utils.XPAdditions(xp)


### PR DESCRIPTION
# Description

Removes comparisons to `numbers.Number` in favour of `(float, int, complex)`

<!-- for user facing bugs -->
Fixes: #704

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Fixed: Unsafe comparison to numbers.Number

-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
