### PR TITLE
gh-819: use `uxpx` within `effective_cls`

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -16,6 +16,7 @@ from transformcl import cltovar
 import array_api_compat
 import array_api_extra as xpx
 
+import glass._array_api_utils as _utils
 import glass.grf
 import glass.harmonics
 import glass.shells
@@ -624,6 +625,7 @@ def effective_cls(
 
     """
     xp = array_api_compat.array_namespace(*cls, weights1, weights2, use_compat=False)
+    uxpx = _utils.XPAdditions(xp)
 
     # this is the number of fields
     n = nfields_from_nspectra(len(cls))
@@ -645,9 +647,9 @@ def effective_cls(
     # get the iterator over leading weight axes
     # auto-spectra do not repeat identical computations
     pairs = (
-        combinations_with_replacement(np.ndindex(shape1[1:]), 2)
+        combinations_with_replacement(uxpx.ndindex(shape1[1:]), 2)
         if weights2 is weights1
-        else product(np.ndindex(shape1[1:]), np.ndindex(shape2[1:]))
+        else product(uxpx.ndindex(shape1[1:]), uxpx.ndindex(shape2[1:]))
     )
 
     # create the output array: axes for all input axes plus lmax+1


### PR DESCRIPTION
# Description

`glass.fields.effective_cls` had been ported but not fully removed dependence on NumPy through the `ndindex` function. This PR uses `uxpx` module to remove dependence on NumPy.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #819

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
