### PR TITLE
gh-992: Use of `default_xp` to reduce the importing numpy

### DIFF
--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -20,9 +20,6 @@ if TYPE_CHECKING:
     from glass._types import ComplexArray, DTypeLike, FloatArray, IntArray
 
 
-DEFAULT_XP = _utils.default_xp()
-
-
 def alm2map(  # noqa: PLR0913
     alms: ComplexArray | Sequence[ComplexArray],
     nside: int,
@@ -151,7 +148,7 @@ def ang2pix(
     phi: float | FloatArray,
     *,
     lonlat: bool = False,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> IntArray:
     """
     Converts the angle to HEALPix pixel numbers.
@@ -174,6 +171,8 @@ def ang2pix(
         The HEALPix pixel numbers.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     return xp.asarray(
         healpix.ang2pix(
             nside,
@@ -189,7 +188,7 @@ def ang2vec(
     phi: float | FloatArray,
     *,
     lonlat: bool = False,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> tuple[FloatArray, FloatArray, FloatArray]:
     """
     Convert angles to 3D position vector.
@@ -210,6 +209,8 @@ def ang2vec(
         A normalised 3-vector pointing in the same direction as ``ang``.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     x, y, z = healpix.ang2vec(
         np.asarray(theta),
         np.asarray(phi),
@@ -317,7 +318,7 @@ def pixwin(
     *,
     lmax: int | None = None,
     pol: bool = False,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> tuple[FloatArray, ...]:
     """
     Return the pixel window function for the given nside.
@@ -338,6 +339,8 @@ def pixwin(
         The temperature pixel window function.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     output = healpy.pixwin(nside, lmax=lmax, pol=pol)
     return (
         tuple(xp.asarray(out, dtype=xp.float64) for out in output)
@@ -351,7 +354,7 @@ def query_strip(
     thetas: tuple[float, float],
     *,
     dtype: DTypeLike | None = None,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> IntArray:
     """
     Computes a mask of the pixels whose centers lie within the colatitude range
@@ -373,6 +376,8 @@ def query_strip(
         The mask of the pixels which lie within the given strip.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     output = np.zeros(nside2npix(nside))
     indices = healpy.query_strip(nside, *thetas)
     output[indices] = 1
@@ -428,7 +433,7 @@ class Rotator:
         self,
         *,
         coord: Sequence[str] | None = None,
-        xp: ModuleType = DEFAULT_XP,
+        xp: ModuleType | None = None,
     ) -> None:
         """Create a rotator with given parameters.
 
@@ -440,6 +445,8 @@ class Rotator:
             The array library backend to use for array operations.
 
         """
+        xp = _utils.default_xp() if xp is None else xp
+
         self.coord = coord
         self.xp = xp
 

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -31,8 +31,6 @@ import itertools
 import math
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 import array_api_compat
 
 import glass._array_api_utils as _utils
@@ -45,15 +43,12 @@ if TYPE_CHECKING:
     from glass._types import FloatArray
 
 
-DEFAULT_XP = _utils.default_xp()
-
-
 def vmap_galactic_ecliptic(
     nside: int,
     galactic: tuple[float, float] = (30, 90),
     ecliptic: tuple[float, float] = (20, 80),
     *,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> FloatArray:
     """
     Visibility map masking galactic and ecliptic plane.
@@ -85,6 +80,8 @@ def vmap_galactic_ecliptic(
         If the ``ecliptic`` argument is not a pair of numbers.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     if len(galactic) != 2:
         msg = "galactic stripe must be a pair of numbers"  # type: ignore[unreachable]
         raise TypeError(msg)
@@ -221,7 +218,7 @@ def fixed_zbins(
     *,
     nbins: int | None = None,
     dz: float | None = None,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> list[tuple[float, float]]:
     """
     Tomographic redshift bins of fixed size.
@@ -252,6 +249,8 @@ def fixed_zbins(
         If both ``nbins`` and ``dz`` are given.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     if nbins is not None and dz is None:
         zbinedges = xp.linspace(zmin, zmax, nbins + 1)
     elif nbins is None and dz is not None:

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -66,9 +66,6 @@ if TYPE_CHECKING:
     from glass.cosmology import Cosmology
 
 
-DEFAULT_XP = _utils.default_xp()
-
-
 @dataclasses.dataclass
 class DistanceWeight:
     """Uniform weight in comoving distance.
@@ -830,7 +827,7 @@ def _uniform_grid(
     *,
     step: float | None = None,
     num: int | None = None,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> FloatArray:
     """
     Create a uniform grid.
@@ -858,6 +855,8 @@ def _uniform_grid(
         If both ``step`` and ``num`` are given.
 
     """
+    xp = _utils.default_xp() if xp is None else xp
+
     if step is not None and num is None:
         return xp.arange(start, stop + step, step)
     if step is None and num is not None:
@@ -872,7 +871,7 @@ def redshift_grid(
     *,
     dz: float | None = None,
     num: int | None = None,
-    xp: ModuleType = DEFAULT_XP,
+    xp: ModuleType | None = None,
 ) -> FloatArray:
     """
     Redshift grid with uniform spacing in redshift.


### PR DESCRIPTION
# Description

- Instead of importing numpy whenever we need to specify the default array backend this PR uses `array_api_utils.default_xp()`
- I have to set the default XP to a global for each relevant module as ruff complains otherwise

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #992

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
