### PR TITLE
gh-22: Add steps to regression-test workflow to comment on a PR

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -20,7 +20,7 @@ jobs:
       end_revision: ${{ github.event.pull_request.head.ref }}
 
   write-pr-comment:
-    name: Regression test
+    name: Write PR Comment
     runs-on: ubuntu-latest
     needs: regression-tests
     if: ${{ failure() }}


### PR DESCRIPTION
# Description

To allow writing a comment on a PR if the regression tests fail, this PR extracts the artefact from the regression test workflow in the benchmarks repo and then extracts the relevant lines to then post in a PR comment.

Depends on https://github.com/glass-dev/glass-benchmarks/pull/23/files


Closes: https://github.com/glass-dev/glass/issues/783


## Changelog entry

Added: PR comments for failing regression tests

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
