### PR TITLE
gh-690: Drop `3.10` support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,7 +87,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -159,9 +158,9 @@ jobs:
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           carryforward:
-            ${{ env.BENCH_COV_NAME }},${{ env.CORE_COV_NAME }}-3.10,${{
-            env.CORE_COV_NAME }}-3.11,${{ env.CORE_COV_NAME }}-3.12,${{
-            env.CORE_COV_NAME }}-3.13,${{ env.CORE_COV_NAME }}-3.14
+            ${{ env.BENCH_COV_NAME }},${{ env.CORE_COV_NAME }}-3.11,${{
+            env.CORE_COV_NAME }}-3.12,${{ env.CORE_COV_NAME }}-3.13,${{
+            env.CORE_COV_NAME }}-3.14
           parallel-finished: true
 
   build:

--- a/glass/algorithm.py
+++ b/glass/algorithm.py
@@ -99,7 +99,7 @@ def nnls(
             q = xpx.at(q)[x <= 0].set(False)
         x = xpx.at(x)[q].set(sq)
         x = xpx.at(x)[~q].set(0)
-    return x
+    return x  # ty:ignore[invalid-return-type]
 
 
 def cov_clip(

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -12,8 +12,6 @@ from glass._array_api_utils import xp_additions as uxpx
 if TYPE_CHECKING:
     from types import ModuleType
 
-    from typing_extensions import Unpack
-
     from glass._types import AnyArray, FloatArray, IntArray
 
 
@@ -48,7 +46,7 @@ def broadcast_leading_axes(
     xp: ModuleType | None = None,
 ) -> tuple[
     tuple[int, ...],
-    Unpack[tuple[FloatArray, ...]],
+    *tuple[FloatArray, ...],
 ]:
     """
     Broadcast all but the last N axes.

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -226,7 +226,7 @@ def cls2cov(
             cov = xpx.at(cov)[:n, i].set(cl)
             cov = xpx.at(cov)[n:, i].set(0.0)
         cov /= 2
-        yield cov
+        yield cov  # ty:ignore[invalid-yield]
 
 
 def discretized_cls(
@@ -684,7 +684,7 @@ def effective_cls(
         out = xpx.at(out)[j1 + j2 + (...,)].set(cl)
         if weights2 is weights1 and j1 != j2:
             out = xpx.at(out)[j2 + j1 + (...,)].set(cl)
-    return out
+    return out  # ty:ignore[invalid-return-type]
 
 
 def gaussian_fields(
@@ -1022,7 +1022,7 @@ def cov_from_spectra(
         cov = xpx.at(cov)[:size, i, j].set(cl_flat[:size])
         cov = xpx.at(cov)[:size, j, i].set(cl_flat[:size])
 
-    return cov
+    return cov  # ty:ignore[invalid-return-type]
 
 
 def check_posdef_spectra(spectra: AngularPowerSpectra) -> bool:

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -154,7 +154,7 @@ def redshifts_from_nz(
 
     assert total == redshifts.size  # noqa: S101
 
-    return redshifts
+    return redshifts  # ty:ignore[invalid-return-type]
 
 
 def galaxy_shear(  # noqa: PLR0913

--- a/glass/jax.py
+++ b/glass/jax.py
@@ -13,8 +13,9 @@ import jax.scipy
 import jax.typing
 
 if TYPE_CHECKING:
+    from typing import Self
+
     from jaxtyping import PRNGKeyArray
-    from typing_extensions import Self
 
     from glass._types import AnyArray, DTypeLike, FloatArray, IntArray
 

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -625,7 +625,7 @@ def multi_plane_matrix(
     for i, w in enumerate(shells):
         mpc.add_window(xp.asarray(wmat[i, :], copy=True), w)
         wmat = xpx.at(wmat)[i, :].set(mpc.kappa)
-    return wmat
+    return wmat  # ty:ignore[invalid-return-type]
 
 
 def multi_plane_weights(

--- a/glass/points.py
+++ b/glass/points.py
@@ -598,14 +598,14 @@ def uniform_positions(
         lat = uxpx.degrees(xp.asin(rng.uniform(-1, 1, size=size)))
 
         # report count
-        count: int | IntArray
+        count: int | IntArray  # ty:ignore[invalid-declaration]
         if dims:
             count = xp.zeros(dims, dtype=xp.int64)
             count = xpx.at(count)[k].set(ngal_sphere[k])
         else:
             count = int(ngal_sphere[k])
 
-        yield lon, lat, count
+        yield lon, lat, count  # ty:ignore[invalid-yield]
 
 
 def position_weights(

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -282,7 +282,7 @@ def ellipticity_gaussian(
         eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
-    return eps
+    return eps  # ty:ignore[invalid-return-type]
 
 
 def ellipticity_intnorm(
@@ -361,4 +361,4 @@ def ellipticity_intnorm(
         eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
-    return eps
+    return eps  # ty:ignore[invalid-return-type]

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,6 @@ nox.options.sessions = [
 ]
 
 ALL_PYTHON = [
-    "3.10",
     "3.11",
     "3.12",
     "3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -96,7 +95,7 @@ optional-dependencies = {examples = [
     "jupyter",
     "matplotlib",
 ]}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.urls]
 Changelog = "https://glass.readthedocs.io/stable/manual/releases.html"

--- a/tests/benchmarks/test_lensing.py
+++ b/tests/benchmarks/test_lensing.py
@@ -8,9 +8,9 @@ import glass
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Never
 
     from pytest_benchmark.fixture import BenchmarkFixture
-    from typing_extensions import Never
 
     from glass._types import FloatArray, UnifiedGenerator
     from glass.cosmology import Cosmology


### PR DESCRIPTION
# Description

This PR drops `3.10` support. This is required to benefit from the new features in `array-api-extra` introduced in #1083.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #690

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Removed: `3.10` Python support

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
