### PR TITLE
gh-432: Run test_multalm with jax

### DIFF
--- a/tests/core/test_harmonics.py
+++ b/tests/core/test_harmonics.py
@@ -13,10 +13,6 @@ if TYPE_CHECKING:
 
 
 def test_multalm(compare: type[Compare], xp: ModuleType) -> None:
-    # Call jax version of iternorm once jax version is written
-    if xp.__name__ == "jax.numpy":
-        pytest.skip("Arrays in multalm are not immutable, so do not support jax")
-
     # check output values and shapes
 
     alm = xp.asarray([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])


### PR DESCRIPTION
# Description

Runs test_multalm with jax as it does not mutate any arrays.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
Refs: #432 

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
