### PR TITLE
gh-1069: fix `ty` warnings and consistent environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,10 +78,8 @@ repos:
   - repo: local
     hooks:
       - id: ty
-        entry: ty check
+        entry: uv run --with ty==0.0.35 ty check
         language: python
-        additional_dependencies:
-          - ty==0.0.35
         name: ty-check
         pass_filenames: true
         types:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,8 +78,8 @@ repos:
   - repo: local
     hooks:
       - id: ty
-        entry: uv run --with ty==0.0.35 ty check
-        language: python
+        entry: uv run --active --with ty==0.0.35 ty check
+        language: system
         name: ty-check
         pass_filenames: true
         types:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,8 +78,10 @@ repos:
   - repo: local
     hooks:
       - id: ty
-        entry: uv run --active --with ty==0.0.35 ty check
-        language: system
+        entry: ty check
+        language: python
+        additional_dependencies:
+          - ty==0.0.35
         name: ty-check
         pass_filenames: true
         types:

--- a/glass/_rng.py
+++ b/glass/_rng.py
@@ -139,7 +139,7 @@ class Generator:
         self,
         lam: float | FloatArray,
         size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
+    ) -> IntArray:
         """
         Draw samples from a Poisson distribution.
 

--- a/glass/jax.py
+++ b/glass/jax.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from jaxtyping import PRNGKeyArray
     from typing_extensions import Self
 
-    from glass._types import AnyArray, DTypeLike, FloatArray
+    from glass._types import AnyArray, DTypeLike, FloatArray, IntArray
 
 
 def _size(
@@ -113,7 +113,7 @@ class Generator:
         lam: float | FloatArray,
         size: int | tuple[int, ...] | None = None,
         dtype: DTypeLike = int,
-    ) -> FloatArray:
+    ) -> IntArray:
         """Draw samples from a Poisson distribution."""
         return jax.random.poisson(self.__key, lam, size, dtype)
 

--- a/glass/points.py
+++ b/glass/points.py
@@ -341,7 +341,7 @@ def _sample_number_galaxies(
     n = xp.clip(n, min=0.0)
 
     # sample actual number in each pixel
-    return rng.poisson(n)  # ty: ignore[invalid-return-type]
+    return rng.poisson(n)
 
 
 def _sample_galaxies_per_pixel(

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,6 +73,7 @@ def _check_revision_count(
 
 
 @nox_uv.session(
+    # ty requires all dependencies to be installed to be the most effective
     uv_all_extras=True,
     uv_all_groups=True,
     uv_sync_locked=False,

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,6 +75,7 @@ def _check_revision_count(
 @nox_uv.session(
     uv_no_install_project=True,
     uv_only_groups=["lint"],
+    uv_sync_locked=False,
 )
 def lint(session: nox.Session) -> None:
     """Run the linter."""
@@ -95,6 +96,7 @@ def _setup_array_backend(session: nox.Session) -> None:
 @nox_uv.session(
     python=ALL_PYTHON,
     uv_groups=["test"],
+    uv_sync_locked=False,
 )
 def tests(session: nox.Session) -> None:
     """Run the unit tests."""
@@ -105,6 +107,7 @@ def tests(session: nox.Session) -> None:
 @nox_uv.session(
     python=ALL_PYTHON,
     uv_groups=["test"],
+    uv_sync_locked=False,
 )
 def coverage(session: nox.Session) -> None:
     """Run tests and compute coverage for the core tests."""
@@ -119,6 +122,7 @@ def coverage(session: nox.Session) -> None:
 
 @nox_uv.session(
     uv_groups=["test"],
+    uv_sync_locked=False,
 )
 def coverage_benchmarks(session: nox.Session) -> None:
     """Run tests and compute coverage for the benchmark tests."""
@@ -137,6 +141,7 @@ def coverage_benchmarks(session: nox.Session) -> None:
     python=ALL_PYTHON,
     uv_groups=["doctest"],
     uv_no_install_project=True,
+    uv_sync_locked=False,
 )
 def doctests(session: nox.Session) -> None:
     """Run the doctests."""
@@ -150,7 +155,10 @@ def doctests(session: nox.Session) -> None:
     session.run("pytest", *session.posargs)
 
 
-@nox_uv.session(uv_extras=["examples"])
+@nox_uv.session(
+    uv_extras=["examples"],
+    uv_sync_locked=False,
+)
 def examples(session: nox.Session) -> None:
     """Run the example notebooks. Pass "html" to build html."""
     if session.posargs:
@@ -176,7 +184,10 @@ def examples(session: nox.Session) -> None:
         )
 
 
-@nox_uv.session(uv_groups=["docs"])
+@nox_uv.session(
+    uv_groups=["docs"],
+    uv_sync_locked=False,
+)
 def docs(session: nox.Session) -> None:
     """Build the docs. Pass "serve" to serve."""
     session.chdir("docs")
@@ -204,13 +215,14 @@ def docs(session: nox.Session) -> None:
 @nox_uv.session(
     uv_no_install_project=True,
     uv_only_groups=["build"],
+    uv_sync_locked=False,
 )
 def build(session: nox.Session) -> None:
     """Build an SDist and wheel."""
     session.run("python", "-m", "build")
 
 
-@nox_uv.session
+@nox_uv.session(uv_sync_locked=False)
 def version(session: nox.Session) -> None:
     """
     Check the current version of the package.
