### PR TITLE
gh-890: add `warn=False` to `redshifts_from_nz` benchmarks

### DIFF
--- a/tests/benchmarks/test_galaxies.py
+++ b/tests/benchmarks/test_galaxies.py
@@ -53,6 +53,7 @@ def test_redshifts_from_nz(
         za,
         wa,
         rng=urngb,
+        warn=False,
     )
     assert redshifts.shape == (13 * scale_factor,)
     assert xpb.min(redshifts) >= 0.0


### PR DESCRIPTION
# Description

We're getting known warnings in the test logs. Should suppress them when the warning isn't desired.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #890

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
