### PR TITLE
gh-908: Port `shapes.py` to support jax

### DIFF
--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -360,7 +360,7 @@ def ellipticity_intnorm(
             xp.asarray(1.0, dtype=e.dtype),
         )
 
-        eps[i : i + count_broadcasted[k]] = e
+        eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
     return eps

--- a/tests/core/test_shapes.py
+++ b/tests/core/test_shapes.py
@@ -167,11 +167,6 @@ def test_ellipticity_intnorm(
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
-    if xp.__name__ == "jax.numpy":
-        pytest.skip(
-            "Arrays in ellipticity_intnorm are not immutable, so do not support jax",
-        )
-
     n = 1_000_000
 
     eps = glass.ellipticity_intnorm(n, 0.256, xp=xp)


### PR DESCRIPTION
# Description

Removes mutations from three functions in `shapes.py` using `array_api_extra.at`.

Closes: #908

## Changelog entry

Added: Support for `jax.numpy` in `glass.ellipticity_ryden04`, `glass.ellipticity_gaussian` and `glass.ellipticity_intnorm`

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
