### PR TITLE
gh-756: Add workflow to trigger reusable workflow from benchmarks repo

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -15,5 +15,5 @@ jobs:
   regression-tests:
     uses: glass-dev/glass-benchmarks/.github/workflows/regression-test.yaml@v0
     with:
-      starting_revision: ${{github.event.pull_request.base.ref}}
-      end_revision: ${{github.event.pull_request.head.ref}}
+      starting_revision: ${{ github.event.pull_request.base.ref }}
+      end_revision: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
# Description

Adds a workflow which runs a reusable workflow from the benchmarks repo

Closes: #756 

Depends on https://github.com/glass-dev/glass-benchmarks/pull/13

## Changelog entry

Added: Performance regression tests in github actions

## Checks

- [x] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
