### PR TITLE
gh-838: don't run regression tests when only tests change

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -8,8 +8,6 @@ on:
       - glass/**
       - noxfile.py
       - pyproject.toml
-      - tests/benchmarks/**
-      - tests/conftest.py
     branches:
       - main
     types:


### PR DESCRIPTION
# Description

The regression tests are flaky and so should only be run when something relevant actually changes. This PR removes test modifications alone being a reason to run them. The benchmark tests are still run for coverage all the time.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #838

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
