### PR TITLE
gh-1045: bump Array API to `2025.12`

### DIFF
--- a/tests/fixtures/array_backends.py
+++ b/tests/fixtures/array_backends.py
@@ -63,7 +63,7 @@ def _import_and_add_array_api_strict(
 
     _check_version("array_api_strict", "2.3.1")
     xp_available_backends["array_api_strict"] = array_api_strict
-    array_api_strict.set_array_api_strict_flags(api_version="2024.12")
+    array_api_strict.set_array_api_strict_flags(api_version="2025.12")
 
 
 def _import_and_add_jax(xp_available_backends: dict[str, ModuleType]) -> None:


### PR DESCRIPTION
# Description

Bumps Array API to `2025.12`.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1045

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Changed: Array API version

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
