### PR TITLE
gh-907: Port points.uniform_positions to support jax

### DIFF
--- a/glass/points.py
+++ b/glass/points.py
@@ -45,6 +45,7 @@ import healpix
 import numpy as np
 
 import array_api_compat
+import array_api_extra as xpx
 
 import glass._array_api_utils as _utils
 import glass.arraytools
@@ -388,7 +389,7 @@ def uniform_positions(
         count: int | IntArray
         if dims:
             count = xp.zeros(dims, dtype=xp.int64)
-            count[k] = ngal_sphere[k]  # type: ignore[index]
+            count = xpx.at(count)[k].set(ngal_sphere[k])
         else:
             count = int(ngal_sphere[k])
 

--- a/tests/core/test_points.py
+++ b/tests/core/test_points.py
@@ -258,11 +258,6 @@ def test_uniform_positions(
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
-    if xp.__name__ == "jax.numpy":
-        pytest.skip(
-            "Arrays in uniform_positions are not immutable, so do not support jax",
-        )
-
     # case: scalar input
 
     ngal: float | FloatArray = 1e-3


### PR DESCRIPTION
# Description

Ports `points.uniform_positions` to support jax 

Refs: #907

## Changelog entry

Added: Support for `jax.numpy` to glass.uniform_positions`

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
