### PR TITLE
gh-742: make `allcontributors` follow the commit spec

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "commitConvention": "angular",
-  "commitType": "gh-540",
+  "commitType": "contributors",
   "contributorsPerLine": 7,
   "files": [
     "docs/CONTRIBUTORS.md"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   check-pr-title:
     if: >-
+      github.event.pull_request.user.login != 'allcontributors[bot]' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'pre-commit-ci[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Following #726, it made sense to do this for `allcontributors` too. This change will mean all commits refer to #540.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #742

<!-- referring some issue -->
Refs: #540, #726

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
