### PR TITLE
gh-983: fix some `typing` ignores, sort fixtures, tidy typing

### DIFF
--- a/glass/_array_api_utils.py
+++ b/glass/_array_api_utils.py
@@ -17,13 +17,14 @@ integration, interpolation, and linear algebra.
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import array_api_compat
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from types import ModuleType
+    from typing import Any
 
     import numpy as np
 

--- a/glass/_types.py
+++ b/glass/_types.py
@@ -1,8 +1,9 @@
+import typing
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import ParamSpec, TypeAlias, TypeVar
+    from typing import TypeAlias
 
     import jaxtyping
     import numpy as np
@@ -13,9 +14,9 @@ if TYPE_CHECKING:
     import glass.jax
     from glass import _rng
 
-    P = ParamSpec("P")
-    R = TypeVar("R")
-    T = TypeVar("T")
+    P = typing.ParamSpec("P")
+    R = typing.TypeVar("R")
+    T = typing.TypeVar("T")
 
     AnyArray: TypeAlias = np.typing.NDArray[Any] | jaxtyping.Array | Array
     ComplexArray: TypeAlias = np.typing.NDArray[np.complex128] | jaxtyping.Array | Array

--- a/glass/algorithm.py
+++ b/glass/algorithm.py
@@ -99,7 +99,7 @@ def nnls(
             q = xpx.at(q)[x <= 0].set(False)
         x = xpx.at(x)[q].set(sq)
         x = xpx.at(x)[~q].set(0)
-    return x  # ty:ignore[invalid-return-type]
+    return x  # ty: ignore[invalid-return-type]
 
 
 def cov_clip(

--- a/glass/algorithm.py
+++ b/glass/algorithm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing
 import warnings
 from typing import TYPE_CHECKING
 
@@ -99,7 +100,7 @@ def nnls(
             q = xpx.at(q)[x <= 0].set(False)
         x = xpx.at(x)[q].set(sq)
         x = xpx.at(x)[~q].set(0)
-    return x  # ty: ignore[invalid-return-type]
+    return typing.cast("FloatArray", x)
 
 
 def cov_clip(

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 import array_api_compat
@@ -177,9 +178,12 @@ def trapezoid_product(
     x: FloatArray
     x, _ = f
     for x_, _ in ff:
-        x = xpx.union1d(  # ty: ignore[invalid-assignment]
-            x[(x >= x_[0]) & (x <= x_[-1])],
-            x_[(x_ >= x[0]) & (x_ <= x[-1])],
+        x = typing.cast(
+            "FloatArray",
+            xpx.union1d(
+                x[(x >= x_[0]) & (x <= x_[-1])],
+                x_[(x_ >= x[0]) & (x_ <= x[-1])],
+            ),
         )
     y = uxpx.interp(x, *f)
     for f_ in ff:

--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -1,6 +1,6 @@
 """Module for cosmology.api utilities."""
 
-from typing import Protocol
+import typing
 
 import cosmology.api
 
@@ -18,6 +18,6 @@ class Cosmology(
     cosmology.api.HasOmegaM0[AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasOmegaM[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasTransverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
-    Protocol,
+    typing.Protocol,
 ):
     """Cosmology protocol for GLASS."""

--- a/glass/ext/__init__.py
+++ b/glass/ext/__init__.py
@@ -28,7 +28,7 @@ def _extend_path(path: list[str], name: str) -> list[str]:
     """
     _pkg, _, _mod = name.partition(".")
 
-    return list(  # ty: ignore[invalid-return-type]
+    return list(
         filter(
             os.path.isdir,
             (os.path.join(p, _mod) for p in pkgutil.extend_path(path, _pkg)),  # noqa: PTH118

--- a/glass/ext/__init__.py
+++ b/glass/ext/__init__.py
@@ -28,7 +28,7 @@ def _extend_path(path: list[str], name: str) -> list[str]:
     """
     _pkg, _, _mod = name.partition(".")
 
-    return list(
+    return list(  # ty:ignore[invalid-return-type]
         filter(
             os.path.isdir,
             (os.path.join(p, _mod) for p in pkgutil.extend_path(path, _pkg)),  # noqa: PTH118

--- a/glass/ext/__init__.py
+++ b/glass/ext/__init__.py
@@ -28,7 +28,7 @@ def _extend_path(path: list[str], name: str) -> list[str]:
     """
     _pkg, _, _mod = name.partition(".")
 
-    return list(  # ty:ignore[invalid-return-type]
+    return list(  # ty: ignore[invalid-return-type]
         filter(
             os.path.isdir,
             (os.path.join(p, _mod) for p in pkgutil.extend_path(path, _pkg)),  # noqa: PTH118

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -663,7 +663,8 @@ def effective_cls(
         itertools.combinations_with_replacement(uxpx.ndindex(shape1[1:], xp=xp), 2)
         if weights2 is weights1
         else itertools.product(
-            uxpx.ndindex(shape1[1:], xp=xp), uxpx.ndindex(shape2[1:], xp=xp)
+            uxpx.ndindex(shape1[1:], xp=xp),
+            uxpx.ndindex(shape2[1:], xp=xp),
         )
     )
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -686,7 +686,7 @@ def effective_cls(
         out = xpx.at(out)[j1 + j2 + (...,)].set(cl)
         if weights2 is weights1 and j1 != j2:
             out = xpx.at(out)[j2 + j1 + (...,)].set(cl)
-    return out  # ty: ignore[invalid-return-type]
+    return typing.cast("FloatArray", out)
 
 
 def gaussian_fields(

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -686,7 +686,7 @@ def effective_cls(
         out = xpx.at(out)[j1 + j2 + (...,)].set(cl)
         if weights2 is weights1 and j1 != j2:
             out = xpx.at(out)[j2 + j1 + (...,)].set(cl)
-    return out  # ty:ignore[invalid-return-type]
+    return out  # ty: ignore[invalid-return-type]
 
 
 def gaussian_fields(

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import itertools
 import math
 import sys
+import typing
 import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -226,7 +227,7 @@ def cls2cov(
             cov = xpx.at(cov)[:n, i].set(cl)
             cov = xpx.at(cov)[n:, i].set(0.0)
         cov /= 2
-        yield cov
+        yield typing.cast("FloatArray", cov)
 
 
 def discretized_cls(
@@ -551,7 +552,7 @@ def getcl(
             cl = cl[: lmax + 1]
         else:
             cl = xpx.pad(cl, (0, lmax + 1 - cl.shape[0]))
-    return cl  # ty: ignore[invalid-return-type]
+    return typing.cast("FloatArray", cl)
 
 
 def enumerate_spectra(
@@ -1022,7 +1023,7 @@ def cov_from_spectra(
         cov = xpx.at(cov)[:size, i, j].set(cl_flat[:size])
         cov = xpx.at(cov)[:size, j, i].set(cl_flat[:size])
 
-    return cov
+    return typing.cast("AnyArray", cov)
 
 
 def check_posdef_spectra(spectra: AngularPowerSpectra) -> bool:

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -148,7 +148,7 @@ def redshifts_from_nz(
                 rng.uniform(0, 1, size=int(count_out[k])),
                 cdf,
                 z_out_slice,
-            )
+            ),
         )
         total += count_out[k]
 

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -154,7 +154,7 @@ def redshifts_from_nz(
 
     assert total == redshifts.size  # noqa: S101
 
-    return redshifts  # ty:ignore[invalid-return-type]
+    return redshifts  # ty: ignore[invalid-return-type]
 
 
 def galaxy_shear(  # noqa: PLR0913

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -20,6 +20,7 @@ Functions
 from __future__ import annotations
 
 import math
+import typing
 import warnings
 from typing import TYPE_CHECKING
 
@@ -154,7 +155,7 @@ def redshifts_from_nz(
 
     assert total == redshifts.size  # noqa: S101
 
-    return redshifts  # ty: ignore[invalid-return-type]
+    return typing.cast("FloatArray", redshifts)
 
 
 def galaxy_shear(  # noqa: PLR0913

--- a/glass/grf/_core.py
+++ b/glass/grf/_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+import typing
+from typing import TYPE_CHECKING
 
 import transformcl
 
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
     from glass._types import AnyArray
 
 
-class Transformation(Protocol):
+class Transformation(typing.Protocol):
     """Protocol for transformations of Gaussian random fields."""
 
     def __call__(self, x: AnyArray, var: float, /) -> AnyArray:

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -56,9 +56,9 @@ def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
     *,
-    potential: Literal[False],
-    deflection: Literal[False],
-    shear: Literal[False],
+    potential: Literal[False] = False,
+    deflection: Literal[False] = False,
+    shear: Literal[False] = False,
     discretized: bool = True,
 ) -> tuple[()]:
     # returns empty tuple

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -32,7 +32,7 @@ Applying lensing
 from __future__ import annotations
 
 import typing
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from glass.shells import RadialWindow
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -65,7 +65,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -79,7 +79,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -93,7 +93,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -107,7 +107,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -124,7 +124,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -141,7 +141,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,
@@ -158,7 +158,7 @@ def from_convergence(
     ...
 
 
-@overload
+@typing.overload
 def from_convergence(
     kappa: FloatArray,
     lmax: int | None = None,

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -31,6 +31,7 @@ Applying lensing
 
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
@@ -625,7 +626,7 @@ def multi_plane_matrix(
     for i, w in enumerate(shells):
         mpc.add_window(xp.asarray(wmat[i, :], copy=True), w)
         wmat = xpx.at(wmat)[i, :].set(mpc.kappa)
-    return wmat
+    return typing.cast("FloatArray", wmat)
 
 
 def multi_plane_weights(

--- a/glass/points.py
+++ b/glass/points.py
@@ -605,7 +605,7 @@ def uniform_positions(
         else:
             count = int(ngal_sphere[k])
 
-        yield lon, lat, count  # ty:ignore[invalid-yield]
+        yield lon, lat, count  # ty: ignore[invalid-yield]
 
 
 def position_weights(

--- a/glass/points.py
+++ b/glass/points.py
@@ -599,7 +599,6 @@ def uniform_positions(
         lat = uxpx.degrees(xp.asin(rng.uniform(-1, 1, size=size)))
 
         # report count
-        count: int | IntArray
         if dims:
             count = xp.zeros(dims, dtype=xp.int64)
             count = xpx.at(count)[k].set(ngal_sphere[k])

--- a/glass/points.py
+++ b/glass/points.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import itertools
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import array_api_compat
 import array_api_extra as xpx
@@ -54,6 +54,7 @@ from glass._array_api_utils import xp_additions as uxpx
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from types import ModuleType
+    from typing import Any
 
     from glass._types import (
         ComplexArray,

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -25,6 +25,7 @@ Utilities
 from __future__ import annotations
 
 import math
+import typing
 from typing import TYPE_CHECKING
 
 import array_api_compat
@@ -282,7 +283,7 @@ def ellipticity_gaussian(
         eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
-    return eps
+    return typing.cast("ComplexArray", eps)
 
 
 def ellipticity_intnorm(
@@ -361,4 +362,4 @@ def ellipticity_intnorm(
         eps = xpx.at(eps)[i : i + count_broadcasted[k]].set(e)
         i += count_broadcasted[k]
 
-    return eps
+    return typing.cast("ComplexArray", eps)

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import dataclasses
 import itertools
 import math
+import typing
 import warnings
 from typing import TYPE_CHECKING
 
@@ -526,7 +527,7 @@ def restrict(
         left=0.0,
         right=0.0,
     ) * glass.arraytools.ndinterp(zr, w.za, w.wa)
-    return zr, fr  # ty: ignore[invalid-return-type]
+    return typing.cast("FloatArray", zr), typing.cast("FloatArray", fr)
 
 
 def partition(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,9 @@ Issues = "https://github.com/glass-dev/glass/issues"
 [tool.coverage]
 report = {exclude_also = [
     "(?:from\\s+[^\\s]+\\s+)?import\\s+.*",
-    "@overload\\n",
+    "@(?:typing\\.)?overload\\n",
     "class\\s+\\w+\\([^)]*\\bProtocol\\b[^)]*\\):", # protocol classes
-    "if TYPE_CHECKING:",
+    "if (?:typing\\.)?TYPE_CHECKING:",
 ], omit = [
     "_types.py", # typing-only module
     "_version.py", # not being tracked anyway

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ Issues = "https://github.com/glass-dev/glass/issues"
 report = {exclude_also = [
     "(?:from\\s+[^\\s]+\\s+)?import\\s+.*",
     "@(?:typing\\.)?overload\\n",
-    "class\\s+\\w+\\([^)]*\\bProtocol\\b[^)]*\\):", # protocol classes
+    "class\\s+\\w+\\([^)]*\\b(?:typing\\.)?Protocol\\b[^)]*\\):", # protocol classes
     "if (?:typing\\.)?TYPE_CHECKING:",
 ], omit = [
     "_types.py", # typing-only module

--- a/tests/benchmarks/test_fields.py
+++ b/tests/benchmarks/test_fields.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 @pytest.mark.stable
 def test_iternorm_no_size(
     benchmark: BenchmarkFixture,
-    generator_consumer: GeneratorConsumer,
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.iternorm with default value for size."""
@@ -50,7 +50,7 @@ def test_iternorm_no_size(
 @pytest.mark.parametrize("num_dimensions", [1, 2])
 def test_iternorm_specify_size(
     benchmark: BenchmarkFixture,
-    generator_consumer: GeneratorConsumer,
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
     num_dimensions: int,
 ) -> None:
@@ -102,8 +102,8 @@ def test_iternorm_specify_size(
 @pytest.mark.stable
 def test_iternorm_k_0(
     benchmark: BenchmarkFixture,
-    compare: Compare,
-    generator_consumer: GeneratorConsumer,
+    compare: type[Compare],
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.iternorm with k set to 0."""
@@ -125,8 +125,8 @@ def test_iternorm_k_0(
 @pytest.mark.stable
 def test_cls2cov(
     benchmark: BenchmarkFixture,
-    compare: Compare,
-    generator_consumer: GeneratorConsumer,
+    compare: type[Compare],
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.cls2cov."""
@@ -158,7 +158,7 @@ def test_cls2cov(
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate_grf(
     benchmark: BenchmarkFixture,
-    generator_consumer: GeneratorConsumer,
+    generator_consumer: type[GeneratorConsumer],
     ncorr: int | None,
     urngb: UnifiedGenerator,
     use_rng: bool,  # noqa: FBT001
@@ -185,8 +185,8 @@ def test_generate_grf(
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate(
     benchmark: BenchmarkFixture,
-    compare: Compare,
-    generator_consumer: GeneratorConsumer,
+    compare: type[Compare],
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
     ncorr: int | None,
 ) -> None:

--- a/tests/benchmarks/test_points.py
+++ b/tests/benchmarks/test_points.py
@@ -32,8 +32,8 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize("remove_monopole", [True, False])
 def test_positions_from_delta(  # noqa: PLR0913
     benchmark: BenchmarkFixture,
-    data_transformer: DataTransformer,
-    generator_consumer: GeneratorConsumer,
+    data_transformer: type[DataTransformer],
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
     bias: float,
     bias_model: Callable[[int], int],
@@ -71,8 +71,8 @@ def test_positions_from_delta(  # noqa: PLR0913
 @pytest.mark.stable
 def test_uniform_positions(
     benchmark: BenchmarkFixture,
-    data_transformer: DataTransformer,
-    generator_consumer: GeneratorConsumer,
+    data_transformer: type[DataTransformer],
+    generator_consumer: type[GeneratorConsumer],
     xpb: ModuleType,
 ) -> None:
     """Benchmarks for glass.uniform_positionsuniform_positions."""

--- a/tests/benchmarks/test_shells.py
+++ b/tests/benchmarks/test_shells.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 def test_radialwindow(
     benchmark: BenchmarkFixture,
     xpb: ModuleType,
-    compare: Compare,
+    compare: type[Compare],
 ) -> None:
     """Benchmark for shells.RadialWindow."""
     # check zeff is computed when not provided

--- a/tests/benchmarks/test_shells.py
+++ b/tests/benchmarks/test_shells.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 @pytest.mark.unstable
 def test_radialwindow(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
     compare: type[Compare],
+    xpb: ModuleType,
 ) -> None:
     """Benchmark for shells.RadialWindow."""
     # check zeff is computed when not provided

--- a/tests/core/grf/test_core.py
+++ b/tests/core/grf/test_core.py
@@ -37,7 +37,10 @@ def test_corr_unknown(xp: ModuleType) -> None:
         glass.grf.dcorr(t1, t2, x)
 
 
-def test_compute(mocker: MockerFixture, xp: ModuleType) -> None:
+def test_compute(
+    mocker: MockerFixture,
+    xp: ModuleType,
+) -> None:
     cltocorr = mocker.patch("transformcl.cltocorr")
     icorr = mocker.patch("glass.grf._core.icorr")
     corrtocl = mocker.patch("transformcl.corrtocl")

--- a/tests/core/grf/test_solver.py
+++ b/tests/core/grf/test_solver.py
@@ -33,7 +33,10 @@ def test_one_transformation(
     compare.assert_array_equal(gl1, gl2)
 
 
-def test_pad(cl: FloatArray, rng: np.random.Generator) -> None:
+def test_pad(
+    cl: FloatArray,
+    rng: np.random.Generator,
+) -> None:
     lam = rng.random()
     t = glass.grf.Lognormal(lam)
 
@@ -62,7 +65,10 @@ def test_initial(
     compare.assert_array_equal(gl1, gl2)
 
 
-def test_no_iterations(cl: FloatArray, compare: type[Compare]) -> None:
+def test_no_iterations(
+    cl: FloatArray,
+    compare: type[Compare],
+) -> None:
     t = glass.grf.Lognormal()
 
     gl1 = glass.grf.compute(cl, t)

--- a/tests/core/grf/test_transformations.py
+++ b/tests/core/grf/test_transformations.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
     from tests.fixtures.helper_classes import Compare
 
 
-def test_normal(compare: type[Compare], urng: UnifiedGenerator) -> None:
+def test_normal(
+    compare: type[Compare],
+    urng: UnifiedGenerator,
+) -> None:
     t = glass.grf.Normal()
     x = urng.standard_normal(10)
     compare.assert_array_equal(t(x, 1.0), x)

--- a/tests/core/test_algorithm.py
+++ b/tests/core/test_algorithm.py
@@ -80,7 +80,10 @@ def test_cov_clip(
     compare.assert_allclose(xp.linalg.eigvalsh(cov), h)
 
 
-def test_nearcorr(compare: type[Compare], xp: ModuleType) -> None:
+def test_nearcorr(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # from Higham (2002)
     a = xp.asarray(
         [

--- a/tests/core/test_arraytools.py
+++ b/tests/core/test_arraytools.py
@@ -59,7 +59,10 @@ def test_broadcast_leading_axes(xp: ModuleType) -> None:
     assert c_out.shape == (3, 4, 5, 6)
 
 
-def test_ndinterp(compare: type[Compare], xp: ModuleType) -> None:
+def test_ndinterp(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # test 1d interpolation
 
     xq = xp.asarray([0, 1, 2, 3, 4])
@@ -144,7 +147,10 @@ def test_ndinterp(compare: type[Compare], xp: ModuleType) -> None:
     )
 
 
-def test_trapezoid_product(compare: type[Compare], xp: ModuleType) -> None:
+def test_trapezoid_product(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     x1 = xp.linspace(0, 2, 100)
     f1 = xp.full_like(x1, 2.0)
 
@@ -156,7 +162,10 @@ def test_trapezoid_product(compare: type[Compare], xp: ModuleType) -> None:
     compare.assert_allclose(s, 1.0)
 
 
-def test_cumulative_trapezoid(compare: type[Compare], xp: ModuleType) -> None:
+def test_cumulative_trapezoid(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # 1D f and x
 
     f = xp.asarray([1, 2, 3, 4])

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -530,7 +530,8 @@ def test_spectra_indices(compare: type[Compare], xp: ModuleType) -> None:
     compare.assert_array_equal(glass.spectra_indices(0, xp=xp), xp.zeros((0, 2)))
     compare.assert_array_equal(glass.spectra_indices(1, xp=xp), [[0, 0]])
     compare.assert_array_equal(
-        glass.spectra_indices(2, xp=xp), [[0, 0], [1, 1], [1, 0]]
+        glass.spectra_indices(2, xp=xp),
+        [[0, 0], [1, 1], [1, 0]],
     )
     compare.assert_array_equal(
         glass.spectra_indices(3, xp=xp),

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -140,7 +140,10 @@ def test_iternorm(xp: ModuleType) -> None:
 
 
 @pytest.mark.skipif(not HAVE_JAX, reason="test requires jax")
-def test_cls2cov_jax(compare: type[Compare], jnp: ModuleType) -> None:
+def test_cls2cov_jax(
+    compare: type[Compare],
+    jnp: ModuleType,
+) -> None:
     nl, nf, nc = 3, 3, 2
 
     generator = glass.cls2cov(
@@ -183,7 +186,10 @@ def test_cls2cov_jax(compare: type[Compare], jnp: ModuleType) -> None:
         compare.assert_allclose(cov2, cov3)
 
 
-def test_cls2cov_no_jax(compare: type[Compare], xpb: ModuleType) -> None:
+def test_cls2cov_no_jax(
+    compare: type[Compare],
+    xpb: ModuleType,
+) -> None:
     # check output values and shape
 
     nl, nf, nc = 3, 2, 2
@@ -294,7 +300,10 @@ def test_lognormal_gls(xp: ModuleType) -> None:
     assert out[2].shape[0] == 3
 
 
-def test_discretized_cls(compare: type[Compare], xp: ModuleType) -> None:
+def test_discretized_cls(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # empty cls
 
     result = glass.discretized_cls([])
@@ -342,7 +351,10 @@ def test_discretized_cls(compare: type[Compare], xp: ModuleType) -> None:
         compare.assert_allclose(cl[:n], expected)
 
 
-def test_effective_cls(compare: type[Compare], xp: ModuleType) -> None:
+def test_effective_cls(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # empty cls
 
     result = glass.effective_cls([], xp.asarray([]))
@@ -379,7 +391,10 @@ def test_effective_cls(compare: type[Compare], xp: ModuleType) -> None:
     assert result.shape == (1, 1, 15)
 
 
-def test_generate_grf(compare: type[Compare], xp: ModuleType) -> None:
+def test_generate_grf(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     gls: AngularPowerSpectra = [xp.asarray([1.0, 0.5, 0.1])]
     nside = 4
     ncorr = 1
@@ -420,7 +435,10 @@ def test_generate_lognormal(xp: ModuleType) -> None:
     next(result)
 
 
-def test_generate(compare: type[Compare], xp: ModuleType) -> None:
+def test_generate(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # shape mismatch error
 
     fields = [lambda x, var: x, lambda x, var: x]  # noqa: ARG005
@@ -458,7 +476,10 @@ def test_generate(compare: type[Compare], xp: ModuleType) -> None:
     compare.assert_allclose(result[1], result[0] ** 2, atol=1e-05)
 
 
-def test_getcl(compare: type[Compare], xp: ModuleType) -> None:
+def test_getcl(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # make a mock Cls array with the index pairs as entries
     cls: AngularPowerSpectra = [
         xp.asarray([i, j], dtype=xp.float64)
@@ -503,7 +524,10 @@ def test_nfields_from_nspectra(not_triangle_numbers: list[int]) -> None:
             glass.nfields_from_nspectra(t)
 
 
-def test_enumerate_spectra(compare: type[Compare], xp: ModuleType) -> None:
+def test_enumerate_spectra(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     n = 100
     tn = n * (n + 1) // 2
 
@@ -525,7 +549,10 @@ def test_enumerate_spectra(compare: type[Compare], xp: ModuleType) -> None:
         next(it)
 
 
-def test_spectra_indices(compare: type[Compare], xp: ModuleType) -> None:
+def test_spectra_indices(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     compare.assert_array_equal(glass.spectra_indices(0), xp.zeros((0, 2)))
     compare.assert_array_equal(glass.spectra_indices(0, xp=xp), xp.zeros((0, 2)))
     compare.assert_array_equal(glass.spectra_indices(1, xp=xp), [[0, 0]])
@@ -565,7 +592,10 @@ def test_lognormal_fields(xp: ModuleType) -> None:
     assert [f.lamda for f in fields] == [1, 4, 9]
 
 
-def test_compute_gaussian_spectra(mocker: MockerFixture, xp: ModuleType) -> None:
+def test_compute_gaussian_spectra(
+    mocker: MockerFixture,
+    xp: ModuleType,
+) -> None:
     mock = mocker.patch("glass.grf.compute")
 
     fields = [glass.grf.Normal(), glass.grf.Normal()]
@@ -584,7 +614,10 @@ def test_compute_gaussian_spectra(mocker: MockerFixture, xp: ModuleType) -> None
         glass.compute_gaussian_spectra(fields, spectra[:2])
 
 
-def test_compute_gaussian_spectra_gh639(mocker: MockerFixture, xp: ModuleType) -> None:
+def test_compute_gaussian_spectra_gh639(
+    mocker: MockerFixture,
+    xp: ModuleType,
+) -> None:
     """Test compute_gaussian_spectra() with an empty input."""
     mock = mocker.patch("glass.grf.compute")
 
@@ -600,7 +633,10 @@ def test_compute_gaussian_spectra_gh639(mocker: MockerFixture, xp: ModuleType) -
     assert gls[2].shape[0] == 0
 
 
-def test_solve_gaussian_spectra(mocker: MockerFixture, xp: ModuleType) -> None:
+def test_solve_gaussian_spectra(
+    mocker: MockerFixture,
+    xp: ModuleType,
+) -> None:
     mock = mocker.patch("glass.grf.solve")
 
     result = mock.return_value
@@ -653,7 +689,10 @@ def test_healpix_to_glass_spectra(compare: type[Compare]) -> None:
     compare.assert_array_equal(out, [11, 22, 21, 33, 32, 31, 44, 43, 42, 41])
 
 
-def test_glass_to_healpix_alm(compare: type[Compare], xp: ModuleType) -> None:
+def test_glass_to_healpix_alm(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     inp = xp.asarray([00, 10, 11, 20, 21, 22, 30, 31, 32, 33], dtype=xp.complex128)
     out = glass.fields._glass_to_healpix_alm(inp)
     compare.assert_array_equal(

--- a/tests/core/test_galaxies.py
+++ b/tests/core/test_galaxies.py
@@ -15,7 +15,10 @@ if TYPE_CHECKING:
     from tests.fixtures.helper_classes import Compare
 
 
-def test_redshifts(mocker: MockerFixture, xp: ModuleType) -> None:
+def test_redshifts(
+    mocker: MockerFixture,
+    xp: ModuleType,
+) -> None:
     # create a mock radial window function
     w = mocker.Mock()
     w.za = xp.linspace(0.0, 1.0, 20)
@@ -32,7 +35,10 @@ def test_redshifts(mocker: MockerFixture, xp: ModuleType) -> None:
     assert z.shape == (10,)
 
 
-def test_redshifts_from_nz(urng: UnifiedGenerator, xp: ModuleType) -> None:
+def test_redshifts_from_nz(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
     # test sampling
 
     redshifts = glass.redshifts_from_nz(

--- a/tests/core/test_harmonics.py
+++ b/tests/core/test_harmonics.py
@@ -12,7 +12,10 @@ if TYPE_CHECKING:
     from tests.fixtures.helper_classes import Compare
 
 
-def test_multalm(compare: type[Compare], xp: ModuleType) -> None:
+def test_multalm(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     # check output values and shapes
 
     alm = xp.asarray([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])

--- a/tests/core/test_lensing.py
+++ b/tests/core/test_lensing.py
@@ -31,7 +31,7 @@ def test_from_convergence(
 
     # check with all False
 
-    results = glass.from_convergence(kappa)  # ty: ignore[no-matching-overload]
+    results = glass.from_convergence(kappa)
     compare.assert_array_equal(results, ())
 
     # check all combinations of potential, deflection, shear being True

--- a/tests/core/test_observations.py
+++ b/tests/core/test_observations.py
@@ -16,7 +16,10 @@ if TYPE_CHECKING:
     from tests.fixtures.helper_classes import Compare
 
 
-def test_vmap_galactic_ecliptic(compare: type[Compare], xp: ModuleType) -> None:
+def test_vmap_galactic_ecliptic(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.vmap_galactic_ecliptic`."""
     n_side = 4
 
@@ -83,7 +86,10 @@ def test_gaussian_nz(
     assert nz.shape == (z.shape[0], z.shape[0])
 
 
-def test_smail_nz(compare: type[Compare], xp: ModuleType) -> None:
+def test_smail_nz(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.smail_nz`."""
     alpha = 1
     beta = 1
@@ -134,7 +140,10 @@ def test_fixed_zbins_default_xp(compare: type[Compare]) -> None:
         glass.fixed_zbins(zmin, zmax, nbins=nbins, dz=dz)
 
 
-def test_fixed_zbins_xp_provided(compare: type[Compare], xp: ModuleType) -> None:
+def test_fixed_zbins_xp_provided(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.fixed_zbins`."""
     zmin = 0.0
     zmax = 1.0
@@ -170,7 +179,10 @@ def test_fixed_zbins_xp_provided(compare: type[Compare], xp: ModuleType) -> None
         glass.fixed_zbins(zmin, zmax, nbins=nbins, dz=dz, xp=xp)
 
 
-def test_equal_dens_zbins(compare: type[Compare], xp: ModuleType) -> None:
+def test_equal_dens_zbins(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.equal_dens_zbins`."""
     z = xp.linspace(0, 1, 11)
     nbins = 5
@@ -191,7 +203,10 @@ def test_equal_dens_zbins(compare: type[Compare], xp: ModuleType) -> None:
     assert len(zbins) == nbins
 
 
-def test_tomo_nz_gausserr(compare: type[Compare], xp: ModuleType) -> None:
+def test_tomo_nz_gausserr(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.tomo_nz_gausserr`."""
     sigma_0 = 0.1
     z = xp.linspace(0, 1, 11)

--- a/tests/core/test_points.py
+++ b/tests/core/test_points.py
@@ -482,7 +482,10 @@ def test_position_weights(
             compare.assert_allclose(weights, expected)
 
 
-def test_displace_arg_complex(compare: type[Compare], xp: ModuleType) -> None:
+def test_displace_arg_complex(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Test displace function with complex-valued displacement."""
     d = 5.0  # deg
     r = d / 180 * math.pi
@@ -508,7 +511,10 @@ def test_displace_arg_complex(compare: type[Compare], xp: ModuleType) -> None:
     compare.assert_allclose([lon, lat], [-d, 0.0], atol=1e-15)
 
 
-def test_displace_arg_real(compare: type[Compare], xp: ModuleType) -> None:
+def test_displace_arg_real(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Test displace function with real-valued argument."""
     d = 5.0  # deg
     r = d / 180 * math.pi

--- a/tests/core/test_points.py
+++ b/tests/core/test_points.py
@@ -223,7 +223,7 @@ def test_sample_number_galaxies_rng(
 
 
 def test_sample_galaxies_per_pixel(
-    data_transformer: DataTransformer,
+    data_transformer: type[DataTransformer],
     xp: ModuleType,
 ) -> None:
     batch = 1000000
@@ -248,7 +248,7 @@ def test_sample_galaxies_per_pixel(
 
 def test_positions_from_delta(  # noqa: PLR0915
     compare: type[Compare],
-    data_transformer: DataTransformer,
+    data_transformer: type[DataTransformer],
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
@@ -400,7 +400,7 @@ def test_positions_from_delta(  # noqa: PLR0915
 
 
 def test_uniform_positions(
-    data_transformer: DataTransformer,
+    data_transformer: type[DataTransformer],
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:

--- a/tests/core/test_shapes.py
+++ b/tests/core/test_shapes.py
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
     from tests.fixtures.helper_classes import Compare
 
 
-def test_triaxial_axis_ratio(urng: UnifiedGenerator, xp: ModuleType) -> None:
+def test_triaxial_axis_ratio(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
     # Pass floats without xp
 
     with pytest.raises(
@@ -63,7 +66,10 @@ def test_triaxial_axis_ratio(urng: UnifiedGenerator, xp: ModuleType) -> None:
     assert xp.all((qmax >= q) & (q >= qmin))
 
 
-def test_ellipticity_ryden04(urng: UnifiedGenerator, xp: ModuleType) -> None:
+def test_ellipticity_ryden04(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
     # Pass floats without xp
 
     with pytest.raises(

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -61,7 +61,10 @@ def test_volume_weight(
     compare.assert_array_less(w[:-1], w[1:])
 
 
-def test_density_weight(compare: type[Compare], cosmo: Cosmology) -> None:
+def test_density_weight(
+    compare: type[Compare],
+    cosmo: Cosmology,
+) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
@@ -101,7 +104,10 @@ def test_tophat_windows(xp: ModuleType) -> None:
     assert all(xp.all(w.wa == 1) for w in ws)
 
 
-def test_linear_windows(compare: type[Compare], xp: ModuleType) -> None:
+def test_linear_windows(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.linear_windows`."""
     dz = 1e-2
     zgrid = xp.asarray(
@@ -150,7 +156,10 @@ def test_linear_windows(compare: type[Compare], xp: ModuleType) -> None:
         glass.linear_windows(xp.asarray([0.1, 0.2, 0.3]))
 
 
-def test_cubic_windows(compare: type[Compare], xp: ModuleType) -> None:
+def test_cubic_windows(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Add unit tests for :func:`glass.cubic_windows`."""
     dz = 1e-2
     zgrid = xp.asarray(
@@ -340,7 +349,10 @@ def test_redshift_grid(xp: ModuleType) -> None:
         glass.redshift_grid(zmin, zmax, dz=dz, num=num, xp=xp)
 
 
-def test_distance_grid(compare: type[Compare], cosmo: Cosmology) -> None:
+def test_distance_grid(
+    compare: type[Compare],
+    cosmo: Cosmology,
+) -> None:
     """Add unit tests for :func:`glass.distance_grid`."""
     zmin = 0.0
     zmax = 1.0
@@ -449,7 +461,10 @@ def test_radial_window_immutable(xp: ModuleType) -> None:
         w.zeff = zeff  # ty: ignore[invalid-assignment]
 
 
-def test_radial_window_zeff_none(compare: type[Compare], xp: ModuleType) -> None:
+def test_radial_window_zeff_none(
+    compare: type[Compare],
+    xp: ModuleType,
+) -> None:
     """Checks ``zeff`` is computed when not provided to :class:`RadialWindow`."""
     # check zeff is computed when not provided
 

--- a/tests/core/test_user.py
+++ b/tests/core/test_user.py
@@ -39,7 +39,8 @@ def test_read_write_cls(
 
     compare.assert_array_equal(values, np.concat(cls))
     compare.assert_array_equal(
-        split, np.cumulative_sum([cl.shape[0] for cl in cls[:-1]])
+        split,
+        np.cumulative_sum([cl.shape[0] for cl in cls[:-1]]),
     )
     compare.assert_array_equal(cls, np.split(values, split))
 

--- a/tests/fixtures/helper_classes.py
+++ b/tests/fixtures/helper_classes.py
@@ -160,7 +160,7 @@ class HealpixInputs:
     def alm(*, rng: UnifiedGenerator) -> ComplexArray:
         """Generate random alm coefficients."""
         return rng.standard_normal(  # ty: ignore[unsupported-operator]
-            HealpixInputs.alm_size
+            HealpixInputs.alm_size,
         ) + 1j * rng.standard_normal(
             HealpixInputs.alm_size,
         )


### PR DESCRIPTION
# Description

Reattempt at #1094. Tidying up some `ty: ignore` statements. Sorting fixtures alphabetically and fix the missing `type[]` typing.. Also be more selective on `from typing import <x>`.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #983, #1071

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
