### PR TITLE
gh-1066: Pin `ty` in local `pre-commit` hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage*
 dist
 styles
 tests/benchmarks/**/results
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
   - repo: local
     hooks:
       - id: ty
-        entry: uv run ty check
+        entry: uv run --with ty==0.0.35 ty check
         language: python
         name: ty-check
         pass_filenames: true

--- a/glass/algorithm.py
+++ b/glass/algorithm.py
@@ -99,7 +99,7 @@ def nnls(
             q = xpx.at(q)[x <= 0].set(False)
         x = xpx.at(x)[q].set(sq)
         x = xpx.at(x)[~q].set(0)
-    return x  # ty: ignore[invalid-return-type]
+    return x
 
 
 def cov_clip(

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -103,7 +103,7 @@ def broadcast_leading_axes(
         xp.broadcast_to(xp.asarray(a), dims + t)
         for (a, _), t in zip(args, trails, strict=False)
     )
-    return (dims, *arrs)
+    return (dims, *arrs) # ty: ignore[invalid-return-type]
 
 
 def ndinterp(  # noqa: PLR0913

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -103,7 +103,7 @@ def broadcast_leading_axes(
         xp.broadcast_to(xp.asarray(a), dims + t)
         for (a, _), t in zip(args, trails, strict=False)
     )
-    return (dims, *arrs) # ty: ignore[invalid-return-type]
+    return (dims, *arrs)  # ty: ignore[invalid-return-type]
 
 
 def ndinterp(  # noqa: PLR0913

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -684,7 +684,7 @@ def effective_cls(
         out = xpx.at(out)[j1 + j2 + (...,)].set(cl)
         if weights2 is weights1 and j1 != j2:
             out = xpx.at(out)[j2 + j1 + (...,)].set(cl)
-    return out  # ty: ignore[invalid-return-type]
+    return out
 
 
 def gaussian_fields(
@@ -1022,7 +1022,7 @@ def cov_from_spectra(
         cov = xpx.at(cov)[:size, i, j].set(cl_flat[:size])
         cov = xpx.at(cov)[:size, j, i].set(cl_flat[:size])
 
-    return cov  # ty: ignore[invalid-return-type]
+    return cov
 
 
 def check_posdef_spectra(spectra: AngularPowerSpectra) -> bool:

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -154,7 +154,7 @@ def redshifts_from_nz(
 
     assert total == redshifts.size  # noqa: S101
 
-    return redshifts  # ty: ignore[invalid-return-type]
+    return redshifts
 
 
 def galaxy_shear(  # noqa: PLR0913

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -625,7 +625,7 @@ def multi_plane_matrix(
     for i, w in enumerate(shells):
         mpc.add_window(xp.asarray(wmat[i, :], copy=True), w)
         wmat = xpx.at(wmat)[i, :].set(mpc.kappa)
-    return wmat  # ty: ignore[invalid-return-type]
+    return wmat
 
 
 def multi_plane_weights(

--- a/glass/points.py
+++ b/glass/points.py
@@ -598,7 +598,7 @@ def uniform_positions(
         lat = uxpx.degrees(xp.asin(rng.uniform(-1, 1, size=size)))
 
         # report count
-        count: int | IntArray  # ty: ignore[invalid-declaration]
+        count: int | IntArray
         if dims:
             count = xp.zeros(dims, dtype=xp.int64)
             count = xpx.at(count)[k].set(ngal_sphere[k])

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -282,7 +282,7 @@ def ellipticity_gaussian(
         eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
-    return eps  # ty: ignore[invalid-return-type]
+    return eps
 
 
 def ellipticity_intnorm(
@@ -361,4 +361,4 @@ def ellipticity_intnorm(
         eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
-    return eps  # ty: ignore[invalid-return-type]
+    return eps

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -249,7 +249,7 @@ class RadialWindow:
         To be removed upon deprecation of ``glass.ext.camb``.
 
         """
-        yield from (self.za, self.wa, self.zeff) # ty: ignore[invalid-yield]
+        yield from (self.za, self.wa, self.zeff)  # ty: ignore[invalid-yield]
 
     def _calculate_zeff(self) -> float:
         """

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -249,7 +249,7 @@ class RadialWindow:
         To be removed upon deprecation of ``glass.ext.camb``.
 
         """
-        yield from (self.za, self.wa, self.zeff)
+        yield from (self.za, self.wa, self.zeff) # ty: ignore[invalid-yield]
 
     def _calculate_zeff(self) -> float:
         """

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -79,7 +79,7 @@ class MockCosmology:
 
     def inv_comoving_distance(self, dc: FloatArray) -> FloatArray:
         """Inverse function for the comoving distance in Mpc."""
-        return 1_000 * (1 / (dc + np.finfo(float).eps))  # ty: ignore[unsupported-operator]
+        return 1_000 * (1 / (dc + np.finfo(float).eps))
 
     def Omega_m(self, z: FloatArray) -> FloatArray:  # noqa: N802
         """Matter density parameter at redshift z."""


### PR DESCRIPTION
# Description

Pins `ty` in the local `pre-commit` hook. This is to make sure we have consistent outputs prior to the release of the official hook (cref: https://github.com/astral-sh/ty/issues/269).

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1066

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
