### PR TITLE
gh-1106: pin `vale` version in action to fix docs check

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -61,3 +61,4 @@ jobs:
           filter_mode: nofilter
           reporter: github-pr-review
           vale_flags: --glob='!.nox/*'
+          version: 3.14.1


### PR DESCRIPTION
# Description

https://github.com/vale-cli/vale/issues/1105 is causing the documentation action to fail, by pinning `vale` it passes.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1106

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
