### PR TITLE
gh-1052: `RadialWindow` is now a `dataclass`

### DIFF
--- a/docs/user/how-glass-works.rst
+++ b/docs/user/how-glass-works.rst
@@ -20,8 +20,8 @@ Radial discretisation
 The discretisation in the radial (line of sight) direction is done in *GLASS*
 using the concept of a :term:`radial window`, which consists of a window
 function :math:`W` that assigns a weight :math:`W(z)` to each redshift
-:math:`z`.  In the *GLASS* code, the :class:`~glass.RadialWindow` named
-tuple is used to define radial windows.
+:math:`z`.  In the *GLASS* code, the :class:`~glass.RadialWindow` ``dataclass``
+is used to define radial windows.
 
 A sequence :math:`W_1, W_2, \ldots` of such window functions defines the shells
 of the simulation.  For example, the :func:`~glass.tophat_windows`


### PR DESCRIPTION
# Description

Just spotted this while preparing for the ARCHER2 talk.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1052

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
