### PR TITLE
gh-875: Filter jax from benchmark tests

### DIFF
--- a/tests/benchmarks/test_arraytools.py
+++ b/tests/benchmarks/test_arraytools.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
 @pytest.mark.unstable
 def test_broadcast_leading_axes(
     benchmark: BenchmarkFixture,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark test for glass.arraytools.broadcast_leading_axes."""
     # Ensure we don't use too much memory
     a_in = 0
     b_shape = (4, 10)
     c_shape = (30, 1, 5, 6)
-    b_in = xp_benchmarks.zeros(b_shape)
-    c_in = xp_benchmarks.zeros(c_shape)
+    b_in = xpb.zeros(b_shape)
+    c_in = xpb.zeros(c_shape)
 
     dims, *rest = benchmark(
         glass.arraytools.broadcast_leading_axes,
@@ -45,39 +45,39 @@ def test_broadcast_leading_axes(
 def test_cumulative_trapezoid_1d(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark test for glass.arraytools.cumulative_trapezoid."""
     scaled_length = 10_000
 
-    f = xp_benchmarks.arange(scaled_length + 1)[1:]  # [1, 2, 3, 4,...]
-    x = xp_benchmarks.arange(scaled_length)  # [0, 1, 2, 3,...]
+    f = xpb.arange(scaled_length + 1)[1:]  # [1, 2, 3, 4,...]
+    x = xpb.arange(scaled_length)  # [0, 1, 2, 3,...]
 
     expected_first_4_out = [0.0, 1.5, 4.0, 7.5]
 
     ct = benchmark(glass.arraytools.cumulative_trapezoid, f, x)
-    compare.assert_allclose(ct[:4], xp_benchmarks.asarray(expected_first_4_out))
+    compare.assert_allclose(ct[:4], xpb.asarray(expected_first_4_out))
 
 
 @pytest.mark.unstable
 def test_cumulative_trapezoid_2d(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark test for glass.arraytools.cumulative_trapezoid."""
     scaled_length = 5_000
 
-    f = xp_benchmarks.stack(
+    f = xpb.stack(
         [  # [[1, 2, 3, 4,...], [1, 2, 3, 4,...]]
-            xp_benchmarks.arange(scaled_length + 1)[1:],
-            xp_benchmarks.arange(scaled_length + 1)[1:],
+            xpb.arange(scaled_length + 1)[1:],
+            xpb.arange(scaled_length + 1)[1:],
         ],
     )
-    x = xp_benchmarks.arange(scaled_length)  # [0, 1, 2, 3,...]
+    x = xpb.arange(scaled_length)  # [0, 1, 2, 3,...]
 
     expected_first_4_out = [0.0, 1.5, 4.0, 7.5]
 
     ct = benchmark(glass.arraytools.cumulative_trapezoid, f, x)
-    compare.assert_allclose(ct[0, :4], xp_benchmarks.asarray(expected_first_4_out))
-    compare.assert_allclose(ct[1, :4], xp_benchmarks.asarray(expected_first_4_out))
+    compare.assert_allclose(ct[0, :4], xpb.asarray(expected_first_4_out))
+    compare.assert_allclose(ct[1, :4], xpb.asarray(expected_first_4_out))

--- a/tests/benchmarks/test_fields.py
+++ b/tests/benchmarks/test_fields.py
@@ -23,14 +23,11 @@ if TYPE_CHECKING:
 def test_iternorm_no_size(
     benchmark: BenchmarkFixture,
     generator_consumer: GeneratorConsumer,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.iternorm with default value for size."""
     k = 2
-    array_in = [
-        xp_benchmarks.asarray(x)
-        for x in xp_benchmarks.arange(10_000, dtype=xp_benchmarks.float64)
-    ]
+    array_in = [xpb.asarray(x) for x in xpb.arange(10_000, dtype=xpb.float64)]
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(k, iter(array_in))
@@ -42,7 +39,7 @@ def test_iternorm_no_size(
     assert isinstance(j, int)
     assert a.shape == (k,)
     assert s.shape == ()
-    assert s.dtype == xp_benchmarks.float64
+    assert s.dtype == xpb.float64
     assert s.shape == ()
 
 
@@ -51,7 +48,7 @@ def test_iternorm_no_size(
 def test_iternorm_specify_size(
     benchmark: BenchmarkFixture,
     generator_consumer: GeneratorConsumer,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
     num_dimensions: int,
 ) -> None:
     """Benchmarks for glass.iternorm with size specified."""
@@ -68,9 +65,7 @@ def test_iternorm_specify_size(
             ]
             for _ in range(10_000)
         ]
-    array_in = [
-        xp_benchmarks.asarray(arr, dtype=xp_benchmarks.float64) for arr in list_input
-    ]
+    array_in = [xpb.asarray(arr, dtype=xpb.float64) for arr in list_input]
     expected_result = [
         1,
         (3, 2),
@@ -103,14 +98,11 @@ def test_iternorm_k_0(
     benchmark: BenchmarkFixture,
     compare: Compare,
     generator_consumer: GeneratorConsumer,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.iternorm with k set to 0."""
     k = 0
-    array_in = [
-        xp_benchmarks.stack([x])
-        for x in xp_benchmarks.ones(1_000, dtype=xp_benchmarks.float64)
-    ]
+    array_in = [xpb.stack([x]) for x in xpb.ones(1_000, dtype=xpb.float64)]
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(k, iter(array_in))
@@ -121,7 +113,7 @@ def test_iternorm_k_0(
     j, a, s = results[0]
     assert j is None
     assert a.shape == (0,)
-    compare.assert_allclose(xp_benchmarks.asarray(s), 1.0)
+    compare.assert_allclose(xpb.asarray(s), 1.0)
 
 
 @pytest.mark.stable
@@ -129,14 +121,14 @@ def test_cls2cov(
     benchmark: BenchmarkFixture,
     compare: Compare,
     generator_consumer: GeneratorConsumer,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.cls2cov."""
     # check output values and shape
 
     nl, nf, nc = 3, 2, 2
-    array_in = [urng_benchmarks.random(3) for _ in range(1_000)]
+    array_in = [urngb.random(3) for _ in range(1_000)]
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.cls2cov(
@@ -151,11 +143,11 @@ def test_cls2cov(
     cov = covs[0]
 
     assert cov.shape == (nl, nc + 1)
-    assert cov.dtype == xp_benchmarks.float64
+    assert cov.dtype == xpb.float64
 
     compare.assert_allclose(
         cov[:, 0],
-        xp_benchmarks.asarray([0.348684, 0.047089, 0.487811]),
+        xpb.asarray([0.348684, 0.047089, 0.487811]),
         atol=1e-6,
     )
     compare.assert_allclose(
@@ -170,27 +162,25 @@ def test_cls2cov(
 @pytest.mark.parametrize("use_rng", [False, True])
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate_grf(  # noqa: PLR0913
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
     benchmark: BenchmarkFixture,
     generator_consumer: GeneratorConsumer,
-    urng_benchmarks: UnifiedGenerator,
+    urngb: UnifiedGenerator,
     use_rng: bool,  # noqa: FBT001
     ncorr: int | None,
 ) -> None:
     """Benchmarks for glass.fields._generate_grf with positional arguments only."""
-    if xp_benchmarks.__name__ == "array_api_strict":
-        pytest.skip(
-            f"glass.fields._generate_grf not yet ported for {xp_benchmarks.__name__}"
-        )
+    if xpb.__name__ == "array_api_strict":
+        pytest.skip(f"glass.fields._generate_grf not yet ported for {xpb.__name__}")
 
-    gls = [urng_benchmarks.random(1_000)]
+    gls = [urngb.random(1_000)]
     nside = 4
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.fields._generate_grf(
             gls,
             nside,
-            rng=urng_benchmarks if use_rng else None,  # type: ignore[arg-type]
+            rng=urngb if use_rng else None,  # type: ignore[arg-type]
             ncorr=ncorr,
         )
         return generator_consumer.consume(generator)  # type: ignore[no-any-return]
@@ -212,19 +202,19 @@ def test_generate(  # noqa: PLR0913
     benchmark: BenchmarkFixture,
     compare: Compare,
     generator_consumer: GeneratorConsumer,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
     expected_len: int,
     ncorr: int | None,
 ) -> None:
     """Benchmarks for glass.generate."""
-    if xp_benchmarks.__name__ == "array_api_strict":
-        pytest.skip(f"glass.generate not yet ported for {xp_benchmarks.__name__}")
+    if xpb.__name__ == "array_api_strict":
+        pytest.skip(f"glass.generate not yet ported for {xpb.__name__}")
 
     n = 100
     fields = [lambda x, var: x for _ in range(n)]  # noqa: ARG005
     fields[1] = lambda x, var: x**2  # noqa: ARG005
     nth_triangular_number = int((n * (n + 1)) / 2)
-    gls = [xp_benchmarks.ones(10) for _ in range(nth_triangular_number)]
+    gls = [xpb.ones(10) for _ in range(nth_triangular_number)]
     nside = 16
 
     def function_to_benchmark() -> list[Any]:
@@ -248,13 +238,13 @@ def test_generate(  # noqa: PLR0913
 def test_getcl_lmax_0(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.getcl with lmax of 0."""
     scale_factor = 1_000
     # make a mock Cls array with the index pairs as entries
     cls = [
-        xp_benchmarks.asarray([i, j], dtype=xp_benchmarks.float64)
+        xpb.asarray([i, j], dtype=xpb.float64)
         for i in range(scale_factor)
         for j in range(i, -1, -1)
     ]
@@ -270,9 +260,7 @@ def test_getcl_lmax_0(
         random_j,
         lmax=0,
     )
-    expected = xp_benchmarks.asarray(
-        [max(random_i, random_j)], dtype=xp_benchmarks.float64
-    )
+    expected = xpb.asarray([max(random_i, random_j)], dtype=xpb.float64)
     assert result.size == 1
     compare.assert_allclose(result, expected)
 
@@ -281,13 +269,13 @@ def test_getcl_lmax_0(
 def test_getcl_lmax_larger_than_cls(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.getcl with lmax larger than the length of cl."""
     scale_factor = 1_000
     # make a mock Cls array with the index pairs as entries
     cls = [
-        xp_benchmarks.asarray([i, j], dtype=xp_benchmarks.float64)
+        xpb.asarray([i, j], dtype=xpb.float64)
         for i in range(scale_factor)
         for j in range(i, -1, -1)
     ]
@@ -304,6 +292,6 @@ def test_getcl_lmax_larger_than_cls(
         random_j,
         lmax=lmax,
     )
-    expected = xp_benchmarks.zeros((lmax - 1,), dtype=xp_benchmarks.float64)
+    expected = xpb.zeros((lmax - 1,), dtype=xpb.float64)
     assert result.size == lmax + 1
     compare.assert_allclose(result[2:], expected)

--- a/tests/benchmarks/test_galaxies.py
+++ b/tests/benchmarks/test_galaxies.py
@@ -17,34 +17,34 @@ if TYPE_CHECKING:
 @pytest.mark.stable
 def test_redshifts(
     benchmark: BenchmarkFixture,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark for galaxies.redshifts."""
     scale_factor = 1_000
     # create a mock radial window function
-    za = xp_benchmarks.linspace(0.0, 1.0, 20 * scale_factor)
-    wa = xp_benchmarks.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
+    za = xpb.linspace(0.0, 1.0, 20 * scale_factor)
+    wa = xpb.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
     w = glass.RadialWindow(za, wa)
 
     # sample redshifts (scalar)
-    z = benchmark(glass.redshifts, 13 * scale_factor, w, rng=urng_benchmarks)
+    z = benchmark(glass.redshifts, 13 * scale_factor, w, rng=urngb)
     assert z.shape == (13 * scale_factor,)
-    assert xp_benchmarks.min(z) >= 0.0
-    assert xp_benchmarks.max(z) <= 1.0
+    assert xpb.min(z) >= 0.0
+    assert xpb.max(z) <= 1.0
 
 
 @pytest.mark.stable
 def test_redshifts_from_nz(
     benchmark: BenchmarkFixture,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark for galaxies.redshifts_from_nz."""
     scale_factor = 1_000
     # create a mock radial window function
-    za = xp_benchmarks.linspace(0.0, 1.0, 20 * scale_factor)
-    wa = xp_benchmarks.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
+    za = xpb.linspace(0.0, 1.0, 20 * scale_factor)
+    wa = xpb.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
 
     # sample redshifts (scalar)
     redshifts = benchmark(
@@ -52,36 +52,36 @@ def test_redshifts_from_nz(
         13 * scale_factor,
         za,
         wa,
-        rng=urng_benchmarks,
+        rng=urngb,
     )
     assert redshifts.shape == (13 * scale_factor,)
-    assert xp_benchmarks.min(redshifts) >= 0.0
-    assert xp_benchmarks.max(redshifts) <= 1.0
-    assert xp_benchmarks.all((0 <= redshifts) & (redshifts <= 1))  # noqa: SIM300
+    assert xpb.min(redshifts) >= 0.0
+    assert xpb.max(redshifts) <= 1.0
+    assert xpb.all((0 <= redshifts) & (redshifts <= 1))  # noqa: SIM300
 
 
 @pytest.mark.stable
 @pytest.mark.parametrize("reduced_shear", [True, False])
 def test_galaxy_shear(
     benchmark: BenchmarkFixture,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
     reduced_shear: bool,  # noqa: FBT001
 ) -> None:
     """Benchmark for galaxies.galaxy_shear."""
-    if xp_benchmarks.__name__ == "array_api_strict":
-        pytest.skip(f"glass.galaxy_shear not yet ported for {xp_benchmarks.__name__}")
+    if xpb.__name__ == "array_api_strict":
+        pytest.skip(f"glass.galaxy_shear not yet ported for {xpb.__name__}")
 
     scale_factor = 100
     size = (12 * scale_factor,)
-    kappa = urng_benchmarks.normal(size=size)
-    gamma1 = urng_benchmarks.normal(size=size)
-    gamma2 = urng_benchmarks.normal(size=size)
+    kappa = urngb.normal(size=size)
+    gamma1 = urngb.normal(size=size)
+    gamma2 = urngb.normal(size=size)
 
     gal_size = (512 * scale_factor,)
-    gal_lon = urng_benchmarks.normal(size=gal_size)
-    gal_lat = urng_benchmarks.normal(size=gal_size)
-    gal_eps = urng_benchmarks.normal(size=gal_size)
+    gal_lon = urngb.normal(size=gal_size)
+    gal_lat = urngb.normal(size=gal_size)
+    gal_eps = urngb.normal(size=gal_size)
 
     shear = benchmark(
         glass.galaxy_shear,
@@ -99,14 +99,14 @@ def test_galaxy_shear(
 @pytest.mark.stable
 def test_gaussian_phz(
     benchmark: BenchmarkFixture,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for galaxies.gaussian_phz."""
     scaled_length = 10_000
 
-    z = xp_benchmarks.linspace(0, 1, scaled_length)
-    sigma_0 = xp_benchmarks.ones(scaled_length)
+    z = xpb.linspace(0, 1, scaled_length)
+    sigma_0 = xpb.ones(scaled_length)
 
     phz = benchmark(
         glass.gaussian_phz,
@@ -114,9 +114,9 @@ def test_gaussian_phz(
         sigma_0,
         lower=0.5,
         upper=1.5,
-        rng=urng_benchmarks,
+        rng=urngb,
     )
 
     assert phz.shape == (scaled_length,)
-    assert xp_benchmarks.all(phz >= 0.5)
-    assert xp_benchmarks.all(phz <= 1.5)
+    assert xpb.all(phz >= 0.5)
+    assert xpb.all(phz <= 1.5)

--- a/tests/benchmarks/test_harmonics.py
+++ b/tests/benchmarks/test_harmonics.py
@@ -17,17 +17,17 @@ if TYPE_CHECKING:
 def test_multalm(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.harmonics.multalm."""
     scale_factor = 100_000
 
-    alm = xp_benchmarks.arange(scale_factor * 5, dtype=xp_benchmarks.float64)
-    bl = xp_benchmarks.asarray(scale_factor * 3, dtype=xp_benchmarks.float64)
+    alm = xpb.arange(scale_factor * 5, dtype=xpb.float64)
+    bl = xpb.asarray(scale_factor * 3, dtype=xpb.float64)
 
     result = benchmark(glass.harmonics.multalm, alm, bl)
 
     compare.assert_allclose(
         result[:5],
-        xp_benchmarks.asarray([scale_factor * x for x in [0.0, 3.0, 6.0, 9.0, 12.0]]),
+        xpb.asarray([scale_factor * x for x in [0.0, 3.0, 6.0, 9.0, 12.0]]),
     )

--- a/tests/benchmarks/test_lensing.py
+++ b/tests/benchmarks/test_lensing.py
@@ -23,29 +23,27 @@ def test_multi_plane_matrix(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
     cosmo: Cosmology,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for add_window and add_plane with a multi_plane_matrix."""
-    if xp_benchmarks.__name__ == "array_api_strict":
-        pytest.skip(
-            f"glass.multi_plane_matrix not yet ported for {xp_benchmarks.__name__}"
-        )
+    if xpb.__name__ == "array_api_strict":
+        pytest.skip(f"glass.multi_plane_matrix not yet ported for {xpb.__name__}")
 
     # Use this over the fixture to allow us to add many more windows
     shells = [
         glass.RadialWindow(
-            xp_benchmarks.arange(i, i + 3, dtype=xp_benchmarks.float64),
-            xp_benchmarks.asarray([0.0, 1.0, 0.0]),
+            xpb.arange(i, i + 3, dtype=xpb.float64),
+            xpb.asarray([0.0, 1.0, 0.0]),
             float(i + 1),
         )
         for i in range(1000)
     ]
     mat = glass.multi_plane_matrix(shells, cosmo)
-    deltas = urng_benchmarks.random((len(shells), 10))
+    deltas = urngb.random((len(shells), 10))
 
-    compare.assert_array_equal(mat, xp_benchmarks.tril(mat))
-    compare.assert_array_equal(xp_benchmarks.triu(mat, 1), 0)
+    compare.assert_array_equal(mat, xpb.tril(mat))
+    compare.assert_array_equal(xpb.triu(mat, 1), 0)
 
     def setup_shells_and_deltas() -> tuple[
         tuple[
@@ -83,32 +81,30 @@ def test_multi_plane_weights(
     benchmark: BenchmarkFixture,
     compare: type[Compare],
     cosmo: Cosmology,
-    urng_benchmarks: UnifiedGenerator,
-    xp_benchmarks: ModuleType,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
 ) -> None:
     """Benchmarks for add_window and add_plane with a multi_plane_weights."""
-    if xp_benchmarks.__name__ == "array_api_strict":
-        pytest.skip(
-            f"glass.multi_plane_weights not yet ported for {xp_benchmarks.__name__}"
-        )
+    if xpb.__name__ == "array_api_strict":
+        pytest.skip(f"glass.multi_plane_weights not yet ported for {xpb.__name__}")
 
     # Use this over the fixture to allow us to add many more windows
     shells = [
         glass.RadialWindow(
-            xp_benchmarks.arange(i, i + 3, dtype=xp_benchmarks.float64),
-            xp_benchmarks.asarray([0.0, 1.0, 0.0]),
+            xpb.arange(i, i + 3, dtype=xpb.float64),
+            xpb.asarray([0.0, 1.0, 0.0]),
             float(i + 1),
         )
         for i in range(500)
     ]
-    w_in = xp_benchmarks.eye(len(shells))
-    deltas = urng_benchmarks.random((len(shells), 10))
-    weights = urng_benchmarks.random((len(shells), 3))
+    w_in = xpb.eye(len(shells))
+    deltas = urngb.random((len(shells), 10))
+    weights = urngb.random((len(shells), 3))
 
     w_out = glass.multi_plane_weights(w_in, shells, cosmo)
 
-    compare.assert_array_equal(w_out, xp_benchmarks.triu(w_out, 1))
-    compare.assert_array_equal(xp_benchmarks.tril(w_out), 0)
+    compare.assert_array_equal(w_out, xpb.triu(w_out, 1))
+    compare.assert_array_equal(xpb.tril(w_out), 0)
 
     def setup_shells_deltas_and_weights() -> tuple[
         tuple[

--- a/tests/benchmarks/test_shapes.py
+++ b/tests/benchmarks/test_shapes.py
@@ -17,17 +17,17 @@ if TYPE_CHECKING:
 @pytest.mark.stable
 def test_ellipticity_ryden04(
     benchmark: BenchmarkFixture,
-    urng_benchmarks: UnifiedGenerator,
+    urngb: UnifiedGenerator,
 ) -> None:
     """Benchmark for glass.ellipticity_ryden04."""
     size = (1000, 1000)
 
     # single ellipticity
 
-    mu = urng_benchmarks.random(size) * -1.0
-    sigma = urng_benchmarks.random(size)
-    gamma = urng_benchmarks.random(size)
-    sigma_gamma = urng_benchmarks.random(size)
+    mu = urngb.random(size) * -1.0
+    sigma = urngb.random(size)
+    gamma = urngb.random(size)
+    sigma_gamma = urngb.random(size)
 
     e = benchmark(glass.ellipticity_ryden04, mu, sigma, gamma, sigma_gamma, size=size)
     assert e.shape == size
@@ -36,13 +36,13 @@ def test_ellipticity_ryden04(
 @pytest.mark.stable
 def test_ellipticity_gaussian(
     benchmark: BenchmarkFixture,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark for glass.ellipticity_guassian."""
     array_length = 10
     n = 1_000_000
-    count = xp_benchmarks.full(array_length, fill_value=n)
-    sigma = xp_benchmarks.full(array_length, fill_value=0.256)
+    count = xpb.full(array_length, fill_value=n)
+    sigma = xpb.full(array_length, fill_value=0.256)
 
     eps = benchmark(
         glass.ellipticity_gaussian,
@@ -56,13 +56,13 @@ def test_ellipticity_gaussian(
 @pytest.mark.stable
 def test_ellipticity_intnorm(
     benchmark: BenchmarkFixture,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
 ) -> None:
     """Benchmark for glass.ellipticity_intnorm."""
     array_length = 10
     n = 1_000_000
-    count = xp_benchmarks.full(array_length, fill_value=n)
-    sigma = xp_benchmarks.full(array_length, fill_value=0.256)
+    count = xpb.full(array_length, fill_value=n)
+    sigma = xpb.full(array_length, fill_value=0.256)
 
     eps = benchmark(
         glass.ellipticity_intnorm,

--- a/tests/benchmarks/test_shells.py
+++ b/tests/benchmarks/test_shells.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 @pytest.mark.unstable
 def test_radialwindow(
     benchmark: BenchmarkFixture,
-    xp_benchmarks: ModuleType,
+    xpb: ModuleType,
     compare: Compare,
 ) -> None:
     """Benchmark for shells.RadialWindow."""
@@ -24,8 +24,8 @@ def test_radialwindow(
     arr_length = 100_000
     expected_zeff = 66_666.0
 
-    wa = xp_benchmarks.arange(arr_length)
-    za = xp_benchmarks.arange(arr_length)
+    wa = xpb.arange(arr_length)
+    za = xpb.arange(arr_length)
 
     w = benchmark(glass.RadialWindow, za, wa)
 

--- a/tests/fixtures/array_backends.py
+++ b/tests/fixtures/array_backends.py
@@ -116,7 +116,7 @@ def xp(request: pytest.FixtureRequest) -> ModuleType:
     params=[xp for name, xp in xp_available_backends.items() if name != "jax.numpy"],
     scope="session",
 )
-def xp_benchmarks(request: pytest.FixtureRequest) -> ModuleType:
+def xpb(request: pytest.FixtureRequest) -> ModuleType:
     """
     Fixture for array backend.
 

--- a/tests/fixtures/generators.py
+++ b/tests/fixtures/generators.py
@@ -57,12 +57,12 @@ def urng(xp: ModuleType) -> UnifiedGenerator:
 
 
 @pytest.fixture
-def urng_benchmarks(xp_benchmarks: ModuleType) -> UnifiedGenerator:
+def urngb(xpb: ModuleType) -> UnifiedGenerator:
     """
     Fixture for a unified RNG interface to be used in benchmarks.
 
-    Access the relevant RNG using `urng_benchmarks.` in tests.
+    Access the relevant RNG using `urngb.` in tests.
 
-    Must be used with the `xp_benchmarks` fixture.
+    Must be used with the `xpb` fixture.
     """
-    return _select_urng(xp_benchmarks)
+    return _select_urng(xpb)


### PR DESCRIPTION
# Description

Adds new test fixtures `xp_benchmarks` and `urng_benchmarks` whcih exclude jax. This is done as regression testing jax does not make sense since it is not supported in older versions.

Closes: #875 

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
