### PR TITLE
gh-861: be more careful with coverage exclusion [WIP]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,8 @@ report = {exclude_also = [
     "class\\s+\\w+\\([^)]*\\bProtocol\\b[^)]*\\):", # protocol classes
     "if TYPE_CHECKING:",
 ], omit = [
-    "glass/_types.py",  # typing-only module
-    "glass/_version.py",  # not being tracked anyway
+    "_types.py", # typing-only module
+    "_version.py", # not being tracked anyway
 ], precision = 2, show_missing = true, skip_covered = true, skip_empty = true, sort = "cover"}
 run = {branch = true, parallel = true, source = [
     "glass",


### PR DESCRIPTION
# Description

In the [coverage.py documentation](https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion) they recommend the following

```toml
[tool.coverage.report]
exclude_also = [
    'def __repr__',
    'if self.debug:',
    'if settings.DEBUG',
    'raise AssertionError',
    'raise NotImplementedError',
    'if 0:',
    'if __name__ == .__main__.:',
    'if TYPE_CHECKING:',
    'class .*\bProtocol\):',
    '@(abc\.)?abstractmethod',
]
```

we are doing something similar, but it's not working. This PR aims to address that.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
