### PR TITLE
gh-758: Add benchmarks for glass.algorithm

### DIFF
--- a/tests/benchmarks/test_algorithm.py
+++ b/tests/benchmarks/test_algorithm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
 import glass.algorithm
@@ -12,6 +13,8 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from pytest_benchmark.fixture import BenchmarkFixture
+
+    from glass._types import UnifiedGenerator
 
 
 def test_nnls(xp: ModuleType, benchmark: BenchmarkFixture) -> None:
@@ -31,3 +34,82 @@ def test_nnls(xp: ModuleType, benchmark: BenchmarkFixture) -> None:
     y = a @ b
     res = benchmark(glass.algorithm.nnls, a, y)
     assert xp.linalg.vector_norm((a @ res) - y) < 1e-7
+
+
+@pytest.mark.parametrize("rtol", [None, 1.0])
+def test_cov_clip(
+    xp: ModuleType,
+    urng: UnifiedGenerator,
+    benchmark: BenchmarkFixture,
+    rtol: float | None,
+) -> None:
+    """
+    Benchmark test for glass.algorithm.cov_clip.
+
+    Parameterize over rtol to ensure the most coverage possible.
+    """
+    # prepare a random matrix
+    m = urng.random((4, 4))
+
+    # symmetric matrix
+    a = (m + m.T) / 2
+
+    # fix by clipping negative eigenvalues
+    cov = benchmark(glass.algorithm.cov_clip, a, rtol=rtol)
+
+    # make sure all eigenvalues are positive
+    assert xp.all(xp.linalg.eigvalsh(cov) >= 0)
+
+    if rtol is not None:
+        h = xp.max(xp.linalg.eigvalsh(a))
+        np.testing.assert_allclose(xp.linalg.eigvalsh(cov), h, rtol=1e-6)
+
+
+@pytest.mark.parametrize("tol", [None, 0.0001])
+def test_nearcorr(
+    xp: ModuleType,
+    benchmark: BenchmarkFixture,
+    tol: float | None,
+) -> None:
+    """
+    Benchmark test for glass.algorithm.nearcorr.
+
+    Parameterize over tol to ensure the most coverage possible.
+    """
+    # from Higham (2002)
+    a = xp.asarray(
+        [
+            [1.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ],
+    )
+    b = xp.asarray(
+        [
+            [1.0000, 0.7607, 0.1573],
+            [0.7607, 1.0000, 0.7607],
+            [0.1573, 0.7607, 1.0000],
+        ],
+    )
+
+    x = benchmark(glass.algorithm.nearcorr, a, tol=tol)
+    np.testing.assert_allclose(x, b, atol=0.0001)
+
+
+def test_cov_nearest(
+    xp: ModuleType,
+    urng: UnifiedGenerator,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark test for glass.algorithm.cov_nearest."""
+    # prepare a random matrix
+    m = urng.random((4, 4))
+
+    # symmetric matrix
+    a = xp.eye(4) + (m + m.T) / 2
+
+    # compute covariance
+    cov = benchmark(glass.algorithm.cov_nearest, a)
+
+    # make sure all eigenvalues are positive
+    assert xp.all(xp.linalg.eigvalsh(cov) >= 0)


### PR DESCRIPTION
# Description

> Migrated over from https://github.com/glass-dev/glass-benchmarks/pull/16

Adding benchmarks for `glass.algorithm` functions. Mostly these benchmarks are copies of the tests that exist in glass already. However, I have removed sad paths tests which exit early as I believe these are not as relevant for testing the performance of these functions in a working state.

There is still work to be done for benchmarking `glass.algorithm.nnls` as this is not fully covered. Should be handled in https://github.com/glass-dev/glass/issues/759

Closes: #758

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
