### PR TITLE
gh-751: tidy up doc plotting routines

### DIFF
--- a/docs/user/how-glass-works.rst
+++ b/docs/user/how-glass-works.rst
@@ -30,23 +30,24 @@ which are flat and non-overlapping.
 
 .. plot::
 
-    import glass
     import numpy as np
 
+    import glass
+
     # create a redshift grid for shell edges
-    zs = glass.redshift_grid(0., 0.5, dz=0.1, xp=np)
+    zs = glass.redshift_grid(0.0, 0.5, dz=0.1, xp=np)
 
     # create the top hat windows
     ws = glass.tophat_windows(zs)
 
     # plot each window
     for i, (za, wa, zeff) in enumerate(ws):
-        plt.plot(za, wa, c='k', lw=2)
+        plt.plot(za, wa, c="k", lw=2)
         plt.fill_between(za, np.zeros_like(wa), wa, alpha=0.5)
-        plt.annotate(f'shell {i+1}', (zeff, 0.5), ha='center', va='center')
+        plt.annotate(f"shell {i + 1}", (zeff, 0.5), ha="center", va="center")
 
-    plt.xlabel('redshift $z$')
-    plt.ylabel('window function $W(z)$')
+    plt.xlabel("redshift $z$")
+    plt.ylabel("window function $W(z)$")
     plt.tight_layout()
 
 Given such a sequence of window functions :math:`W_i`, *GLASS* discretises a
@@ -75,28 +76,39 @@ included:
 
 .. plot::
 
-    import glass
     import numpy as np
 
-    plot_windows = [glass.tophat_windows, glass.linear_windows,
-                    glass.cubic_windows]
-    nr = (len(plot_windows)+1)//2
+    import glass
 
-    fig, axes = plt.subplots(nr, 2, figsize=(8, nr*3), layout="constrained",
-                             squeeze=False, sharex=False, sharey=True)
+    plot_windows = [
+        glass.tophat_windows,
+        glass.linear_windows,
+        glass.cubic_windows,
+    ]
+    nr = (len(plot_windows) + 1) // 2
 
-    zs = glass.redshift_grid(0., 0.5, dz=0.1, xp=np)
-    zt = np.linspace(0., 0.5, 200)
+    fig, axes = plt.subplots(
+        nr,
+        2,
+        figsize=(8, nr * 3),
+        layout="constrained",
+        squeeze=False,
+        sharex=False,
+        sharey=True,
+    )
+
+    zs = glass.redshift_grid(0.0, 0.5, dz=0.1, xp=np)
+    zt = np.linspace(0.0, 0.5, 200)
 
     for ax in axes.flat:
-        ax.axis(False)
-    for windows, ax in zip(plot_windows, axes.flat):
+        ax.axis("off")
+    for windows, ax in zip(plot_windows, axes.flat, strict=False):
         ws = windows(zs)
         wt = np.zeros_like(zt)
-        ax.axis(True)
+        ax.axis("on")
         ax.set_title(windows.__name__)
-        for i, (za, wa, zeff) in enumerate(ws):
-            wt += np.interp(zt, za, wa, left=0., right=0.)
+        for za, wa, _ in ws:
+            wt += np.interp(zt, za, wa, left=0.0, right=0.0)
             ax.fill_between(za, np.zeros_like(wa), wa, alpha=0.5)
         ax.plot(zt, wt, c="k", lw=2)
     for ax in axes.flat:


### PR DESCRIPTION
# Description

The plotting routines in "How GLASS Works" aren't formatted well. Ideally we'd use `ruff`, but for now we can have a manual improvement.

Looks the same
<img width="893" height="949" alt="doc plots" src="https://github.com/user-attachments/assets/8e027abe-92f4-4131-b6a2-32e2bbf1ef2d" />

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #751

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
