### PR TITLE
gh-920: Remove array-api-strict from xpb

### DIFF
--- a/tests/fixtures/array_backends.py
+++ b/tests/fixtures/array_backends.py
@@ -121,13 +121,13 @@ def xpb(request: pytest.FixtureRequest) -> ModuleType:
     Access array library functions using `xpb.` in tests.
 
     We are excluding array-api-strict and jax for two reasons
-    1. Our use of array-api-strict is not for its Performance but
+    1. Our use of array-api-strict is not for its performance but
        for checking our interface with array libraries. Additionally,
        users are unlikely to use array-api-strict with glass.
        Therefore, it is not worth benchmarking with array-api-strict.
     2. We did not previously support jax, therefore it does
        not _yet_ make sense to regression test jax as there is
-       nothing to compare against since jax is not supported by
+       nothing to compare against, since jax is not supported by
        the older versions of glass.
     """
     return request.param  # type: ignore[no-any-return]


### PR DESCRIPTION
# Description

Removes array-api-strict from `xpb` and adds a description about why we are filtering each backend.

Closes: #920 

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
