### PR TITLE
gh-858: remove `pythonLocation` which comes from `setup-python`

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           key:
             regression-${{ hashFiles('pyproject.toml') }}-${{
-            hashFiles('noxfile.py') }}-${{ env.pythonLocation }}
+            hashFiles('noxfile.py') }}
           path: .nox
 
       - name: Install only dev dependencies

--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           key:
             examples-${{ hashFiles('pyproject.toml') }}-${{
-            hashFiles('noxfile.py') }}-${{ env.pythonLocation }}
+            hashFiles('noxfile.py') }}
           path: .nox
 
       - name: Install only dev dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           key:
             tests-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('noxfile.py')
-            }}-${{ env.pythonLocation }}
+            }}-${{ matrix.python-version }}
           path: .nox
 
       - name: Install only dev dependencies


### PR DESCRIPTION
# Description

Realised we're setill using `env.pythonLocation` which comes from `setup-python`. Since moving to `uv` in #801 we're now using `setup-uv` which doesn't have access to that environment variable. You can see that in the caches.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #858

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
