### PR TITLE
gh-836: consistent setting of seed throughout

### DIFF
--- a/glass/_array_api_utils.py
+++ b/glass/_array_api_utils.py
@@ -101,16 +101,18 @@ def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
     NotImplementedError
         If the array backend is not supported.
     """
+    seed = 42
+
     if xp.__name__ == "jax.numpy":
         import glass.jax  # noqa: PLC0415
 
-        return glass.jax.Generator(seed=42)
+        return glass.jax.Generator(seed=seed)
 
     if xp.__name__ == "numpy":
-        return xp.random.default_rng()  # type: ignore[no-any-return]
+        return xp.random.default_rng(seed=seed)  # type: ignore[no-any-return]
 
     if xp.__name__ == "array_api_strict":
-        return Generator(seed=42)
+        return Generator(seed=seed)
 
     msg = "the array backend in not supported"
     raise NotImplementedError(msg)

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -355,7 +355,7 @@ def _generate_grf(
         If all gls are empty.
     """
     if rng is None:
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(42)
 
     # number of gls and number of fields
     ngls = len(gls)

--- a/glass/points.py
+++ b/glass/points.py
@@ -237,7 +237,7 @@ def positions_from_delta(  # noqa: PLR0912, PLR0913, PLR0915
     """
     # get default RNG if not given
     if rng is None:
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(42)
 
     # get the bias model
     if isinstance(bias_model, str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 #   all (try finding every supported array library available in the environment)
 ARRAY_BACKEND: str = os.environ.get("ARRAY_BACKEND", "")
 
+SEED = 42
+
 # Change jax logger to only log ERROR or worse
 logging.getLogger("jax").setLevel(logging.ERROR)
 
@@ -144,14 +146,12 @@ def urng(xp: ModuleType) -> UnifiedGenerator:
 
     Must be used with the `xp` fixture. Use `rng` for non array API tests.
     """
-    seed = 42
-    backend = xp.__name__
-    if backend == "jax.numpy":
-        return glass.jax.Generator(seed=seed)
-    if backend == "numpy":
-        return np.random.default_rng(seed=seed)
-    if backend == "array_api_strict":
-        return _utils.Generator(seed=seed)
+    if xp.__name__ == "jax.numpy":
+        return glass.jax.Generator(seed=SEED)
+    if xp.__name__ == "numpy":
+        return np.random.default_rng(seed=SEED)
+    if xp.__name__ == "array_api_strict":
+        return _utils.Generator(seed=SEED)
     msg = "the array backend in not supported"
     raise NotImplementedError(msg)
 
@@ -163,7 +163,7 @@ def rng() -> np.random.Generator:
 
     Use `urng` for array API tests.
     """
-    return np.random.default_rng(seed=42)
+    return np.random.default_rng(seed=SEED)
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/test_array_api_utils.py
+++ b/tests/core/test_array_api_utils.py
@@ -1,5 +1,5 @@
 import contextlib
-import importlib
+import importlib.util
 
 import numpy as np
 import pytest
@@ -13,6 +13,7 @@ with contextlib.suppress(ImportError):
 # check if available for testing
 HAVE_ARRAY_API_STRICT = importlib.util.find_spec("array_api_strict") is not None
 HAVE_JAX = importlib.util.find_spec("jax") is not None
+SEED = 42
 
 
 def test_rng_dispatcher_numpy() -> None:
@@ -38,7 +39,7 @@ def test_rng_dispatcher_array_api_strict() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_init() -> None:
-    rng = _utils.Generator(42)
+    rng = _utils.Generator(SEED)
     assert isinstance(rng, _utils.Generator)
 
 
@@ -47,7 +48,7 @@ def test_random() -> None:
     import array_api_strict
     from array_api_strict._array_object import Array
 
-    rng = _utils.Generator(42)
+    rng = _utils.Generator(SEED)
     rvs = rng.random(size=10_000)
     assert rvs.shape == (10_000,)
     assert array_api_strict.min(rvs) >= 0.0
@@ -59,7 +60,7 @@ def test_random() -> None:
 def test_normal() -> None:
     from array_api_strict._array_object import Array
 
-    rng = _utils.Generator(42)
+    rng = _utils.Generator(SEED)
     rvs = rng.normal(1, 2, size=10_000)
     assert rvs.shape == (10_000,)
     assert isinstance(rvs, Array)
@@ -69,7 +70,7 @@ def test_normal() -> None:
 def test_standard_normal() -> None:
     from array_api_strict._array_object import Array
 
-    rng = _utils.Generator(42)
+    rng = _utils.Generator(SEED)
     rvs = rng.standard_normal(size=10_000)
     assert rvs.shape == (10_000,)
     assert isinstance(rvs, Array)
@@ -79,7 +80,7 @@ def test_standard_normal() -> None:
 def test_poisson() -> None:
     from array_api_strict._array_object import Array
 
-    rng = _utils.Generator(42)
+    rng = _utils.Generator(SEED)
     rvs = rng.poisson(lam=1, size=10_000)
     assert rvs.shape == (10_000,)
     assert isinstance(rvs, Array)
@@ -90,7 +91,7 @@ def test_uniform() -> None:
     import array_api_strict
     from array_api_strict._array_object import Array
 
-    rng = _utils.Generator(42)
+    rng = _utils.Generator(SEED)
     rvs = rng.uniform(size=10_000)
     assert rvs.shape == (10_000,)
     assert array_api_strict.min(rvs) >= 0.0

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -332,19 +332,20 @@ def test_generate_grf(compare: type[Compare]) -> None:
     gls = [np.array([1.0, 0.5, 0.1])]
     nside = 4
     ncorr = 1
+    seed = 42
 
     gaussian_fields = list(glass.fields._generate_grf(gls, nside))
 
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
     # requires resetting the RNG for reproducibility
-    rng = np.random.default_rng(seed=42)
+    rng = np.random.default_rng(seed=seed)
     gaussian_fields = list(glass.fields._generate_grf(gls, nside, rng=rng))
 
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
     # requires resetting the RNG for reproducibility
-    rng = np.random.default_rng(seed=42)
+    rng = np.random.default_rng(seed=seed)
     new_gaussian_fields = list(
         glass.fields._generate_grf(gls, nside, ncorr=ncorr, rng=rng),
     )

--- a/tests/core/test_jax.py
+++ b/tests/core/test_jax.py
@@ -7,17 +7,19 @@ from jax.typing import ArrayLike  # noqa: E402
 
 from glass.jax import Generator  # noqa: E402
 
+SEED = 42
+
 
 def test_init() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     assert isinstance(rng, Generator)
     assert isinstance(rng.key, jax.Array)
     assert jax.dtypes.issubdtype(rng.key.dtype, jax.dtypes.prng_key)
-    assert jnp.all(rng.key == jax.random.key(42))
+    assert jnp.all(rng.key == jax.random.key(SEED))
 
 
 def test_from_key() -> None:
-    key = jax.random.key(42)
+    key = jax.random.key(SEED)
     rng = Generator.from_key(key)
     assert rng.key is key
 
@@ -29,7 +31,7 @@ def test_from_key() -> None:
 
 
 def test_key() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     rngkey, outkey = jax.random.split(rng.key, 2)
     key = rng.split()
     assert jnp.all(rng.key == rngkey)
@@ -37,7 +39,7 @@ def test_key() -> None:
 
 
 def test_spawn() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     key, *subkeys = jax.random.split(rng.key, 4)
     subrngs = rng.spawn(3)
     assert rng.key == key
@@ -49,7 +51,7 @@ def test_spawn() -> None:
 
 
 def test_random() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     key = rng.key
     rvs = rng.random(size=10_000)
     assert rng.key != key
@@ -60,7 +62,7 @@ def test_random() -> None:
 
 
 def test_normal() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     key = rng.key
     rvs = rng.normal(1, 2, size=10_000)
     assert rng.key != key
@@ -69,7 +71,7 @@ def test_normal() -> None:
 
 
 def test_standard_normal() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     key = rng.key
     rvs = rng.standard_normal(size=10_000)
     assert rng.key != key
@@ -78,7 +80,7 @@ def test_standard_normal() -> None:
 
 
 def test_poisson() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     key = rng.key
     rvs = rng.poisson(lam=1, size=10_000)
     assert rng.key != key
@@ -87,7 +89,7 @@ def test_poisson() -> None:
 
 
 def test_uniform() -> None:
-    rng = Generator(42)
+    rng = Generator(SEED)
     key = rng.key
     rvs = rng.uniform(size=10_000)
     assert rng.key != key


### PR DESCRIPTION
# Description

Noticed in the benchmarking results that some calls to `np.random.default_rng` in particular did not set the random seed. This might be causing issues in the testing with inconsistent results.

Also, in this PR, there is some clearing up of the use of `42` so that it is easier to change in the future if needed. Also, fewer "magic numbers".

<!-- for user facing bugs -->
Fixes: #836

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: functions that would set a default RNG if not passed in now default to a seed of `42`

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
