### PR TITLE
gh-821: consistent importing of `glass.fields` in tests

### DIFF
--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import glass
+import glass.fields
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -697,7 +698,7 @@ def test_cov_from_spectra() -> None:
 
 def test_check_posdef_spectra() -> None:
     # posdef spectra
-    assert glass.fields.check_posdef_spectra(
+    assert glass.check_posdef_spectra(
         np.array(
             [
                 [1.0, 1.0, 1.0],
@@ -707,7 +708,7 @@ def test_check_posdef_spectra() -> None:
         ),
     )
     # semidef spectra
-    assert glass.fields.check_posdef_spectra(
+    assert glass.check_posdef_spectra(
         np.array(
             [
                 [1.0, 1.0, 1.0],
@@ -717,7 +718,7 @@ def test_check_posdef_spectra() -> None:
         ),
     )
     # indef spectra
-    assert not glass.fields.check_posdef_spectra(
+    assert not glass.check_posdef_spectra(
         np.array(
             [
                 [1.0, 1.0, 1.0],
@@ -739,14 +740,14 @@ def test_regularized_spectra(
     with pytest.warns(UserWarning, match="Nearest correlation matrix not found"):
         # we don't care about convergence here, only that the correct
         # method is called so this is to suppress the warning
-        glass.fields.regularized_spectra(spectra, method="nearest")
+        glass.regularized_spectra(spectra, method="nearest")
     cov_nearest.assert_called_once()
 
     # test method "clip"
     cov_clip = mocker.spy(glass.algorithm, "cov_clip")
-    glass.fields.regularized_spectra(spectra, method="clip")
+    glass.regularized_spectra(spectra, method="clip")
     cov_clip.assert_called_once()
 
     # invalid method
     with pytest.raises(ValueError, match="unknown method"):
-        glass.fields.regularized_spectra(spectra, method="unknown")
+        glass.regularized_spectra(spectra, method="unknown")


### PR DESCRIPTION
# Description

Functions exposed in `__init__.py` aren't being used as such.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #821

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
