### PR TITLE
gh-809: Add benchmarks for fields functions which return Generators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,7 +228,6 @@ lint.per-file-ignores = {"__init__.py" = [
 ], "tests/benchmarks/*" = [
     "D100", # undocumented-public-module
     "INP001", # implicit-namespace-package
-    "PLR0913", # too-many-arguments
     "PLR2004", # magic-value-comparison
     "S101", # assert
     "S311", # suspicious-non-cryptographic-random-usage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,13 +309,10 @@ class GeneratorConsumer:
         The resulting generator will be consumed an any ValueError
         exceptions swallowed.
         """
-        output = []
-        try:
+        output: list[Any] = []
+        with contextlib.suppress(ValueError):
             # Consume in a loop, as we expect users to
-            for result in generator:
-                output.append(result)  # noqa: PERF402
-        except ValueError:
-            pass
+            output.extend(iter(generator))
         return output
 
 


### PR DESCRIPTION
# Description

Adds benchmarks for functions within `fields.py` that return Generators.

The approach I have employed is to benchmark the call to the function being tested, which creates the Generator as well as looping through the Generator until it is exhausted. 

> Note: exhausting a generator often causes an exception to be raised, therefore, I have had to catch these exceptions and just pass on them.

Closes: #809 

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
