### PR TITLE
gh-712: Simplify get_namespace

### DIFF
--- a/glass/_array_api_utils.py
+++ b/glass/_array_api_utils.py
@@ -104,10 +104,18 @@ def get_namespace(*arrays: AnyArray) -> ModuleType:
     ValueError
         If input arrays do not all belong to the same array library.
     """
-    namespace = arrays[0].__array_namespace__()
+    arrays_to_check = tuple(
+        arr for arr in arrays if hasattr(arr, "__array_namespace__")
+    )
+
+    if len(arrays_to_check) == 0:
+        msg = "At least one input arrays must belong to an array library."
+        raise ValueError(msg)
+
+    namespace = arrays_to_check[0].__array_namespace__()
     if any(
         array.__array_namespace__() != namespace
-        for array in arrays
+        for array in arrays_to_check
         if array is not None
     ):
         msg = "input arrays should belong to the same array library"

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -129,8 +129,7 @@ def ndinterp(  # noqa: PLR0913
         The interpolated array.
 
     """
-    arrays_to_check = (xq, fq) if type(x) is float else (x, xq, fq)
-    xp = _utils.get_namespace(*arrays_to_check)
+    xp = _utils.get_namespace(x, xq, fq)
     uxpx = _utils.XPAdditions(xp)
 
     return uxpx.apply_along_axis(

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -678,8 +678,6 @@ def effective_cls(
         If the shapes of *weights1* and *weights2* are incompatible.
 
     """
-    # Try with cls and weights but if cls is a Sequence[float] then we use weights only
-    # and convert cls to an xp array
     xp = _utils.get_namespace(*cls, weights1, weights2)
 
     # this is the number of fields

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -653,16 +653,8 @@ def deflect(
     exponential map.
 
     """
-    arrays_to_check = tuple(
-        x
-        for x in (lon, lat, alpha)
-        if not isinstance(x, (float, int, complex)) and not isinstance(x, list)
-    )
     if xp is None:
-        if len(arrays_to_check) == 0:
-            msg = "Either, one positional input must be an array or xp must be provided"
-            raise ValueError(msg)
-        xp = _utils.get_namespace(*arrays_to_check)
+        xp = _utils.get_namespace(lon, lat, alpha)
     uxpx = _utils.XPAdditions(xp)
 
     alpha = xp.asarray(alpha)

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -124,12 +124,7 @@ def gaussian_nz(
         The redshift distribution at the given ``z`` values.
 
     """
-    arrays_to_check = tuple(
-        x
-        for x in (z, mean, sigma, norm)
-        if not (isinstance(x, (float, int)) or x is None)
-    )
-    xp = _utils.get_namespace(*arrays_to_check)
+    xp = _utils.get_namespace(z, mean, sigma, norm)
     uxpx = _utils.XPAdditions(xp)
 
     mean = xp.asarray(mean, dtype=xp.float64)
@@ -190,12 +185,7 @@ def smail_nz(
     where :math:`z_0` is matched to the given mode of the distribution.
 
     """
-    arrays_to_check = tuple(
-        x
-        for x in (z, z_mode, alpha, beta, norm)
-        if not ((isinstance(x, (float, int))) or x is None)
-    )
-    xp = _utils.get_namespace(*arrays_to_check)
+    xp = _utils.get_namespace(z, z_mode, alpha, beta, norm)
     uxpx = _utils.XPAdditions(xp)
 
     z_mode = xp.asarray(z_mode, dtype=xp.float64)[..., xp.newaxis]

--- a/glass/points.py
+++ b/glass/points.py
@@ -135,8 +135,7 @@ def loglinear_bias(
         The density contrast after biasing.
 
     """
-    arrays_to_check = (delta,) if type(b) is float else (delta, b)
-    xp = _utils.get_namespace(*arrays_to_check)
+    xp = _utils.get_namespace(delta, b)
 
     delta_g = xp.log1p(delta)
     delta_g *= b
@@ -415,12 +414,7 @@ def position_weights(
         The relative weight of each shell for angular clustering.
 
     """
-    arrays_to_check = (
-        (densities, bias)
-        if bias is not None and not isinstance(bias, float)
-        else (densities,)
-    )
-    xp = _utils.get_namespace(*arrays_to_check)
+    xp = _utils.get_namespace(densities, bias)
 
     bias = bias if bias is None or not isinstance(bias, float) else xp.asarray(bias)
 

--- a/tests/test_array_api_utils.py
+++ b/tests/test_array_api_utils.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -7,15 +11,23 @@ from array_api_strict._array_object import Array
 
 import glass._array_api_utils
 
+if TYPE_CHECKING:
+    from types import ModuleType
 
-def test_get_namespace() -> None:
-    arrays = [np.array([1, 2]), np.array([2, 3])]
+
+def test_get_namespace(xp: ModuleType) -> None:
+    arrays = [xp.asarray([1, 2]), xp.asarray([2, 3])]
     namespace = glass._array_api_utils.get_namespace(*arrays)
-    assert namespace == np
+    assert namespace == xp
 
-    arrays = [np.array([1, 2]), jnp.array([2, 3])]
+    arrays = [np.asarray([1, 2]), jnp.asarray([2, 3])]
     with pytest.raises(ValueError, match="input arrays should"):
         glass._array_api_utils.get_namespace(*arrays)
+
+    with pytest.raises(
+        ValueError, match="At least one input arrays must belong to an array library"
+    ):
+        glass._array_api_utils.get_namespace(0.0, 0.0)
 
 
 def test_rng_dispatcher() -> None:

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -145,7 +145,7 @@ def test_deflect_nsew(xp: ModuleType, usecomplex: bool) -> None:  # noqa: FBT001
     # No inputs are arrays and xp not provided
     with pytest.raises(
         ValueError,
-        match="Either, one positional input must be an array or xp must be provided",
+        match="At least one input arrays must belong to an array library",
     ):
         glass.deflect(0.0, 0.0, alpha(0, -r, usecomplex=usecomplex))
 


### PR DESCRIPTION
# Description

To simply calls to `get_namespace`, we only check "arrays" which have the attribute `__array_namespace__`. 

Closes: #712

## Changelog entry

Changed: Simplifies get_namespace to allow any arg to be passed.

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
