### PR TITLE
gh-1057: Remove redundant array conversions

### DIFF
--- a/glass/observations.py
+++ b/glass/observations.py
@@ -269,7 +269,7 @@ def equal_dens_zbins(
     z: FloatArray,
     nz: FloatArray,
     nbins: int,
-) -> list[tuple[float, float]]:
+) -> list[tuple[FloatArray, FloatArray]]:
     """
     Equal density tomographic redshift bins.
 
@@ -359,9 +359,10 @@ def tomo_nz_gausserr(
     sz = 2**0.5 * sigma_0 * (1 + z)
     # we need to call xp.asarray here because erf will return a numpy
     # array for array libs which do not implement vectorize.
-    binned_nz = xp.asarray(erf((z - z_lower) / sz))
-    binned_nz -= xp.asarray(erf((z - z_upper) / sz))
-    binned_nz /= 1 + xp.asarray(erf(z / sz))
+    binned_nz = erf((z - z_lower) / sz)
+    binned_nz -= erf((z - z_upper) / sz)
+    binned_nz /= 1 + erf(z / sz)
+    binned_nz = xp.asarray(binned_nz)
     binned_nz *= nz
 
     return binned_nz


### PR DESCRIPTION
# Description

<!-- describe you changes here
make sure your PR title starts with "gh-XXX: " where XXX is the issue you are
solving -->

- Removes the redundant call to `xp.asarray` in `tomo_nz_gausserr` to aid performance.
- Also fixes a ty linting error.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1057

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
