### PR TITLE
gh-793: remove `inplace` option to `multalm`

### DIFF
--- a/glass/harmonics.py
+++ b/glass/harmonics.py
@@ -42,9 +42,4 @@ def multalm(
 
     """
     xp = array_api_compat.array_namespace(alm, bl, use_compat=False)
-    return xp.concat(
-        [
-            alm[ell * (ell + 1) // 2 : (ell + 1) * (ell + 2) // 2] * bl[ell]
-            for ell in range(bl.size)
-        ]
-    )
+    return alm * xp.repeat(bl, xp.arange(bl.size) + 1)

--- a/tests/core/test_harmonics.py
+++ b/tests/core/test_harmonics.py
@@ -55,8 +55,5 @@ def test_multalm(xp: ModuleType) -> None:
     alm = xp.asarray([])
     bl = xp.asarray([])
 
-    with pytest.raises(
-        ValueError,
-        match="need at least one array to concatenate",
-    ):
-        result = glass.harmonics.multalm(alm, bl)
+    result = glass.harmonics.multalm(alm, bl)
+    np.testing.assert_allclose(result, alm)


### PR DESCRIPTION
# Description

This PR removes the `inplace` option within `glass.harmonics.multalm` function. This performs array mutation, so this helps with the overall Array API efforts.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #793

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Removed: The `inplace` kwarg to `glass.harmonics.multalm`

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
