### PR TITLE
gh-920: Filter array_api_strict using the correct string

### DIFF
--- a/tests/fixtures/array_backends.py
+++ b/tests/fixtures/array_backends.py
@@ -110,7 +110,7 @@ def xp(request: pytest.FixtureRequest) -> ModuleType:
     params=[
         xp
         for name, xp in xp_available_backends.items()
-        if name not in {"array-api-strict", "jax.numpy"}
+        if name not in {"array_api_strict", "jax.numpy"}
     ],
     scope="session",
 )


### PR DESCRIPTION
# Description

Fixes something missed in #922. Uses the correct string to filter array_api_strict from xpb.

Refs: #920 

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
