### PR TITLE
gh-1090: move `ty` from `pre-commit` to `nox`

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   prek:
     if: github.event.pull_request.draft == false
-    name: Run prek
+    name: Run linting
     permissions:
       contents: read
     runs-on: ubuntu-slim

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,15 +66,6 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
-  - repo: local
-    hooks:
-      - id: ty
-        entry: uv run --no-active --with ty==0.0.35 ty check
-        language: system
-        name: ty-check
-        pass_filenames: false
-        types:
-          - python
   - repo: https://github.com/kynan/nbstripout
     rev: 0.9.1
     hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,7 +79,8 @@ def _check_revision_count(
 )
 def lint(session: nox.Session) -> None:
     """Run the linter."""
-    session.run("prek", "run", "--all-files", "--color", "always", *session.posargs)
+    session.run("prek", "run", "--all-files", "--color", "always")
+    session.run("ty", "check")
 
 
 def _setup_array_backend(session: nox.Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ doctest = [
 ]
 lint = [
     "prek",
+    "ty==0.0.35",
 ]
 test = [
     "cosmology-api",


### PR DESCRIPTION
# Description

Developers currently have to have everything installed which might be disruptive. This solution means that we no longer run `ty` via `prek` explicitly, but rather run it through `nox -s lint`. CI uses `nox` so it will be unchaged there.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1090

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Changed: `ty` is now run from `nox` rather than `pre-commit`

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
