### PR TITLE
gh-878: Use fixture.* rather than tests.fixture.*

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import logging
 logging.getLogger("jax").setLevel(logging.ERROR)
 
 pytest_plugins = [
-    "tests.fixtures.array_backends",
-    "tests.fixtures.domain",
-    "tests.fixtures.generators",
-    "tests.fixtures.helper_classes",
+    "fixtures.array_backends",
+    "fixtures.domain",
+    "fixtures.generators",
+    "fixtures.helper_classes",
 ]


### PR DESCRIPTION
# Description

Regression tests where failing to import `tests`. If we remove `tests` from the module path it works locally.


Closes: #878 

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
