### PR TITLE
gh-756: Run reg tests for relevant changes

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -5,9 +5,9 @@ on:
   pull_request:
     paths:
       - .github/workflows/regression-test.yaml
-      - pyproject.toml
       - glass/**
       - noxfile.py
+      - pyproject.toml
       - tests/benchmarks/**
       - tests/conftest.py
     branches:


### PR DESCRIPTION
# Description

Somehow this was missed. According to #756, we should only be running regression tests for relevant file changes (glass/* or dependencies i.e. pyproject.toml)

<!-- for user facing bugs -->
Fixes: #756 






## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
