### PR TITLE
gh-406: Add xp to tests for ported arraytools functions

### DIFF
--- a/tests/test_arraytools.py
+++ b/tests/test_arraytools.py
@@ -169,5 +169,5 @@ def test_cumulative_trapezoid(xp: ModuleType) -> None:
     ct = glass.arraytools.cumulative_trapezoid(f, x)
     np.testing.assert_allclose(
         ct,
-        np.array([[0.0, 2.5, 12.25, 31.0], [0.0, 2.5, 8.5, 17.5]]),
+        xp.asarray([[0.0, 2.5, 12.25, 31.0], [0.0, 2.5, 8.5, 17.5]]),
     )


### PR DESCRIPTION
# Description

As the straightforward functions in `arraytools` have already been ported. This PR just updates their tests to use the xp fixture and test for each array backend.

Closes: #406 

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
