### PR TITLE
gh-912: use `math.pi`

### DIFF
--- a/glass/points.py
+++ b/glass/points.py
@@ -498,7 +498,7 @@ def displace(
     #              cosθ cos|α| + sinθ sin|α| cosγ)
     # δ = arctan2(sin|α| sinγ, sinθ cos|α| - cosθ sin|α| cosγ)
 
-    t = xp.asarray(lat) / 180 * xp.pi
+    t = xp.asarray(lat) / 180 * math.pi
     ct, st = xp.sin(t), xp.cos(t)  # sin and cos flipped: lat not co-lat
 
     a = xp.hypot(alpha1, alpha2)  # abs(alpha)
@@ -511,7 +511,7 @@ def displace(
 
     d = xp.atan2(sa * sg, st * ca - ct * sa * cg)
 
-    return lon - d / xp.pi * 180, tp / xp.pi * 180
+    return lon - d / math.pi * 180, tp / math.pi * 180
 
 
 def displacement(
@@ -551,9 +551,9 @@ def displacement(
         use_compat=False,
     )
 
-    a = (90.0 - to_lat) / 180 * xp.pi
-    b = (90.0 - from_lat) / 180 * xp.pi
-    g = (from_lon - to_lon) / 180 * xp.pi
+    a = (90.0 - to_lat) / 180 * math.pi
+    b = (90.0 - from_lat) / 180 * math.pi
+    g = (from_lon - to_lon) / 180 * math.pi
 
     sa, ca = xp.sin(a), xp.cos(a)
     sb, cb = xp.sin(b), xp.cos(b)

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -24,6 +24,7 @@ Utilities
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import array_api_compat
@@ -98,7 +99,7 @@ def triaxial_axis_ratio(
     cos2_theta = rng.uniform(low=-1.0, high=1.0, size=size)
     cos2_theta *= cos2_theta
     sin2_theta = 1 - cos2_theta
-    cos2_phi = xp.cos(rng.uniform(low=0.0, high=2 * xp.pi, size=size))
+    cos2_phi = xp.cos(rng.uniform(low=0.0, high=2 * math.pi, size=size))
     cos2_phi *= cos2_phi
     sin2_phi = 1 - cos2_phi
 
@@ -207,7 +208,7 @@ def ellipticity_ryden04(  # noqa: PLR0913
     q = triaxial_axis_ratio(zeta, xi, rng=rng)
 
     # assemble ellipticity with random complex phase
-    e = xp.exp(1j * rng.uniform(0, 2 * xp.pi, size=q.shape))
+    e = xp.exp(1j * rng.uniform(0, 2 * math.pi, size=q.shape))
     e *= (1 - q) / (1 + q)
 
     # return the ellipticity

--- a/tests/core/test_points.py
+++ b/tests/core/test_points.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import healpix
@@ -339,7 +340,7 @@ def test_position_weights(
 def test_displace_arg_complex(compare: type[Compare], xp: ModuleType) -> None:
     """Test displace function with complex-valued displacement."""
     d = 5.0  # deg
-    r = d / 180 * xp.pi
+    r = d / 180 * math.pi
 
     # displace the origin so everything is easy
     lon0 = xp.asarray(0.0)
@@ -365,7 +366,7 @@ def test_displace_arg_complex(compare: type[Compare], xp: ModuleType) -> None:
 def test_displace_arg_real(compare: type[Compare], xp: ModuleType) -> None:
     """Test displace function with real-valued argument."""
     d = 5.0  # deg
-    r = d / 180 * xp.pi
+    r = d / 180 * math.pi
 
     # displace the origin so everything is easy
     lon0 = xp.asarray(0.0)
@@ -395,17 +396,17 @@ def test_displace_abs(
 ) -> None:
     """Check that points are displaced by the correct angular distance."""
     n = 1_000
-    abs_alpha = urng.uniform(0, 2 * xp.pi, size=n)
-    arg_alpha = urng.uniform(-xp.pi, xp.pi, size=n)
+    abs_alpha = urng.uniform(0, 2 * math.pi, size=n)
+    arg_alpha = urng.uniform(-math.pi, math.pi, size=n)
 
-    lon_ = urng.uniform(-xp.pi, xp.pi, size=n) / xp.pi * 180
-    lat_ = xp.asin(urng.uniform(-1, 1, size=n)) / xp.pi * 180
+    lon_ = urng.uniform(-math.pi, math.pi, size=n) / math.pi * 180
+    lat_ = xp.asin(urng.uniform(-1, 1, size=n)) / math.pi * 180
 
     lon, lat = glass.displace(lon_, lat_, abs_alpha * xp.exp(1j * arg_alpha))
 
-    th = (90.0 - lat) / 180 * xp.pi
-    th_ = (90.0 - lat_) / 180 * xp.pi
-    delta = (lon - lon_) / 180 * xp.pi
+    th = (90.0 - lat) / 180 * math.pi
+    th_ = (90.0 - lat_) / 180 * math.pi
+    delta = (lon - lon_) / 180 * math.pi
 
     cos_a = xp.cos(th) * xp.cos(th_) + xp.cos(delta) * xp.sin(th) * xp.sin(th_)
 
@@ -419,11 +420,11 @@ def test_displacement(
 ) -> None:
     """Check that displacement of points is computed correctly."""
     # unit changes for displacements
-    deg5 = xp.asarray(5.0) / 180 * xp.pi
+    deg5 = xp.asarray(5.0) / 180 * math.pi
     north = xp.exp(xp.asarray(1j * 0.0))
-    east = xp.exp(xp.asarray(1j * (xp.pi / 2)))
-    south = xp.exp(xp.asarray(1j * xp.pi))
-    west = xp.exp(xp.asarray(1j * (3 * xp.pi / 2)))
+    east = xp.exp(xp.asarray(1j * (math.pi / 2)))
+    south = xp.exp(xp.asarray(1j * math.pi))
+    west = xp.exp(xp.asarray(1j * (3 * math.pi / 2)))
 
     zero = xp.asarray(0.0)
     five = xp.asarray(5.0)


### PR DESCRIPTION
# Description

Consistent use of `math.pi` over `xp.pi` to aid in Array API porting.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #912

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