@@ -226,6 +238,7 @@ def version(session: nox.Session) -> None:
 @nox_uv.session(
     uv_no_install_project=True,
     uv_only_groups=["test"],
+    uv_sync_locked=False,
 )
 def benchmarks(session: nox.Session) -> None:
     """
@@ -245,6 +258,7 @@ def benchmarks(session: nox.Session) -> None:
 @nox_uv.session(
     uv_no_install_project=True,
     uv_only_groups=["test"],
+    uv_sync_locked=False,
 )
 def regression_tests(session: nox.Session) -> None:
     """

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,8 +73,8 @@ def _check_revision_count(
 
 
 @nox_uv.session(
-    uv_no_install_project=True,
-    uv_only_groups=["lint"],
+    uv_all_extras=True,
+    uv_all_groups=True,
     uv_sync_locked=False,
 )
 def lint(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -74,7 +74,6 @@ def _check_revision_count(
 
 @nox_uv.session(
     # ty requires all dependencies to be installed to be the most effective
-    uv_all_extras=True,
     uv_all_groups=True,
     uv_sync_locked=False,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,16 +272,20 @@ overrides."tool.hatch".first = [
 overrides."tool.ruff.lint.isort.section-order".inline_arrays = false
 # https://github.com/pappasam/toml-sort/issues/94
 overrides."tool.ty".first = [
+    "analysis",
     "rules",
     "src",
+    "terminal",
 ]
 
 [tool.ty]
+analysis.respect-type-ignore-comments = false
 rules.invalid-argument-type = "ignore"
 src.include = [
     "glass",
     "tests",
 ]
+terminal.error-on-warning = true
 
 [[tool.ty.overrides]]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,6 @@ lint = [
     "pre-commit",
     "prek",
 ]
-release = [
-    "hatch-vcs",
-    "hatchling",
-]
 test = [
     "cosmology-api",
     "fitsio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ doctest = [
 ]
 lint = [
     "pre-commit",
+    "prek",
 ]
 release = [
     "hatch-vcs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
 ]
 docs = [
     "array-api-strict",
-    "cosmology.api",
+    "cosmology-api",
     "furo",
     "ipython",
     "jax",
@@ -47,7 +47,7 @@ release = [
     "hatchling",
 ]
 test = [
-    "cosmology.api",
+    "cosmology-api",
     "fitsio",
     "pytest",
     "pytest-benchmark",

--- a/tests/core/test_array_api_utils.py
+++ b/tests/core/test_array_api_utils.py
@@ -22,7 +22,7 @@ def test_rng_dispatcher_numpy() -> None:
 
 @pytest.mark.skipif(not HAVE_JAX, reason="test requires jax")
 def test_rng_dispatcher_jax() -> None:
-    import jax.numpy as jnp  # ty: ignore[unresolved-import]
+    import jax.numpy as jnp
 
     rng = _rng.rng_dispatcher(xp=jnp)
     assert isinstance(rng, glass.jax.Generator)
@@ -30,7 +30,7 @@ def test_rng_dispatcher_jax() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_rng_dispatcher_array_api_strict() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.rng_dispatcher(xp=array_api_strict)
     assert isinstance(rng, _rng.Generator)
@@ -38,7 +38,7 @@ def test_rng_dispatcher_array_api_strict() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_init() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.Generator(xp=array_api_strict)
     assert isinstance(rng, _rng.Generator)
@@ -46,7 +46,7 @@ def test_init() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_random() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.rng_dispatcher(xp=array_api_strict)
     rvs = rng.random(size=10_000)
@@ -58,7 +58,7 @@ def test_random() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_normal() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.rng_dispatcher(xp=array_api_strict)
     rvs = rng.normal(1, 2, size=10_000)
@@ -68,7 +68,7 @@ def test_normal() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_standard_normal() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.rng_dispatcher(xp=array_api_strict)
     rvs = rng.standard_normal(size=10_000)
@@ -78,7 +78,7 @@ def test_standard_normal() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_poisson() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.rng_dispatcher(xp=array_api_strict)
     rvs = rng.poisson(lam=1, size=10_000)
@@ -88,7 +88,7 @@ def test_poisson() -> None:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_uniform() -> None:
-    import array_api_strict  # ty: ignore[unresolved-import]
+    import array_api_strict
 
     rng = _rng.rng_dispatcher(xp=array_api_strict)
     rvs = rng.uniform(size=10_000)

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -13,13 +13,12 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import FloatArray
-    from glass.cosmology import Cosmology
 
 
 @pytest.fixture(scope="session")
-def cosmo() -> Cosmology:
+def cosmo() -> MockCosmology:
     """Mock cosmology to use for core tests."""
-    return MockCosmology()  # ty: ignore[invalid-return-type]
+    return MockCosmology()
 
 
 class MockCosmology:

--- a/tests/fixtures/helper_classes.py
+++ b/tests/fixtures/helper_classes.py
@@ -12,7 +12,13 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import Any
 
-    from glass._types import AnyArray, FloatArray, IntArray, UnifiedGenerator
+    from glass._types import (
+        AnyArray,
+        ComplexArray,
+        FloatArray,
+        IntArray,
+        UnifiedGenerator,
+    )
 
 
 class Compare:
@@ -151,7 +157,7 @@ class HealpixInputs:
     nside: int = 4
 
     @staticmethod
-    def alm(*, rng: UnifiedGenerator) -> FloatArray:
+    def alm(*, rng: UnifiedGenerator) -> ComplexArray:
         """Generate random alm coefficients."""
         return rng.standard_normal(  # ty: ignore[unsupported-operator]
             HealpixInputs.alm_size

--- a/tests/fixtures/helper_classes.py
+++ b/tests/fixtures/helper_classes.py
@@ -153,7 +153,9 @@ class HealpixInputs:
     @staticmethod
     def alm(*, rng: UnifiedGenerator) -> FloatArray:
         """Generate random alm coefficients."""
-        return rng.standard_normal(HealpixInputs.alm_size) + 1j * rng.standard_normal(  # ty: ignore[unsupported-operator]
+        return rng.standard_normal(  # ty: ignore[unsupported-operator]
+            HealpixInputs.alm_size
+        ) + 1j * rng.standard_normal(
             HealpixInputs.alm_size,
         )
 


### PR DESCRIPTION
# Description

This PR ensures greater consistency for developers when it comes to typing through `ty`. I've raised #1070 and #1071 as related issues.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1062,#1069

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
