### PR TITLE
gh-783: Write PR comment if regression test workflow fails

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -58,7 +58,7 @@ jobs:
         continue-on-error: true
         run: >-
           uv run nox -s regression_tests-${{ matrix.python-version }} --
-          "$BASE_REF" "$HEAD_REF" | tee $REGRESSION_TEST_OUTPUT_FILE
+          "${BASE_REF}" "${HEAD_REF}" | tee ${REGRESSION_TEST_OUTPUT_FILE}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -68,13 +68,13 @@ jobs:
         id: extract_comment
         if: failure()
         run: >-
-          f=$REGRESSION_TEST_OUTPUT_FILE; start=$(grep -n -m1 'Performance has
-          regressed:' "$f" | cut -d: -f1)
+          f=${REGRESSION_TEST_OUTPUT_FILE}; start=$(grep -n -m1 'Performance has
+          regressed:' "${f}" | cut -d: -f1)
             || { echo "No match"; exit 1; };
-          s_dash=$(awk -v n=$start 'NR<=n && /^-+$/ {l=NR} END{print l}' "$f");
-          e_dash=$(awk -v n=$start 'NR>=n && /^-+$/ {print NR; exit}' "$f");
-          PR_COMMENT_MSG=$(sed -n "${s_dash},${e_dash}p" "$f"); echo
-          "PR_COMMENT_MSG=$PR_COMMENT_MSG" >> $GITHUB_OUTPUT;
+          s_dash=$(awk -v n=${start} 'NR<=n && /^-+$/ {l=NR} END{print l}'
+          "${f}"); e_dash=$(awk -v n=${start} 'NR>=n && /^-+$/ {print NR; exit}'
+          "${f}"); PR_COMMENT_MSG=$(sed -n "${s_dash},${e_dash}p" "${f}"); echo
+          "PR_COMMENT_MSG=${PR_COMMENT_MSG}" >> ${GITHUB_OUTPUT};
 
       - name: Write PR comment
         if: failure()


### PR DESCRIPTION
# Description

> Migrated over from https://github.com/glass-dev/glass-benchmarks/pull/23 and https://github.com/glass-dev/glass/pull/776

To allow writing a comment on a PR if the regression tests fail, this PR extracts the relevant lines from the regression test failure message to then post in a PR comment.

Closes: #783

## Changelog entry

Added: PR comment from failing regression test

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
