### PR TITLE
gh-810: run regression tests only on latest Python

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -23,13 +23,6 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Regression test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -38,7 +31,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.13
 
       - name: Cache nox
         uses: actions/cache@v4
@@ -52,9 +45,7 @@ jobs:
         run: uv sync --only-dev
 
       - name: Run regression test
-        run: >-
-          uv run nox -s regression_tests-${{ matrix.python-version }} --
-          "$BASE_REF" "$HEAD_REF"
+        run: uv run nox -s regression_tests -- "$BASE_REF" "$HEAD_REF"
         env:
           ARRAY_BACKEND: all
           BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -219,7 +219,6 @@ def version(session: nox.Session) -> None:
 
 
 @nox_uv.session(
-    python=ALL_PYTHON,
     uv_no_install_project=True,
     uv_only_groups=["test"],
 )
@@ -238,7 +237,6 @@ def benchmarks(session: nox.Session) -> None:
 
 
 @nox_uv.session(
-    python=ALL_PYTHON,
     uv_no_install_project=True,
     uv_only_groups=["test"],
 )


### PR DESCRIPTION
# Description

Performs the regression test only on the latest Python version. We've decided to do this because in reality we only care about modern versions for benchmarking. Further, as the tests are flaky, it makes sense to remove one extra case of potential failure.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #810

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
