### PR TITLE
gh-730: add missing import from docstring

### DIFF
--- a/glass/shells.py
+++ b/glass/shells.py
@@ -186,6 +186,7 @@ class RadialWindow:
     immutable (however, the array entries may **not** be immutable; do
     not change them in place)::
 
+        >>> import dataclasses
         >>> import glass
         >>> import numpy as np
         >>> za = np.asarray([0.0, 1.0])


### PR DESCRIPTION
# Description

It would have been nice to be able to enforce that all imports are in the docstring rather than borrowing from the top of the file. This doesn't seem to be possible? Spent a while looking into this. I will close the issue manually, and this PR instead just adds one missing import.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
Refs: #730

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
