### PR TITLE
gh-931: fix version for TestPyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,13 @@ jobs:
       - name: List distributions to be deployed
         run: ls -l dist/
 
+      - name: Extract version
+        run: |-
+          VERSION=$(echo ls dist/*.whl | head -1 | cut -d- -f2 | cut -d+ -f1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true


### PR DESCRIPTION
# Description

The version needs to be set for TestPyPI so that the `workflow_dispatch` can run successfully. This PR extracts the version from the `dist` so it should work.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #932

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
