### PR TITLE
gh-747: Force nox to default to 3.13

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           cache-dependency-path: pyproject.toml
           cache: pip
-          python-version: 3.x
+          python-version: 3.13
 
       - name: Cache nox
         uses: actions/cache@v4
@@ -34,7 +34,7 @@ jobs:
           path: .nox
 
       - name: Install nox
-        run: python -m pip install nox[uv]
+        run: python -m pip install nox
 
       - name: Run examples
         run: nox -s examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           path: .nox
 
       - name: Install nox and coverage.py
-        run: python -m pip install coverage[toml] nox[uv]
+        run: python -m pip install coverage[toml] nox
 
       - name: Install ubuntu dependencies for fitsio
         run: sudo apt-get install -y libbz2-dev
@@ -108,10 +108,10 @@ jobs:
         with:
           cache-dependency-path: pyproject.toml
           cache: pip
-          python-version: 3.x
+          python-version: 3.13
 
       - name: Install nox
-        run: python -m pip install nox[uv]
+        run: python -m pip install nox
 
       - name: Build SDist and wheel
         run: nox -s build --verbose
@@ -132,13 +132,13 @@ jobs:
         with:
           cache-dependency-path: pyproject.toml
           cache: pip
-          python-version: 3.x
+          python-version: 3.13
 
       - name: Install dependencies
         run: |-
           sudo apt-get update
           sudo apt-get install -y pandoc
-          python -m pip install nox[uv]
+          python -m pip install nox
 
       - name: Build docs
         run: nox -s docs --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ developers. All of these commands (or sessions in the language of `nox`) -
 `nox` can be installed via `pip` using -
 
 ```bash
-pip install nox[uv]
+pip install nox
 ```
 
 The default sessions (`lint` and `tests`) can be executed using -

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ ARRAY_BACKENDS = {
 }
 
 
-@nox.session(python="3.13")
+@nox.session
 def lint(session: nox.Session) -> None:
     """Run the linter."""
     session.install("pre-commit")
@@ -69,7 +69,7 @@ def doctests(session: nox.Session) -> None:
     session.run("pytest", *session.posargs)
 
 
-@nox.session(python="3.13")
+@nox.session
 def examples(session: nox.Session) -> None:
     """Run the example notebooks. Pass "html" to build html."""
     session.install("-e", ".[examples]")
@@ -97,7 +97,7 @@ def examples(session: nox.Session) -> None:
         )
 
 
-@nox.session(python="3.13")
+@nox.session
 def docs(session: nox.Session) -> None:
     """Build the docs. Pass "serve" to serve."""
     session.install("-e", ".", "--group", "docs")
@@ -121,14 +121,14 @@ def docs(session: nox.Session) -> None:
             print("Unsupported argument to docs")
 
 
-@nox.session(python="3.13")
+@nox.session
 def build(session: nox.Session) -> None:
     """Build an SDist and wheel."""
     session.install("build")
     session.run("python", "-m", "build")
 
 
-@nox.session(python="3.13")
+@nox.session
 def version(session: nox.Session) -> None:
     """
     Check the current version of the package.


### PR DESCRIPTION
# Description

`healpy` doesn't currently support Python 3.14. A recent GitHub Actions update means that Python defaults to 3.14. This PR ensures that we are always working in the latest Python version that we are supporting.

<!-- for user facing bugs -->
Fixes: #747

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: `nox` now runs in the latest supported Python version only

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
