### PR TITLE
gh-1085: refactor iternorm

### DIFF
--- a/glass/fields.py
+++ b/glass/fields.py
@@ -6,7 +6,7 @@ import itertools
 import math
 import sys
 import warnings
-from collections import deque
+import collections
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -386,7 +386,7 @@ def _generate_grf(
     z_size = n * (n + 1) // 2
 
     # store standard normal random variates
-    y = deque()
+    y = collections.deque()
 
     # sample the Gaussian fields iteratively
     for w in iternorm(cov):

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -9,7 +9,6 @@ import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-import numpy as np
 import transformcl
 
 import array_api_compat
@@ -91,94 +90,78 @@ def nfields_from_nspectra(nspectra: int) -> int:
     return n
 
 
-def iternorm(
-    k: int,
-    cov: Iterable[FloatArray],
-    size: int | tuple[int, ...] = (),
-) -> Generator[tuple[int | None, FloatArray, FloatArray]]:
+def iternorm(cov: Iterable[FloatArray]) -> Generator[tuple[FloatArray, FloatArray]]:
     """
-    Return the vector a and variance sigma^2 for iterative normal sampling.
+    Return shift vector and and standard deviation for iterative normal sampling.
 
     Parameters
     ----------
-    k
-        The number of fields.
     cov
         The covariance matrix for the fields.
-    size
-        The size of the covariance matrix.
 
     Yields
     ------
-    index
-        The index for iterative sampling.
     vector
-        The vector for iterative sampling.
+        The shift vector for iterative sampling.
     standard_deviation
         The standard deviation for iterative sampling.
 
-    Raises
-    ------
-    TypeError
-        If the covariance matrix is not broadcastable to the given size.
-    ValueError
-        If the covariance matrix is not positive definite.
-
     """
-    n = (size,) if isinstance(size, int) else size
-
-    m = np.zeros((*n, k, k))
-    a = np.zeros((*n, k))
-    s = np.zeros((*n,))
-    q = (*n, k + 1)
-    j = 0 if k > 0 else None
-
-    # We must use cov_expanded here as cov has been consumed to determine the namespace
     for i, x in enumerate(cov):
-        x_np = np.asarray(x)
-        if x_np.shape != q:
-            try:
-                x_np = np.broadcast_to(x_np, q)
-            except ValueError:
-                msg = (
-                    f"covariance row {i}: shape {x_np.shape} cannot be broadcast to {q}"
-                )
-                raise TypeError(msg) from None
+        # number of correlations, this will determine matrix size
+        k = x.shape[-1] - 1
+        if k < 0:
+            raise ValueError("empty covariance matrix")
 
-        # only need to update matrix A if there are correlations
-        if j is not None:
+        # check for first iteration
+        if i == 0:
+            # extract input array backend
+            xp = x.__array_namespace__()
+            # get shape of covariance
+            n = x.shape[:-1]
+            # initialise empty matrix to start iteration
+            m = xp.zeros((*n, k, k))
+            a = xp.zeros((*n, k))
+            s = xp.ones(n)
+        else:
+            # make sure input shape is compatible with previous iteration
+            if x.shape[:-1] != n:
+                raise ValueError("shape mismatch in covariance")
+
             # compute new entries of matrix A
-            m[..., :, j] = 0
-            m[..., j : j + 1, :] = np.matmul(a[..., np.newaxis, :], m)
-            m[..., j, j] = np.where(s != 0, -1, 0)
-            np.divide(
-                m[..., j, :],
-                -s[..., np.newaxis],
-                where=(m[..., j, :] != 0),
-                out=m[..., j, :],
-            )
+            # see https://arxiv.org/pdf/2302.01942
 
-            # compute new vector a
-            c = x_np[..., 1:, np.newaxis]
-            a = np.matmul(m[..., :j], c[..., k - j :, :])
-            a += np.matmul(m[..., j:], c[..., : k - j, :])
-            a = np.reshape(a, (*n, k))
+            # compute a^T @ m via matmul by adding a new axis
+            atm = a[..., None, :] @ m
 
-            # next rolling index
-            j = (j - 1) % k
+            # build the updated matrix m
+            # append zero column to matrix block
+            m = xp.concat([m, xp.zeros((*n, m.shape[-2], 1), dtype=m.dtype)], axis=-1)
+            # new row with 1 in bottom right corner
+            r = xp.concat([-atm, xp.ones((*n, 1, 1), dtype=atm.dtype)], axis=-1)
+            # scale new row with standard deviation
+            r /= s[..., None, None]
+            # concatenate first row and rest of matrix
+            m = xp.concat([m, r], axis=-2)
+
+        # cut matrix down to size
+        m = m[..., m.shape[-2] - k :, m.shape[-1] - k :]
+
+        # get correlation vector
+        # reverse vector to order it from oldest to newest
+        c = x[..., :0:-1]
+
+        # compute new vector a via matmul
+        a = (m @ c[..., None])[..., 0]
 
         # compute new standard deviation
-        s = x_np[..., 0] - np.einsum("...i,...i", a, a)
-        if np.any(s < 0):
-            msg = "covariance matrix is not positive definite"
-            raise ValueError(msg)
-        s = np.sqrt(s)
+        s = x[..., 0] - xp.vecdot(a, a)
+        if xp.any(s < 0):
+            raise ValueError("covariance matrix is not positive definite")
+        s = xp.sqrt(s)
 
-        # Extract input array backend or conversion of outputs
-        xp = x.__array_namespace__()
-
-        # yield the next index, vector a, and standard deviation s
-        yield j, xp.asarray(a), xp.asarray(s)
+        # yield the shift vector a and standard deviation s
+        yield a, s
 
 
 def cls2cov(

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -90,42 +90,40 @@ def nfields_from_nspectra(nspectra: int) -> int:
     return n
 
 
-def iternorm(cov: Iterable[FloatArray]) -> Generator[tuple[FloatArray, FloatArray]]:
+def iternorm(cov: Iterable[FloatArray]) -> Iterator[FloatArray]:
     """
-    Return shift vector and and standard deviation for iterative normal sampling.
+    Compute scaling vectors for iterative normal sampling.
 
     Parameters
     ----------
     cov
-        The covariance matrix for the fields.
+        The covariance matrix (or a stack of covariance matrices) for the fields.
 
     Yields
     ------
-    vector
-        The shift vector for iterative sampling.
-    standard_deviation
-        The standard deviation for iterative sampling.
+    x
+        The scaling vector (or a stack of scaling vectors) for iterative sampling.
 
     """
-    for i, x in enumerate(cov):
+    for i, row in enumerate(cov):
         # number of correlations, this will determine matrix size
-        k = x.shape[-1] - 1
+        k = row.shape[-1] - 1
         if k < 0:
             raise ValueError("empty covariance matrix")
 
         # check for first iteration
         if i == 0:
             # extract input array backend
-            xp = x.__array_namespace__()
+            xp = row.__array_namespace__()
             # get shape of covariance
-            n = x.shape[:-1]
+            n = row.shape[:-1]
             # initialise empty matrix to start iteration
             m = xp.zeros((*n, k, k))
             a = xp.zeros((*n, k))
             s = xp.ones(n)
         else:
             # make sure input shape is compatible with previous iteration
-            if x.shape[:-1] != n:
+            if row.shape[:-1] != n:
                 raise ValueError("shape mismatch in covariance")
 
             # compute new entries of matrix A
@@ -149,19 +147,22 @@ def iternorm(cov: Iterable[FloatArray]) -> Generator[tuple[FloatArray, FloatArra
 
         # get correlation vector
         # reverse vector to order it from oldest to newest
-        c = x[..., :0:-1]
+        c = row[..., :0:-1]
 
         # compute new vector a via matmul
         a = (m @ c[..., None])[..., 0]
 
         # compute new standard deviation
-        s = x[..., 0] - xp.vecdot(a, a)
+        s = row[..., 0] - xp.vecdot(a, a)
         if xp.any(s < 0):
             raise ValueError("covariance matrix is not positive definite")
         s = xp.sqrt(s)
 
-        # yield the shift vector a and standard deviation s
-        yield a, s
+        # concatenate a and s into a single scaling vector
+        x = xp.concat([a, s[..., None]], axis=-1)
+
+        # yield the scaling vector
+        yield x
 
 
 def cls2cov(

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import collections
 import itertools
 import math
 import sys
 import warnings
-import collections
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -104,6 +104,12 @@ def iternorm(cov: Iterable[FloatArray]) -> Iterator[FloatArray]:
     ------
     w
         The scaling vector (or a stack of scaling vectors) for iterative sampling.
+
+    Raises
+    ------
+    ValueError
+        Raised when the provided covariance matrix is empty, has inconsistent
+        shape, or is not positive semi-definite.
 
     """
     for i, row in enumerate(cov):

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -6,6 +6,7 @@ import itertools
 import math
 import sys
 import warnings
+from collections import deque
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -372,30 +373,30 @@ def _generate_grf(
     # generates the covariance matrix for the iterative sampler
     cov = cls2cov(gls, n, ngrf, ncorr)
 
-    # working arrays for the iterative sampling
+    # alm size
     z_size = n * (n + 1) // 2
-    y = xp.zeros((z_size, ncorr), dtype=xp.complex128)
 
-    # generate the conditional normal distribution for iterative sampling
-    conditional_dist = iternorm(ncorr, cov, size=n)
+    # store standard normal random variates
+    y = deque()
 
-    # sample the fields from the conditional distribution
-    for j, a, s in conditional_dist:
+    # sample the Gaussian fields iteratively
+    for w in iternorm(cov):
         # standard normal random variates for alm
-        # sample real and imaginary parts, then view as complex number
-        z = rng.standard_normal((z_size,)) + (1j * rng.standard_normal((z_size,)))
+        # sample real and imaginary parts, then combine into complex number
+        z = rng.standard_normal((z_size, 2)) @ xp.asarray([1, 1j])
 
-        # scale by standard deviation of the conditional distribution
-        # variance is distributed over real and imaginary part
-        alm = glass.harmonics.multalm(z, s)
+        # append to stack of standard normals
+        y.append(z)
 
-        # add the mean of the conditional distribution
-        for i in range(ncorr):
-            alm += glass.harmonics.multalm(y[:, i], a[:, i])
+        # forget oldest variates that are no longer correlated
+        while len(y) > w.shape[-1]:
+            y.popleft()
 
-        # store the standard normal in y array at the indicated index
-        if j is not None:
-            y = xpx.at(y)[:, j].set(z)
+        # how many correlations have missing variates
+        mis = w.shape[-1] - len(y)
+
+        # compute the correlated variate
+        alm = sum(glass.harmonics.multalm(z, w[..., i + mis]) for i, z in enumerate(y))
 
         alm = _glass_to_healpix_alm(alm)
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -136,8 +136,17 @@ def iternorm(cov: Iterable[FloatArray]) -> Iterator[FloatArray]:
             # build the updated matrix m
             # append zero column to matrix block
             m = xp.concat([m, xp.zeros((*n, m.shape[-2], 1), dtype=m.dtype)], axis=-1)
-            # new row with 1 in bottom right corner
-            r = xp.concat([-atm, xp.ones((*n, 1, 1), dtype=atm.dtype)], axis=-1)
+            # generate the bottom right corner: 1 where s > 0, 0 otherwise
+            u = xp.where(
+                s > 0,
+                xp.ones(n, dtype=atm.dtype),
+                xp.zeros(n, dtype=atm.dtype),
+            )
+            # assemble the new row
+            r = xp.concat([-atm, u[..., None, None]], axis=-1)
+            # set zero standard deviation to unity to prevent division by zero
+            # this should be fine as corresponding entries in r are zero
+            s = xp.where(s > 0, s, xp.ones(n, dtype=s.dtype))
             # scale new row with standard deviation
             r /= s[..., None, None]
             # concatenate first row and rest of matrix

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -101,7 +101,7 @@ def iternorm(cov: Iterable[FloatArray]) -> Iterator[FloatArray]:
 
     Yields
     ------
-    x
+    w
         The scaling vector (or a stack of scaling vectors) for iterative sampling.
 
     """
@@ -159,10 +159,10 @@ def iternorm(cov: Iterable[FloatArray]) -> Iterator[FloatArray]:
         s = xp.sqrt(s)
 
         # concatenate a and s into a single scaling vector
-        x = xp.concat([a, s[..., None]], axis=-1)
+        w = xp.concat([a, s[..., None]], axis=-1)
 
         # yield the scaling vector
-        yield x
+        yield w
 
 
 def cls2cov(

--- a/tests/benchmarks/test_fields.py
+++ b/tests/benchmarks/test_fields.py
@@ -26,16 +26,15 @@ def test_iternorm_no_size(
     xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.iternorm with k=2."""
-    array_in = [xpb.asarray([x, x, x]) for x in xpb.arange(10_000, dtype=xpb.float64)]
+    array_in = [xpb.asarray([1.0, 0.5, 0.1])] * 10_000
 
-    def function_to_benchmark() -> None:
+    def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(array_in)
-        generator_consumer.consume(
-            generator,
-            valid_exception="covariance matrix is not positive definite",
-        )
+        return generator_consumer.consume(generator)
 
-    benchmark(function_to_benchmark)
+    result = benchmark(function_to_benchmark)
+
+    assert len(result) == len(array_in)
 
 
 @pytest.mark.stable
@@ -48,26 +47,17 @@ def test_iternorm_specify_size(
 ) -> None:
     """Benchmarks for glass.iternorm with k=2 and size=(3,)."""
     if num_dimensions == 1:
-        list_input = [[1.0, 0.5, 0.5] for _ in range(10_000)]
+        array_in = [xpb.asarray([1.0, 0.5, 0.1])] * 10_000
     elif num_dimensions == 2:
-        list_input = [
-            [
-                [1.0, 0.5, 0.5],
-                [0.5, 0.2, 0.1],
-                [0.5, 0.1, 0.2],
-            ]
-            for _ in range(10_000)
-        ]
-    array_in = [xpb.asarray(arr, dtype=xpb.float64) for arr in list_input]
+        array_in = [xpb.asarray([[1.0, 0.5, 0.1]] * 3)] * 10_000
 
-    def function_to_benchmark() -> None:
+    def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(array_in)
-        generator_consumer.consume(
-            generator,
-            valid_exception="covariance matrix is not positive definite",
-        )
+        return generator_consumer.consume(generator)
 
-    benchmark(function_to_benchmark)
+    result = benchmark(function_to_benchmark)
+
+    assert len(result) == len(array_in)
 
 
 @pytest.mark.stable
@@ -79,11 +69,13 @@ def test_iternorm_k_0(
     """Benchmarks for glass.iternorm with k set to 0."""
     array_in = [xpb.asarray([x]) for x in xpb.ones(1_000, dtype=xpb.float64)]
 
-    def function_to_benchmark() -> None:
+    def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(array_in)
-        generator_consumer.consume(generator)
+        return generator_consumer.consume(generator)
 
-    benchmark(function_to_benchmark)
+    result = benchmark(function_to_benchmark)
+
+    assert len(result) == len(array_in)
 
 
 @pytest.mark.stable

--- a/tests/benchmarks/test_fields.py
+++ b/tests/benchmarks/test_fields.py
@@ -25,25 +25,17 @@ def test_iternorm_no_size(
     generator_consumer: GeneratorConsumer,
     xpb: ModuleType,
 ) -> None:
-    """Benchmarks for glass.iternorm with default value for size."""
-    k = 2
-    array_in = [xpb.asarray(x) for x in xpb.arange(10_000, dtype=xpb.float64)]
+    """Benchmarks for glass.iternorm with k=2."""
+    array_in = [xpb.asarray([x, x, x]) for x in xpb.arange(10_000, dtype=xpb.float64)]
 
-    def function_to_benchmark() -> list[Any]:
-        generator = glass.iternorm(k, iter(array_in))
-        return generator_consumer.consume(
+    def function_to_benchmark() -> None:
+        generator = glass.iternorm(array_in)
+        generator_consumer.consume(
             generator,
             valid_exception="covariance matrix is not positive definite",
         )
 
-    results = benchmark(function_to_benchmark)
-    j, a, s = results[0]
-
-    assert isinstance(j, int)
-    assert a.shape == (k,)
-    assert s.shape == ()
-    assert s.dtype == xpb.float64
-    assert s.shape == ()
+    benchmark(function_to_benchmark)
 
 
 @pytest.mark.stable
@@ -54,9 +46,7 @@ def test_iternorm_specify_size(
     xpb: ModuleType,
     num_dimensions: int,
 ) -> None:
-    """Benchmarks for glass.iternorm with size specified."""
-    k = 2
-    size = (3,)
+    """Benchmarks for glass.iternorm with k=2 and size=(3,)."""
     if num_dimensions == 1:
         list_input = [[1.0, 0.5, 0.5] for _ in range(10_000)]
     elif num_dimensions == 2:
@@ -69,57 +59,31 @@ def test_iternorm_specify_size(
             for _ in range(10_000)
         ]
     array_in = [xpb.asarray(arr, dtype=xpb.float64) for arr in list_input]
-    expected_result = [
-        1,
-        (3, 2),
-        (3,),
-    ]
 
-    def function_to_benchmark() -> list[Any]:
-        generator = glass.iternorm(k, iter(array_in), size)
-        return generator_consumer.consume(
+    def function_to_benchmark() -> None:
+        generator = glass.iternorm(array_in)
+        generator_consumer.consume(
             generator,
             valid_exception="covariance matrix is not positive definite",
         )
 
-    # check output shapes and types
-
-    results = benchmark(function_to_benchmark)
-    result1 = results[0]
-    result2 = results[1]
-
-    assert result1 != result2
-    assert isinstance(result1, tuple)
-    assert len(result1) == 3
-
-    j, a, s = result1
-    assert isinstance(j, int)
-    assert j == expected_result[0]
-    assert a.shape == expected_result[1]
-    assert s.shape == expected_result[2]
+    benchmark(function_to_benchmark)
 
 
 @pytest.mark.stable
 def test_iternorm_k_0(
     benchmark: BenchmarkFixture,
-    compare: Compare,
     generator_consumer: GeneratorConsumer,
     xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.iternorm with k set to 0."""
-    k = 0
-    array_in = [xpb.stack([x]) for x in xpb.ones(1_000, dtype=xpb.float64)]
+    array_in = [xpb.asarray([x]) for x in xpb.ones(1_000, dtype=xpb.float64)]
 
-    def function_to_benchmark() -> list[Any]:
-        generator = glass.iternorm(k, iter(array_in))
-        return generator_consumer.consume(generator)
+    def function_to_benchmark() -> None:
+        generator = glass.iternorm(array_in)
+        generator_consumer.consume(generator)
 
-    results = benchmark(function_to_benchmark)
-
-    j, a, s = results[0]
-    assert j is None
-    assert a.shape == (0,)
-    compare.assert_allclose(xpb.asarray(s), 1.0)
+    benchmark(function_to_benchmark)
 
 
 @pytest.mark.stable

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -26,117 +26,89 @@ def not_triangle_numbers() -> list[int]:
     return [2, 4, 5, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19, 20]
 
 
-def test_iternorm(xp: ModuleType) -> None:
-    # check output shapes and types
-
-    k = 2
-
-    generator = glass.iternorm(
-        k,
-        (xp.asarray(x) for x in [1.0, 0.5, 0.5, 0.5, 0.2, 0.1, 0.5, 0.1, 0.2]),
-    )
-    result = next(generator)
-
-    j, a, s = result
-
-    assert isinstance(j, int)
-    assert a.shape == (k,)
-    assert s.shape == ()
-    assert s.dtype == xp.float64
-    assert s.shape == ()
-
-    # specify size
-
-    size = 3
-
-    generator = glass.iternorm(
-        k,
-        (
-            xp.asarray(arr)
-            for arr in [
-                [1.0, 0.5, 0.5],
-                [0.5, 0.2, 0.1],
-                [0.5, 0.1, 0.2],
-            ]
-        ),
-        size,
-    )
-    result = next(generator)
-
-    j, a, s = result
-
-    assert isinstance(j, int)
-    assert a.shape == (size, k)
-    assert s.shape == (size,)
-
-    # test shape mismatch error
-
-    with pytest.raises(TypeError, match="covariance row 0: shape"):
-        list(
-            glass.iternorm(
-                k,
-                (
-                    xp.asarray(arr)
-                    for arr in [
-                        [1.0, 0.5],
-                        [0.5, 0.2],
-                    ]
-                ),
-            ),
+@pytest.mark.parametrize("k", [0, 1, 2], ids=["k=0", "k=1", "k=2"])
+@pytest.mark.parametrize("test_nd", [False, True], ids=["0d", "nd"])
+def test_iternorm(k, test_nd, xp: ModuleType, compare: type[Compare]) -> None:
+    """Test iternorm against explicit computation."""
+    # covariance matrix to sample
+    if test_nd:
+        cov = xp.asarray(
+            [
+                # first cov
+                [
+                    [1.0, 0.2, 0.1],
+                    [0.2, 0.5, 0.2],
+                    [0.1, 0.2, 0.3],
+                ],
+                # second cov
+                [
+                    [1.4, 0.4, 0.5],
+                    [0.4, 1.5, 0.8],
+                    [0.5, 0.8, 1.3],
+                ],
+            ],
+        )
+    else:
+        cov = xp.asarray(
+            [
+                [1.0, 0.2, 0.1],
+                [0.2, 0.5, 0.2],
+                [0.1, 0.2, 0.3],
+            ],
         )
 
-    # test positive definite error
-
-    with pytest.raises(ValueError, match="covariance matrix is not positive definite"):
-        list(
-            glass.iternorm(
-                k,
-                (xp.asarray(x) for x in [1.0, 0.5, 0.9, 0.5, 0.2, 0.4, 0.9, 0.4, -1.0]),
-            ),
-        )
-
-    # test multiple iterations
-
-    size = (3,)
-
     generator = glass.iternorm(
-        k,
-        (
-            xp.asarray(arr)
-            for arr in [
-                [
-                    [1.0, 0.5, 0.5],
-                    [0.5, 0.2, 0.1],
-                    [0.5, 0.1, 0.2],
-                ],
-                [
-                    [2.0, 1.0, 0.8],
-                    [1.0, 0.5, 0.3],
-                    [0.8, 0.3, 0.6],
-                ],
-            ]
-        ),
-        size,
+        # for each covariance row, start at the diagonal diagonal and go left
+        # trim to at most k elements (= max. number of correlations)
+        cov[..., i, i::-1][..., : min(i, k) + 1]
+        for i in range(cov.shape[-1])
     )
 
-    result1 = next(generator)
-    result2 = next(generator)
+    # check rows against explicit calculation
+    # see https://arxiv.org/pdf/2302.01942, Appendix A
+    # ruff: disable[N806]
+    for n, (a, s) in enumerate(generator):
+        Sn = cov[..., :n, :n]
+        cn = cov[..., :n, n]
+        vn = cov[..., n, n]
+        if n > k:
+            # zero out correlations that should be forgotten
+            # i.e. more than k away from the diagonal of the cov. matrix
+            mask = xp.where(
+                xp.abs(xp.arange(n)[:, None] - xp.arange(n)) <= k,
+                xp.ones(n),
+                xp.zeros(n),
+            )
+            Sn *= mask
+            mask = xp.where(xp.arange(n) >= n - k, xp.ones(n), xp.zeros(n))
+            cn *= mask
+        Sninv = xp.linalg.pinv(Sn)
+        # stabilise Cholesky decomposition
+        An = xp.linalg.cholesky(Sninv + 1e-100 * xp.eye(n), upper=True)
+        compare.assert_allclose(An.mT @ An, Sninv)
+        an = (An @ cn[..., None])[..., 0]
+        sn = xp.sqrt(vn - xp.vecdot(an, an))
+        # make sure a only has k correlations
+        assert a.shape[-1] <= k
+        # cannot compare a directly, only a^T @ a
+        compare.assert_allclose(xp.vecdot(a, a), xp.vecdot(an, an))
+        compare.assert_allclose(s, sn)
+    # ruff: enable[N806]
 
-    assert result1 != result2
-    assert isinstance(result1, tuple)
-    assert len(result1) == 3
-    assert isinstance(result2, tuple)
-    assert len(result2) == 3
 
-    # test k = 0
+def test_iternorm_errors(xp: ModuleType) -> None:
+    """Test iternorm raises when it should."""
+    # covariance matrix is empty
+    with pytest.raises(ValueError, match="empty covariance"):
+        list(glass.iternorm([xp.ones(0)]))
 
-    generator = glass.iternorm(0, xp.asarray([1.0]))
+    # covariance matrix changes shape
+    with pytest.raises(ValueError, match="shape mismatch"):
+        list(glass.iternorm([xp.ones(1), xp.ones((5, 2))]))
 
-    j, a, s = result
-
-    assert j == 1
-    assert a.shape == (3, 2)
-    assert s.shape == (3,)
+    # covariance matrix not pos. def.
+    with pytest.raises(ValueError, match="not positive definite"):
+        list(glass.iternorm([xp.asarray([1.0]), xp.asarray([0.1, 1.0])]))
 
 
 @pytest.mark.skipif(not HAVE_JAX, reason="test requires jax")

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -67,7 +67,7 @@ def test_iternorm(k, test_nd, xp: ModuleType, compare: type[Compare]) -> None:
     # check rows against explicit calculation
     # see https://arxiv.org/pdf/2302.01942, Appendix A
     # ruff: disable[N806]
-    for n, (a, s) in enumerate(generator):
+    for n, x in enumerate(generator):
         Sn = cov[..., :n, :n]
         cn = cov[..., :n, n]
         vn = cov[..., n, n]
@@ -89,7 +89,9 @@ def test_iternorm(k, test_nd, xp: ModuleType, compare: type[Compare]) -> None:
         an = (An @ cn[..., None])[..., 0]
         sn = xp.sqrt(vn - xp.vecdot(an, an))
         # make sure a only has k correlations
-        assert a.shape[-1] <= k
+        assert x.shape[-1] <= min(n, k) + 1
+        # split scaling vector up into a and s
+        a, s = x[..., :-1], x[..., -1]
         # cannot compare a directly, only a^T @ a
         compare.assert_allclose(xp.vecdot(a, a), xp.vecdot(an, an))
         compare.assert_allclose(s, sn)

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -63,7 +63,7 @@ def test_iternorm(
         )
 
     generator = glass.iternorm(
-        # for each covariance row, start at the diagonal diagonal and go left
+        # for each covariance row, start at the diagonal and go left
         # trim to at most k elements (= max. number of correlations)
         cov[..., i, i::-1][..., : min(i, k) + 1]
         for i in range(cov.shape[-1])

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -30,9 +30,9 @@ def not_triangle_numbers() -> list[int]:
 @pytest.mark.parametrize("test_nd", [False, True], ids=["0d", "nd"])
 def test_iternorm(
     compare: type[Compare],
-	k: int,
-	test_nd: bool,
-	xp: ModuleType,
+    k: int,
+    test_nd: bool,  # noqa: FBT001
+    xp: ModuleType,
 ) -> None:
     """Test iternorm against explicit computation."""
     # covariance matrix to sample

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -67,7 +67,7 @@ def test_iternorm(k, test_nd, xp: ModuleType, compare: type[Compare]) -> None:
     # check rows against explicit calculation
     # see https://arxiv.org/pdf/2302.01942, Appendix A
     # ruff: disable[N806]
-    for n, x in enumerate(generator):
+    for n, w in enumerate(generator):
         Sn = cov[..., :n, :n]
         cn = cov[..., :n, n]
         vn = cov[..., n, n]
@@ -89,9 +89,9 @@ def test_iternorm(k, test_nd, xp: ModuleType, compare: type[Compare]) -> None:
         an = (An @ cn[..., None])[..., 0]
         sn = xp.sqrt(vn - xp.vecdot(an, an))
         # make sure a only has k correlations
-        assert x.shape[-1] <= min(n, k) + 1
+        assert w.shape[-1] <= min(n, k) + 1
         # split scaling vector up into a and s
-        a, s = x[..., :-1], x[..., -1]
+        a, s = w[..., :-1], w[..., -1]
         # cannot compare a directly, only a^T @ a
         compare.assert_allclose(xp.vecdot(a, a), xp.vecdot(an, an))
         compare.assert_allclose(s, sn)

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -28,7 +28,12 @@ def not_triangle_numbers() -> list[int]:
 
 @pytest.mark.parametrize("k", [0, 1, 2], ids=["k=0", "k=1", "k=2"])
 @pytest.mark.parametrize("test_nd", [False, True], ids=["0d", "nd"])
-def test_iternorm(k, test_nd, xp: ModuleType, compare: type[Compare]) -> None:
+def test_iternorm(
+    compare: type[Compare],
+	k: int,
+	test_nd: bool,
+	xp: ModuleType,
+) -> None:
     """Test iternorm against explicit computation."""
     # covariance matrix to sample
     if test_nd:


### PR DESCRIPTION
# Description

An attempt to

* simplify `iternorm()` in a way that makes it clear this is the same algorithm as in Appendix A of [arXiv:2302.01942](https://arxiv.org/pdf/2302.01942),
* add tests that check for correctness of the algorithm, and
* make `iternorm()` Array API compatible.

The function now takes only an iterable of covariance matrix rows. It will figure out the correct shape of the output from the input. It will also figure out the number of correlations to keep from each covariance matrix row individually, which means that the function can now dynamically forget previous correlations.

The function now yields a single scaling vector that can be applied to the stack of standard normal random variates to get the correctly correlated normal variate.

Closes: #1085

## Changelog entry

Changed: simplified `glass.iternorm()` that is now Array API compatible

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
