### PR TITLE
gh-995: Allow filtering a single benchmark test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,8 +211,8 @@ supported Python versions using -
 uv run nox -s tests
 ```
 
-Only `tests`, `coverage`, `coverage_benchmarks`, `doctests`, `benchmarks`, and
-the `regression_tests` session run on all supported Python versions by default.
+Only `tests`, `coverage` and the `doctests` session run on all supported Python
+versions by default.
 
 To specify a particular Python version (for example `3.14`), use the following
 syntax -
@@ -253,10 +253,11 @@ To ensure that _GLASS_ remains performant over time, a set of benchmarks are
 provided in the [benchmarks](./tests/benchmarks/) folder. These benchmarks can
 be run through nox.
 
-A single benchmark can be run by specifying the revision to benchmark.
+All of the benchmarks for a given revision can be run by specifying the revision
+to benchmark.
 
 ```sh
-uv run nox -s benchmark -- <revision-to-benchmark>
+uv run nox -s benchmarks -- <revision-to-benchmark>
 ```
 
 The benchmarks can be used to run a regression test of _GLASS_. These regression
@@ -265,6 +266,19 @@ _GLASS_.
 
 ```sh
 uv run nox -s regression-tests -- <initial-state-revision> <revision-to-compare>
+```
+
+To filter the benchmark tests to be ran, one can pass pytest arguments via the
+cli after the required revision arguments. For example, if you wished to run
+only benchmarks from the `test_fields.py` file you could run one of the
+following commands:
+
+```sh
+# Benchmarks
+uv run nox -s benchmarks -- <revision-to-benchmark> -k test_fields
+# Regression tests
+uv run nox -s regression-tests -- <initial-state-revision> \
+<revision-to-compare> -k test_fields
 ```
 
 <!-- prettier-ignore -->

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,10 +64,10 @@ def _check_revision_count(
         msg = f"{expected_count} revision(s) not provided"
         raise ValueError(msg)
 
-    if len(session_posargs) != expected_count:
+    if len(session_posargs) < expected_count:
         msg = (
             f"Incorrect number of revisions provided ({len(session_posargs)}), "
-            f"expected {expected_count}"
+            f"expected at least {expected_count}"
         )
         raise ValueError(msg)
 
@@ -239,7 +239,12 @@ def benchmarks(session: nox.Session) -> None:
 
     # overwrite current package with specified revision
     session.install(f"git+{GLASS_REPO_URL}@{revision}")
-    session.run("pytest", BENCH_TESTS_LOC)
+    session.run(
+        "pytest",
+        BENCH_TESTS_LOC,
+        *SHARED_BENCHMARK_FLAGS,
+        *session.posargs[1:],
+    )
 
 
 @nox_uv.session(
@@ -271,6 +276,7 @@ def regression_tests(session: nox.Session) -> None:
         BENCH_TESTS_LOC,
         "--benchmark-autosave",
         *SHARED_BENCHMARK_FLAGS,
+        *session.posargs[2:],
     )
 
     session.log(f"Comparing {before_revision} benchmark to revision {after_revision}")
@@ -284,6 +290,7 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare=0001",
         "--benchmark-compare-fail=mean:5%",
         *SHARED_BENCHMARK_FLAGS,
+        *session.posargs[2:],
     )
 
     session.log("Running unstable regression tests")
@@ -296,4 +303,5 @@ def regression_tests(session: nox.Session) -> None:
         # Absolute time comparison in seconds
         "--benchmark-compare-fail=mean:0.0005",
         *SHARED_BENCHMARK_FLAGS,
+        *session.posargs[2:],
     )


### PR DESCRIPTION
# Description

- Allows the passing of pytest flags to the benchmark and regression tests nox commands

Fixes: #995 

## Changelog entry

Added: Ability to run benchmarks/regression tests for a single test


## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
