### PR TITLE
gh-853: import glass more consistently in tests

### DIFF
--- a/tests/benchmarks/test_fields.py
+++ b/tests/benchmarks/test_fields.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import healpy as hp
 import pytest
 
+import glass
 import glass.fields
 
 if TYPE_CHECKING:
@@ -35,7 +36,7 @@ def test_iternorm_no_size(
     array_in = [xp.asarray(x) for x in xp.arange(10_000, dtype=xp.float64)]
 
     def function_to_benchmark() -> list[Any]:
-        generator = glass.fields.iternorm(k, iter(array_in))
+        generator = glass.iternorm(k, iter(array_in))
         return generator_consumer.consume(generator)  # type: ignore[no-any-return]
 
     results = benchmark(function_to_benchmark)
@@ -82,7 +83,7 @@ def test_iternorm_specify_size(
     ]
 
     def function_to_benchmark() -> list[Any]:
-        generator = glass.fields.iternorm(k, iter(array_in), size)
+        generator = glass.iternorm(k, iter(array_in), size)
         return generator_consumer.consume(generator)  # type: ignore[no-any-return]
 
     # check output shapes and types
@@ -118,7 +119,7 @@ def test_iternorm_k_0(
     array_in = [xp.stack([x]) for x in xp.ones(1_000, dtype=xp.float64)]
 
     def function_to_benchmark() -> list[Any]:
-        generator = glass.fields.iternorm(k, iter(array_in))
+        generator = glass.iternorm(k, iter(array_in))
         return generator_consumer.consume(generator)  # type: ignore[no-any-return]
 
     results = benchmark(function_to_benchmark)
@@ -148,7 +149,7 @@ def test_cls2cov(
     array_in = [urng.random(3) for _ in range(1_000)]
 
     def function_to_benchmark() -> list[Any]:
-        generator = glass.fields.cls2cov(
+        generator = glass.cls2cov(
             array_in,
             nl,
             nf,
@@ -223,9 +224,9 @@ def test_generate(  # noqa: PLR0913
     expected_len: int,
     ncorr: int | None,
 ) -> None:
-    """Benchmarks for glass.fields.generate."""
+    """Benchmarks for glass.generate."""
     if xp.__name__ in {"array_api_strict", "jax.numpy"}:
-        pytest.skip(f"glass.fields.generate not yet ported for {xp.__name__}")
+        pytest.skip(f"glass.generate not yet ported for {xp.__name__}")
 
     n = 100
     fields = [lambda x, var: x for _ in range(n)]  # noqa: ARG005
@@ -235,7 +236,7 @@ def test_generate(  # noqa: PLR0913
     nside = 16
 
     def function_to_benchmark() -> list[Any]:
-        generator = glass.fields.generate(
+        generator = glass.generate(
             fields,  # type: ignore[arg-type]
             gls,
             nside=nside,
@@ -257,7 +258,7 @@ def test_getcl_lmax_0(
     compare: type[Compare],
     xp: ModuleType,
 ) -> None:
-    """Benchmarks for glass.fields.getcl with lmax of 0."""
+    """Benchmarks for glass.getcl with lmax of 0."""
     scale_factor = 1_000
     # make a mock Cls array with the index pairs as entries
     cls = [
@@ -271,7 +272,7 @@ def test_getcl_lmax_0(
 
     # check slicing
     result = benchmark(
-        glass.fields.getcl,
+        glass.getcl,
         cls,
         random_i,
         random_j,
@@ -288,7 +289,7 @@ def test_getcl_lmax_larger_than_cls(
     compare: type[Compare],
     xp: ModuleType,
 ) -> None:
-    """Benchmarks for glass.fields.getcl with lmax larger than the length of cl."""
+    """Benchmarks for glass.getcl with lmax larger than the length of cl."""
     scale_factor = 1_000
     # make a mock Cls array with the index pairs as entries
     cls = [
@@ -303,7 +304,7 @@ def test_getcl_lmax_larger_than_cls(
     # check padding
     lmax = scale_factor + 50
     result = benchmark(
-        glass.fields.getcl,
+        glass.getcl,
         cls,
         random_i,
         random_j,

--- a/tests/benchmarks/test_lensing.py
+++ b/tests/benchmarks/test_lensing.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import glass.lensing
+import glass
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -28,9 +28,7 @@ def test_multi_plane_matrix(
 ) -> None:
     """Benchmarks for add_window and add_plane with a multi_plane_matrix."""
     if xp.__name__ in {"array_api_strict", "jax.numpy"}:
-        pytest.skip(
-            f"glass.lensing.multi_plane_matrix not yet ported for {xp.__name__}"
-        )
+        pytest.skip(f"glass.multi_plane_matrix not yet ported for {xp.__name__}")
 
     # Use this over the fixture to allow us to add many more windows
     shells = [
@@ -49,19 +47,19 @@ def test_multi_plane_matrix(
 
     def setup_shells_and_deltas() -> tuple[
         tuple[
-            glass.lensing.MultiPlaneConvergence,
+            glass.MultiPlaneConvergence,
             zip[tuple[glass.RadialWindow, FloatArray]],
         ],
         dict[Never, Never],
     ]:
         """Run setup a generator with zip before each benchmark run."""
-        convergence = glass.lensing.MultiPlaneConvergence(cosmo)
+        convergence = glass.MultiPlaneConvergence(cosmo)
         return (convergence, zip(shells, deltas, strict=False)), {}
 
     def multi_plane_matrix_add_window(
-        convergence: type[glass.lensing.MultiPlaneConvergence],
+        convergence: type[glass.MultiPlaneConvergence],
         zipped: tuple[list[type[glass.RadialWindow]], FloatArray],
-    ) -> type[glass.lensing.MultiPlaneConvergence]:
+    ) -> type[glass.MultiPlaneConvergence]:
         """Call add_window repeatedly, to be benchmarked."""
         for shell, delta in zipped:
             convergence.add_window(delta, shell)  # type: ignore[arg-type,call-arg]
@@ -88,9 +86,7 @@ def test_multi_plane_weights(
 ) -> None:
     """Benchmarks for add_window and add_plane with a multi_plane_weights."""
     if xp.__name__ in {"array_api_strict", "jax.numpy"}:
-        pytest.skip(
-            f"glass.lensing.multi_plane_weights not yet ported for {xp.__name__}"
-        )
+        pytest.skip(f"glass.multi_plane_weights not yet ported for {xp.__name__}")
 
     # Use this over the fixture to allow us to add many more windows
     shells = [
@@ -112,19 +108,19 @@ def test_multi_plane_weights(
 
     def setup_shells_deltas_and_weights() -> tuple[
         tuple[
-            glass.lensing.MultiPlaneConvergence,
+            glass.MultiPlaneConvergence,
             zip[tuple[glass.RadialWindow, FloatArray, FloatArray]],
         ],
         dict[Never, Never],
     ]:
         """Run setup a generator with zip before each benchmark run."""
-        convergence = glass.lensing.MultiPlaneConvergence(cosmo)
+        convergence = glass.MultiPlaneConvergence(cosmo)
         return (convergence, zip(shells, deltas, weights, strict=False)), {}
 
     def multi_plane_weights_add_window(
-        convergence: type[glass.lensing.MultiPlaneConvergence],
+        convergence: type[glass.MultiPlaneConvergence],
         zipped: tuple[list[type[glass.RadialWindow]], FloatArray, FloatArray],
-    ) -> type[glass.lensing.MultiPlaneConvergence]:
+    ) -> type[glass.MultiPlaneConvergence]:
         """Call add_window repeatedly, to be benchmarked."""
         for shell, delta, _ in zipped:
             convergence.add_window(delta, shell)  # type: ignore[arg-type,call-arg]

--- a/tests/benchmarks/test_shapes.py
+++ b/tests/benchmarks/test_shapes.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import glass.shapes
+import glass
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -20,7 +20,7 @@ def test_ellipticity_ryden04(
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
-    """Benchmark for glass.shapes.ellipticity_ryden04."""
+    """Benchmark for glass.ellipticity_ryden04."""
     if xp.__name__ == "jax.numpy":
         pytest.skip(
             "Arrays in ellipticity_ryden04 are not immutable, so do not support jax",
@@ -34,9 +34,7 @@ def test_ellipticity_ryden04(
     gamma = urng.random(size)
     sigma_gamma = urng.random(size)
 
-    e = benchmark(
-        glass.shapes.ellipticity_ryden04, mu, sigma, gamma, sigma_gamma, size=size
-    )
+    e = benchmark(glass.ellipticity_ryden04, mu, sigma, gamma, sigma_gamma, size=size)
     assert e.shape == size
 
 
@@ -45,7 +43,7 @@ def test_ellipticity_gaussian(
     benchmark: BenchmarkFixture,
     xp: ModuleType,
 ) -> None:
-    """Benchmark for glass.shapes.ellipticity_guassian."""
+    """Benchmark for glass.ellipticity_guassian."""
     if xp.__name__ == "jax.numpy":
         pytest.skip(
             "Arrays in ellipticity_gaussian are not immutable, so do not support jax",
@@ -70,7 +68,7 @@ def test_ellipticity_intnorm(
     benchmark: BenchmarkFixture,
     xp: ModuleType,
 ) -> None:
-    """Benchmark for glass.shapes.ellipticity_intnorm."""
+    """Benchmark for glass.ellipticity_intnorm."""
     if xp.__name__ == "jax.numpy":
         pytest.skip(
             "Arrays in ellipticity_intnorm are not immutable, so do not support jax",

--- a/tests/benchmarks/test_shells.py
+++ b/tests/benchmarks/test_shells.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import glass.shells
+import glass
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -27,6 +27,6 @@ def test_radialwindow(
     wa = xp.arange(arr_length)
     za = xp.arange(arr_length)
 
-    w = benchmark(glass.shells.RadialWindow, za, wa)
+    w = benchmark(glass.RadialWindow, za, wa)
 
     compare.assert_allclose(w.zeff, expected_zeff)


### PR DESCRIPTION
# Description

If the function is exposed via `__init__.py` then import directly from `glass`.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #853

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
