### PR TITLE
gh-382: Attempt to port to `ragged`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ intersphinx_mapping = {
     "jaxtyping": ("https://docs.kidger.site/jaxtyping", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "python": ("https://docs.python.org/3", None),
+    "ragged": ("https://scikit-hep.org/ragged", None),
 }
 
 

--- a/glass/_types.py
+++ b/glass/_types.py
@@ -2,11 +2,11 @@ import typing
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from typing import TypeAlias
 
     import jaxtyping
     import numpy as np
+    import ragged
 
     from array_api_strict._array_object import Array
     from array_api_strict._dtypes import DType
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
         np.random.Generator | glass.jax.Generator | _rng.Generator
     )
 
-    AngularPowerSpectra: TypeAlias = Sequence[AnyArray]
+    AngularPowerSpectra: TypeAlias = ragged.array
 else:
     # Runtime fallbacks (for Sphinx / autodoc)
     # https://github.com/sphinx-doc/sphinx/issues/11991

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -213,14 +213,14 @@ def cls2cov(
         If negative values are found in the Cls.
 
     """
-    xp = array_api_compat.array_namespace(*cls, use_compat=False)
+    xp = array_api_compat.array_namespace(cls, use_compat=False)
 
     cov = xp.zeros((nl, nc + 1))
     end = 0
     for j in range(nf):
         begin, end = end, end + j + 1
         for i, cl in enumerate(cls[begin:end][: nc + 1]):
-            if i == 0 and xp.any(xp.less(cl, 0)):
+            if i == 0 and xp.any(xp.less(cl, xp.asarray(0))):
                 msg = "negative values in cl"
                 raise ValueError(msg)
             n = cl.shape[0]
@@ -368,20 +368,20 @@ def _generate_grf(
         If all gls are empty.
 
     """
-    xp = array_api_compat.array_namespace(*gls, use_compat=False)
+    xp = array_api_compat.array_namespace(gls, use_compat=False)
 
     if rng is None:
         rng = _rng.rng_dispatcher(xp=xp)
 
     # number of gls and number of fields
-    ngrf = nfields_from_nspectra(len(gls))
+    ngrf = nfields_from_nspectra(gls.shape[0])
 
     # number of correlated fields if not specified
     if ncorr is None:
         ncorr = ngrf - 1
 
     # number of modes
-    n = max((gl.shape[0] for gl in gls), default=0)
+    n = xp.max(gls, axis=0)
     if n == 0:
         msg = "all gls are empty"
         raise ValueError(msg)
@@ -472,7 +472,7 @@ def generate_gaussian(
         If all gls are empty.
 
     """
-    n = nfields_from_nspectra(len(gls))
+    n = nfields_from_nspectra(gls.shape[0])
     fields = [glass.grf.Normal() for _ in range(n)]
     yield from generate(fields, gls, nside, ncorr=ncorr, rng=rng)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "array-api-extra>=0.10.3",
     "healpix>=2022.11.1",
     "healpy>=1.15.0",
+    "ragged>=0.3.0",
     "transformcl>=2026.1",
 ]
 description = "Generator for Large Scale Structure"

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+import ragged
 
 import array_api_extra as xpx
 
@@ -169,31 +170,28 @@ def test_cls2cov_no_jax(xpb: ModuleType) -> None:
     nl, nf, nc = 3, 2, 2
 
     generator = glass.cls2cov(
-        [xpb.asarray([1.0, 0.5, 0.3]), None, xpb.asarray([0.7, 0.6, 0.1])],
+        ragged.array([[1.0, 0.5, 0.3], [], [0.7, 0.6, 0.1]]),
         nl,
         nf,
         nc,
     )
     cov = next(generator)
 
-    assert cov.shape == (nl, nc + 1)
+    assert cov.shape[0] == nl
     assert cov.dtype == xpb.float64
 
-    xpx.testing.assert_equal(cov[:, 0], xpb.asarray([0.5, 0.25, 0.15]))
-    xpx.testing.assert_equal(cov[:, 1], xpb.asarray(0.0), check_shape=False)
-    xpx.testing.assert_equal(cov[:, 2], xpb.asarray(0.0), check_shape=False)
+    xpx.testing.assert_equal(cov[:, 0], ragged.asarray([0.5, 0.25, 0.15]))
+    xpx.testing.assert_equal(cov[:, 1], ragged.asarray(0.0), check_shape=False)
+    xpx.testing.assert_equal(cov[:, 2], ragged.asarray(0.0), check_shape=False)
 
     # test negative value error
 
     generator = glass.cls2cov(
-        [
-            xpb.asarray(arr)
-            for arr in [
-                [-1.0, 0.5, 0.3],
-                [0.8, 0.4, 0.2],
-                [0.7, 0.6, 0.1],
-            ]
-        ],
+        ragged.array([
+            [-1.0, 0.5, 0.3],
+            [0.8, 0.4, 0.2],
+            [0.7, 0.6, 0.1],
+        ]),
         nl,
         nf,
         nc,
@@ -206,40 +204,37 @@ def test_cls2cov_no_jax(xpb: ModuleType) -> None:
     nl, nf, nc = 3, 3, 2
 
     generator = glass.cls2cov(
-        [
-            xpb.asarray(arr)
-            for arr in [
-                [1.0, 0.5, 0.3],
-                [0.8, 0.4, 0.2],
-                [0.7, 0.6, 0.1],
-                [0.9, 0.5, 0.3],
-                [0.6, 0.3, 0.2],
-                [0.8, 0.7, 0.4],
-            ]
-        ],
+        ragged.array([
+            [1.0, 0.5, 0.3],
+            [0.8, 0.4, 0.2],
+            [0.7, 0.6, 0.1],
+            [0.9, 0.5, 0.3],
+            [0.6, 0.3, 0.2],
+            [0.8, 0.7, 0.4],
+        ]),
         nl,
         nf,
         nc,
     )
 
-    cov1 = xpb.asarray(next(generator), copy=False)
-    cov1_copy = xpb.asarray(cov1, copy=True)
-    cov2 = xpb.asarray(next(generator), copy=False)
-    cov2_copy = xpb.asarray(cov2, copy=True)
+    cov1 = next(generator)
+    cov1_copy = xpb.asarray(cov1, copy=True, dtype=xpb.float64)
+    cov2 = next(generator)
+    cov2_copy = xpb.asarray(cov2, copy=True, dtype=xpb.float64)
     cov3 = next(generator)
 
-    assert cov1.shape == (nl, nc + 1)
-    assert cov2.shape == (nl, nc + 1)
-    assert cov3.shape == (nl, nc + 1)
+    assert cov1.shape[0] == nl
+    assert cov2.shape[0] == nl
+    assert cov3.shape[0] == nl
 
     assert cov1.dtype == xpb.float64
     assert cov2.dtype == xpb.float64
     assert cov3.dtype == xpb.float64
 
     # cov1|2|3 reuse the same data, so should all equal the third result
-    xpx.testing.assert_equal(cov1[:, 0], xpb.asarray([0.45, 0.25, 0.15]))
-    xpx.testing.assert_equal(cov1, cov2)
-    xpx.testing.assert_equal(cov2, cov3)
+    xpx.testing.assert_equal(cov1[:, 0], ragged.asarray([0.45, 0.25, 0.15]))
+    np.testing.assert_array_equal(cov1, cov2)
+    np.testing.assert_array_equal(cov2, cov3)
 
     # cov1 has the expected value for the first iteration (different to cov1_copy)
     xpx.testing.assert_equal(cov1_copy[:, 0], xpb.asarray([0.5, 0.25, 0.15]))
@@ -360,7 +355,7 @@ def test_effective_cls(xp: ModuleType) -> None:
 
 
 def test_generate_grf(xp: ModuleType) -> None:
-    gls: AngularPowerSpectra = [xp.asarray([1.0, 0.5, 0.1])]
+    gls: AngularPowerSpectra = ragged.array([1.0, 0.5, 0.1])
     nside = 4
     ncorr = 1
 
@@ -388,15 +383,15 @@ def test_generate_grf(xp: ModuleType) -> None:
         list(glass.fields._generate_grf([xp.asarray([])], nside))
 
 
-def test_generate_gaussian(xp: ModuleType) -> None:
+def test_generate_gaussian() -> None:
     with pytest.deprecated_call():
-        result = glass.generate_gaussian([xp.asarray([1.0, 0.5, 0.1])], 4)
+        result = glass.generate_gaussian(ragged.asarray([1.0, 0.5, 0.1]), 4)
     next(result)
 
 
-def test_generate_lognormal(xp: ModuleType) -> None:
+def test_generate_lognormal() -> None:
     with pytest.deprecated_call():
-        result = glass.generate_lognormal([xp.asarray([1.0, 0.5, 0.1])], 4)
+        result = glass.generate_lognormal(ragged.array([1.0, 0.5, 0.1]), 4)
     next(result)
 
 
@@ -412,7 +407,7 @@ def test_generate(xp: ModuleType) -> None:
 
     nside = 16
     npix = hp.nside2npix(nside)
-    gls: AngularPowerSpectra = [xp.ones(10), xp.ones(10), xp.ones(10)]
+    gls: AngularPowerSpectra = ragged.array([xp.ones(10), xp.ones(10), xp.ones(10)])
 
     result = list(glass.generate(fields, gls, nside=nside))
 


### PR DESCRIPTION
# Description

This is my attempt at changing a few things towards `ragged` for `cls` data. I've abandoned this attempt as there is quite a lot of involved work. Things like `xpx.testing` aren't covered, and it completely fails at the new iternom.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [ ] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
