### PR TITLE
gh-1099: Group @dependabot updates together for pre-commit/GHA

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,31 +1,27 @@
 ---
 version: 2
+
+multi-ecosystem-groups:
+  ci-dependencies:
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: dependabot
+    labels:
+      - dependabot
+
 updates:
   - package-ecosystem: github-actions
-    commit-message:
-      prefix: dependabot
+    directory: /
+    patterns:
+      - "*"
     cooldown:
       default-days: 7
-    directory: /
-    groups:
-      ci-dependencies:
-        patterns:
-          - "*"
-    labels:
-      - dependabot
-    schedule:
-      interval: monthly
+    multi-ecosystem-group: ci-dependencies
   - package-ecosystem: pre-commit
-    commit-message:
-      prefix: dependabot
+    directory: /
+    patterns:
+      - "*"
     cooldown:
       default-days: 7
-    directory: /
-    groups:
-      ci-dependencies:
-        patterns:
-          - "*"
-    labels:
-      - dependabot
-    schedule:
-      interval: monthly
+    multi-ecosystem-group: ci-dependencies

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,7 @@ multi-ecosystem-groups:
   ci-dependencies:
     schedule:
       interval: monthly
+      timezone: Europe/London
     commit-message:
       prefix: dependabot
     labels:
@@ -12,16 +13,16 @@ multi-ecosystem-groups:
 
 updates:
   - package-ecosystem: github-actions
-    directory: /
-    patterns:
-      - "*"
     cooldown:
       default-days: 7
+    directory: /
     multi-ecosystem-group: ci-dependencies
+    patterns:
+      - "*"
   - package-ecosystem: pre-commit
-    directory: /
-    patterns:
-      - "*"
     cooldown:
       default-days: 7
+    directory: /
     multi-ecosystem-group: ci-dependencies
+    patterns:
+      - "*"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -61,3 +61,4 @@ jobs:
           filter_mode: nofilter
           reporter: github-pr-review
           vale_flags: --glob='!.nox/*'
+          version: 3.14.1

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -61,4 +61,3 @@ jobs:
           filter_mode: nofilter
           reporter: github-pr-review
           vale_flags: --glob='!.nox/*'
-          version: 3.14.1


### PR DESCRIPTION
# Description

Uses `multi-ecosystem-groups` to group `pre-commit` and GHA updates together for @dependabot. I thought I'd done this in #1073, but it wasn't working.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1099

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
