### PR TITLE
gh-1124: Allow running glass offline

### DIFF
--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -22,9 +22,11 @@ if TYPE_CHECKING:
     from glass._types import ComplexArray, DTypeLike, FloatArray, IntArray
 
 
-HEALPY_DATAPATH = os.environ.get("HEALPY_DATAPATH")
-if HEALPY_DATAPATH is not None and not pathlib.Path(HEALPY_DATAPATH).is_dir():
-    raise ValueError(f"Healpy datapath not found at '{HEALPY_DATAPATH}'")
+def _get_healpy_datapath() -> str | None:
+    healpy_datapath = os.environ.get("HEALPY_DATAPATH")
+    if healpy_datapath is not None and not pathlib.Path(healpy_datapath).is_dir():
+        raise ValueError(f"Healpy datapath not found at '{healpy_datapath}'")
+    return healpy_datapath
 
 
 def alm2map(  # noqa: PLR0913
@@ -295,7 +297,7 @@ def map2alm(
     return xp.asarray(
         healpy.map2alm(
             inputs,
-            datapath=HEALPY_DATAPATH,
+            datapath=_get_healpy_datapath(),
             lmax=lmax,
             pol=pol,
             use_pixel_weights=use_pixel_weights,
@@ -375,7 +377,7 @@ def pixwin(
     """
     xp = _utils.default_xp() if xp is None else xp
 
-    output = healpy.pixwin(nside, datapath=HEALPY_DATAPATH, lmax=lmax, pol=pol)
+    output = healpy.pixwin(nside, datapath=_get_healpy_datapath(), lmax=lmax, pol=pol)
     return (
         tuple(xp.asarray(out, dtype=xp.float64) for out in output)
         if pol

--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import pathlib
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -18,6 +20,13 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import ComplexArray, DTypeLike, FloatArray, IntArray
+
+
+def _get_healpy_datapath() -> str:
+    healpy_datapath = os.environ.get("HEALPY_DATAPATH")
+    if healpy_datapath is None or pathlib.Path(healpy_datapath).is_dir():
+        raise ValueError(f"Healpy datapath not found at '{healpy_datapath}'")
+    return healpy_datapath
 
 
 def alm2map(  # noqa: PLR0913
@@ -274,8 +283,15 @@ def map2alm(
         if isinstance(maps, Sequence)
         else np.asarray(maps)
     )
+
     return xp.asarray(
-        healpy.map2alm(inputs, lmax=lmax, pol=pol, use_pixel_weights=use_pixel_weights),
+        healpy.map2alm(
+            inputs,
+            datapath=_get_healpy_datapath(),
+            lmax=lmax,
+            pol=pol,
+            use_pixel_weights=use_pixel_weights,
+        ),
     )
 
 
@@ -341,7 +357,7 @@ def pixwin(
     """
     xp = _utils.default_xp() if xp is None else xp
 
-    output = healpy.pixwin(nside, lmax=lmax, pol=pol)
+    output = healpy.pixwin(nside, datapath=_get_healpy_datapath(), lmax=lmax, pol=pol)
     return (
         tuple(xp.asarray(out, dtype=xp.float64) for out in output)
         if pol

--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -22,11 +22,9 @@ if TYPE_CHECKING:
     from glass._types import ComplexArray, DTypeLike, FloatArray, IntArray
 
 
-def _get_healpy_datapath() -> str | None:
-    healpy_datapath = os.environ.get("HEALPY_DATAPATH")
-    if healpy_datapath is not None and not pathlib.Path(healpy_datapath).is_dir():
-        raise ValueError(f"Healpy datapath not found at '{healpy_datapath}'")
-    return healpy_datapath
+HEALPY_DATAPATH = os.environ.get("HEALPY_DATAPATH")
+if HEALPY_DATAPATH is not None and not pathlib.Path(HEALPY_DATAPATH).is_dir():
+    raise ValueError(f"Healpy datapath not found at '{HEALPY_DATAPATH}'")
 
 
 def alm2map(  # noqa: PLR0913
@@ -297,7 +295,7 @@ def map2alm(
     return xp.asarray(
         healpy.map2alm(
             inputs,
-            datapath=_get_healpy_datapath(),
+            datapath=HEALPY_DATAPATH,
             lmax=lmax,
             pol=pol,
             use_pixel_weights=use_pixel_weights,
@@ -377,7 +375,7 @@ def pixwin(
     """
     xp = _utils.default_xp() if xp is None else xp
 
-    output = healpy.pixwin(nside, datapath=_get_healpy_datapath(), lmax=lmax, pol=pol)
+    output = healpy.pixwin(nside, datapath=HEALPY_DATAPATH, lmax=lmax, pol=pol)
     return (
         tuple(xp.asarray(out, dtype=xp.float64) for out in output)
         if pol

--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
     from glass._types import ComplexArray, DTypeLike, FloatArray, IntArray
 
 
-def _get_healpy_datapath() -> str:
+def _get_healpy_datapath() -> str | None:
     healpy_datapath = os.environ.get("HEALPY_DATAPATH")
-    if healpy_datapath is None or pathlib.Path(healpy_datapath).is_dir():
+    if healpy_datapath is not None and not pathlib.Path(healpy_datapath).is_dir():
         raise ValueError(f"Healpy datapath not found at '{healpy_datapath}'")
     return healpy_datapath
 
@@ -262,7 +262,8 @@ def map2alm(
         cd healpy-data
         bash download_weights_8192.sh
 
-    and set datapath to the root of the repository.
+    and set datapath to the root of the repository. If this method is used, the only
+    supported values of nside are 2^n for n in the range 5-13.
 
     Parameters
     ----------
@@ -355,7 +356,8 @@ def pixwin(
         cd healpy-data
         bash download_weights_8192.sh
 
-    and set datapath to the root of the repository.
+    and set datapath to the root of the repository. If this method is used, the only
+    supported values of nside are 2^n for n in the range 5-13.
 
     Parameters
     ----------

--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -255,6 +255,15 @@ def map2alm(
     """
     Computes the alm of a HEALPix map. The input maps must all be in ring ordering.
 
+    If you are running in an offline environment, you must provide a datapath to local
+    healpy datafiles. To download these files:
+
+        git clone --depth 1 https://github.com/healpy/healpy-data
+        cd healpy-data
+        bash download_weights_8192.sh
+
+    and set datapath to the root of the repository.
+
     Parameters
     ----------
     maps
@@ -338,6 +347,15 @@ def pixwin(
 ) -> FloatArray | tuple[FloatArray, ...]:
     """
     Return the pixel window function for the given nside.
+
+    If you are running in an offline environment, you must provide a datapath to local
+    healpy datafiles. To download these files:
+
+        git clone --depth 1 https://github.com/healpy/healpy-data
+        cd healpy-data
+        bash download_weights_8192.sh
+
+    and set datapath to the root of the repository.
 
     Parameters
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,5 @@ pytest_plugins = [
     "fixtures.domain",
     "fixtures.generators",
     "fixtures.helper_classes",
+    "fixtures.healpy_data",
 ]

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -202,6 +202,7 @@ def test_map2alm_with_pulled_data(
     pol: bool,  # noqa: FBT001
     urng: UnifiedGenerator,
 ) -> None:
+    """Tests running map2alm offline works as expected."""
     kappa = urng.normal(size=12_288)  # nside=32
     result = hp.map2alm(
         kappa,
@@ -210,6 +211,26 @@ def test_map2alm_with_pulled_data(
         use_pixel_weights=True,
     )
     assert result.shape == expected_shape
+
+
+@pytest.mark.parametrize("pol", [False, True])
+def test_map2alm_with_pulled_data_wrong_path(
+    invalid_healpy_datapath: str,
+    healpix_inputs: type[HealpixInputs],
+    pol: bool,  # noqa: FBT001
+    urng: UnifiedGenerator,
+) -> None:
+    """Tests running map2alm offline incorrectly doesn't fallback to a HTTP request."""
+    kappa = urng.normal(size=12_288)  # nside=32
+    with pytest.raises(
+        ValueError, match=f"Healpy datapath not found at '{invalid_healpy_datapath}"
+    ):
+        hp.map2alm(
+            kappa,
+            lmax=healpix_inputs.lmax,
+            pol=pol,
+            use_pixel_weights=True,
+        )
 
 
 @pytest.mark.parametrize("pol", [True, False])
@@ -304,16 +325,33 @@ def test_pixwin(
         xpx.testing.assert_equal(xp.asarray(old[i], dtype=xp.float64), new[i])
 
 
-@pytest.mark.parametrize(("pol", "expected_shape"), [(False, (12,)), (True, (2, 12))])
+@pytest.mark.parametrize("pol", [False, True])
 def test_pixwin_with_pulled_data(
     add_healpy_datapath_to_env: pytest.FixtureDef,  # noqa: ARG001
-    expected_shape: tuple[int],
     healpix_inputs: type[HealpixInputs],
     pol: bool,  # noqa: FBT001
     xp: ModuleType,
 ) -> None:
+    """Tests running pixwin offline works as expected."""
     result = hp.pixwin(healpix_inputs.nside, lmax=healpix_inputs.lmax, pol=pol, xp=xp)
-    assert xp.asarray(result).shape == expected_shape
+    if pol:
+        assert xp.stack(result).shape == (2, 12)
+    else:
+        assert xp.asarray(result).shape == (12,)
+
+
+@pytest.mark.parametrize("pol", [False, True])
+def test_pixwin_with_pulled_data_wrong_path(
+    invalid_healpy_datapath: str,
+    healpix_inputs: type[HealpixInputs],
+    pol: bool,  # noqa: FBT001
+    xp: ModuleType,
+) -> None:
+    """Tests running pixwin offline incorrectly doesn't fallback to a HTTP request."""
+    with pytest.raises(
+        ValueError, match=f"Healpy datapath not found at '{invalid_healpy_datapath}"
+    ):
+        hp.pixwin(healpix_inputs.nside, lmax=healpix_inputs.lmax, pol=pol, xp=xp)
 
 
 @pytest.mark.parametrize("thetas", [((20, 80)), ((30, 90))])

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -190,22 +190,19 @@ def test_get_nside(
 
 
 @pytest.mark.parametrize(
-    "pol,expected_shape",
+    ("pol", "expected_shape"),
     [
-        (
-            False,
-            (78,)
-        ),
-    ]
+        (False, (78,)),
+    ],
 )
 def test_map2alm_with_pulled_data(
-    add_healpy_datapath_to_env: pytest.FixtureDef,
+    add_healpy_datapath_to_env: pytest.FixtureDef,  # noqa: ARG001
     expected_shape: tuple[int],
     healpix_inputs: type[HealpixInputs],
     pol: bool,  # noqa: FBT001
     urng: UnifiedGenerator,
-):  
-    kappa = urng.normal(size=12_288) # nside=32
+) -> None:
+    kappa = urng.normal(size=12_288)  # nside=32
     result = hp.map2alm(
         kappa,
         lmax=healpix_inputs.lmax,
@@ -307,26 +304,14 @@ def test_pixwin(
         xpx.testing.assert_equal(xp.asarray(old[i], dtype=xp.float64), new[i])
 
 
-@pytest.mark.parametrize(
-    "pol,expected_shape",
-    [
-        (
-            False,
-            (12,)
-        ),
-        (
-            True,
-            (2, 12,)
-        )
-    ]
-)
+@pytest.mark.parametrize(("pol", "expected_shape"), [(False, (12,)), (True, (2, 12))])
 def test_pixwin_with_pulled_data(
-    add_healpy_datapath_to_env: pytest.FixtureDef,
+    add_healpy_datapath_to_env: pytest.FixtureDef,  # noqa: ARG001
     expected_shape: tuple[int],
     healpix_inputs: type[HealpixInputs],
     pol: bool,  # noqa: FBT001
     xp: ModuleType,
-):  
+) -> None:
     result = hp.pixwin(healpix_inputs.nside, lmax=healpix_inputs.lmax, pol=pol, xp=xp)
     assert xp.asarray(result).shape == expected_shape
 

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -190,14 +190,33 @@ def test_get_nside(
 
 
 @pytest.mark.parametrize(
-    ("pol", "use_pixel_weights"),
+    "pol,expected_shape",
     [
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    ],
+        (
+            False,
+            (78,)
+        ),
+    ]
 )
+def test_map2alm_with_pulled_data(
+    add_healpy_datapath_to_env: pytest.FixtureDef,
+    expected_shape: tuple[int],
+    healpix_inputs: type[HealpixInputs],
+    pol: bool,  # noqa: FBT001
+    urng: UnifiedGenerator,
+):  
+    kappa = urng.normal(size=12_288) # nside=32
+    result = hp.map2alm(
+        kappa,
+        lmax=healpix_inputs.lmax,
+        pol=pol,
+        use_pixel_weights=True,
+    )
+    assert result.shape == expected_shape
+
+
+@pytest.mark.parametrize("pol", [True, False])
+@pytest.mark.parametrize("use_pixel_weights", [True, False])
 def test_map2alm_individual(
     healpix_inputs: type[HealpixInputs],
     pol: bool,  # noqa: FBT001
@@ -286,6 +305,30 @@ def test_pixwin(
     assert len(old) == len(new)
     for i in range(len(old)):
         xpx.testing.assert_equal(xp.asarray(old[i], dtype=xp.float64), new[i])
+
+
+@pytest.mark.parametrize(
+    "pol,expected_shape",
+    [
+        (
+            False,
+            (12,)
+        ),
+        (
+            True,
+            (2, 12,)
+        )
+    ]
+)
+def test_pixwin_with_pulled_data(
+    add_healpy_datapath_to_env: pytest.FixtureDef,
+    expected_shape: tuple[int],
+    healpix_inputs: type[HealpixInputs],
+    pol: bool,  # noqa: FBT001
+    xp: ModuleType,
+):  
+    result = hp.pixwin(healpix_inputs.nside, lmax=healpix_inputs.lmax, pol=pol, xp=xp)
+    assert xp.asarray(result).shape == expected_shape
 
 
 @pytest.mark.parametrize("thetas", [((20, 80)), ((30, 90))])

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -195,7 +195,8 @@ def test_map2alm_with_pulled_data(
     urng: UnifiedGenerator,
 ) -> None:
     """Tests running map2alm offline works as expected."""
-    kappa = urng.normal(size=12_288)  # nside=32
+    npix = healpy.nside2npix(32)
+    kappa = urng.normal(size=npix)
     result = hp.map2alm(
         kappa,
         lmax=healpix_inputs.lmax,
@@ -213,7 +214,8 @@ def test_map2alm_with_pulled_data_wrong_path(
     urng: UnifiedGenerator,
 ) -> None:
     """Tests running map2alm offline incorrectly doesn't fallback to a HTTP request."""
-    kappa = urng.normal(size=12_288)  # nside=32
+    npix = healpy.nside2npix(32)
+    kappa = urng.normal(size=npix)
     with pytest.raises(
         ValueError,
         match=f"Healpy datapath not found at '{invalid_healpy_datapath}",

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -223,7 +223,8 @@ def test_map2alm_with_pulled_data_wrong_path(
     """Tests running map2alm offline incorrectly doesn't fallback to a HTTP request."""
     kappa = urng.normal(size=12_288)  # nside=32
     with pytest.raises(
-        ValueError, match=f"Healpy datapath not found at '{invalid_healpy_datapath}"
+        ValueError,
+        match=f"Healpy datapath not found at '{invalid_healpy_datapath}",
     ):
         hp.map2alm(
             kappa,
@@ -349,7 +350,8 @@ def test_pixwin_with_pulled_data_wrong_path(
 ) -> None:
     """Tests running pixwin offline incorrectly doesn't fallback to a HTTP request."""
     with pytest.raises(
-        ValueError, match=f"Healpy datapath not found at '{invalid_healpy_datapath}"
+        ValueError,
+        match=f"Healpy datapath not found at '{invalid_healpy_datapath}",
     ):
         hp.pixwin(healpix_inputs.nside, lmax=healpix_inputs.lmax, pol=pol, xp=xp)
 

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -189,8 +189,8 @@ def test_get_nside(
     assert healpy.get_nside(np.asarray(kappa)) == hp.get_nside(kappa)
 
 
+@pytest.mark.usefixtures("_add_healpy_datapath_to_env")
 def test_map2alm_with_pulled_data(
-    add_healpy_datapath_to_env: pytest.FixtureDef,  # noqa: ARG001
     healpix_inputs: type[HealpixInputs],
     urng: UnifiedGenerator,
 ) -> None:
@@ -320,9 +320,9 @@ def test_pixwin(
         xpx.testing.assert_equal(xp.asarray(old[i], dtype=xp.float64), new[i])
 
 
+@pytest.mark.usefixtures("_add_healpy_datapath_to_env")
 @pytest.mark.parametrize("pol", [False, True])
 def test_pixwin_with_pulled_data(
-    add_healpy_datapath_to_env: pytest.FixtureDef,  # noqa: ARG001
     healpix_inputs: type[HealpixInputs],
     pol: bool,  # noqa: FBT001
     xp: ModuleType,

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -189,17 +189,9 @@ def test_get_nside(
     assert healpy.get_nside(np.asarray(kappa)) == hp.get_nside(kappa)
 
 
-@pytest.mark.parametrize(
-    ("pol", "expected_shape"),
-    [
-        (False, (78,)),
-    ],
-)
 def test_map2alm_with_pulled_data(
     add_healpy_datapath_to_env: pytest.FixtureDef,  # noqa: ARG001
-    expected_shape: tuple[int],
     healpix_inputs: type[HealpixInputs],
-    pol: bool,  # noqa: FBT001
     urng: UnifiedGenerator,
 ) -> None:
     """Tests running map2alm offline works as expected."""
@@ -207,10 +199,10 @@ def test_map2alm_with_pulled_data(
     result = hp.map2alm(
         kappa,
         lmax=healpix_inputs.lmax,
-        pol=pol,
+        pol=False,
         use_pixel_weights=True,
     )
-    assert result.shape == expected_shape
+    assert result.shape == (78,)
 
 
 @pytest.mark.parametrize("pol", [False, True])

--- a/tests/core/test_jax.py
+++ b/tests/core/test_jax.py
@@ -13,8 +13,6 @@ from glass import _rng  # noqa: E402
 from glass.jax import Generator  # noqa: E402
 
 if TYPE_CHECKING:
-    from types import ModuleType
-
     from glass._types import FloatArray, IntArray
 
 
@@ -74,13 +72,12 @@ def test_spawn() -> None:
 def test_random(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
-    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.random(size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert xp.asarray(rvs) == shape_output
+    assert jnp.asarray(rvs).shape == shape_output
     assert jnp.min(rvs) >= 0.0
     assert jnp.max(rvs) < 1.0
     assert isinstance(rvs, ArrayLike)
@@ -112,13 +109,12 @@ def test_normal(
     scale: float | FloatArray,
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
-    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.normal(loc=loc, scale=scale, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert xp.asarray(rvs) == shape_output
+    assert jnp.asarray(rvs).shape == shape_output
     assert isinstance(rvs, ArrayLike)
 
 
@@ -158,13 +154,12 @@ def test_normal_shape_mismatch_broadcast() -> None:
 def test_standard_normal(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
-    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.standard_normal(size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert xp.asarray(rvs) == shape_output
+    assert jnp.asarray(rvs).shape == shape_output
     assert isinstance(rvs, ArrayLike)
 
 
@@ -189,13 +184,12 @@ def test_poisson(
     lam: float | FloatArray,
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
-    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.poisson(lam=lam, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert xp.asarray(rvs) == shape_output
+    assert jnp.asarray(rvs).shape == shape_output
     assert isinstance(rvs, ArrayLike)
 
 
@@ -237,13 +231,12 @@ def test_uniform(
     high: float | FloatArray,
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
-    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.uniform(low=low, high=high, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert xp.asarray(rvs) == shape_output
+    assert jnp.asarray(rvs).shape == shape_output
     assert jnp.all(rvs >= low)
     assert jnp.all(rvs < high)
     assert isinstance(rvs, ArrayLike)

--- a/tests/core/test_jax.py
+++ b/tests/core/test_jax.py
@@ -13,6 +13,8 @@ from glass import _rng  # noqa: E402
 from glass.jax import Generator  # noqa: E402
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from glass._types import FloatArray, IntArray
 
 
@@ -72,12 +74,13 @@ def test_spawn() -> None:
 def test_random(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
+    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.random(size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert rvs.shape == shape_output
+    assert xp.asarray(rvs) == shape_output
     assert jnp.min(rvs) >= 0.0
     assert jnp.max(rvs) < 1.0
     assert isinstance(rvs, ArrayLike)
@@ -109,12 +112,13 @@ def test_normal(
     scale: float | FloatArray,
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
+    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.normal(loc=loc, scale=scale, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert rvs.shape == shape_output
+    assert xp.asarray(rvs) == shape_output
     assert isinstance(rvs, ArrayLike)
 
 
@@ -154,12 +158,13 @@ def test_normal_shape_mismatch_broadcast() -> None:
 def test_standard_normal(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
+    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.standard_normal(size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert rvs.shape == shape_output
+    assert xp.asarray(rvs) == shape_output
     assert isinstance(rvs, ArrayLike)
 
 
@@ -184,12 +189,13 @@ def test_poisson(
     lam: float | FloatArray,
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
+    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.poisson(lam=lam, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert rvs.shape == shape_output
+    assert xp.asarray(rvs) == shape_output
     assert isinstance(rvs, ArrayLike)
 
 
@@ -231,12 +237,13 @@ def test_uniform(
     high: float | FloatArray,
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
+    xp: ModuleType,
 ) -> None:
     rng = _rng.rng_dispatcher(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.uniform(low=low, high=high, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
-    assert rvs.shape == shape_output
+    assert xp.asarray(rvs) == shape_output
     assert jnp.all(rvs >= low)
     assert jnp.all(rvs < high)
     assert isinstance(rvs, ArrayLike)

--- a/tests/fixtures/healpy_data.py
+++ b/tests/fixtures/healpy_data.py
@@ -1,0 +1,55 @@
+"""Fixtures for handling healpy data within tests"""
+
+import pytest
+import subprocess
+import pathlib
+import os
+
+@pytest.fixture(scope="session")
+def healpy_datapath(request: pytest.FixtureRequest) -> str:
+    """
+    Pulls the healpy data and returns the path to the new folder.
+
+    Also performs cleanup by removing the cloned dir.
+    """
+    subprocess.run(
+        """
+        git clone --depth 1 https://github.com/healpy/healpy-data;
+        cd healpy-data;
+        bash download_weights_8192.sh;
+        """
+        ,
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    healpy_datapath = str(pathlib.Path("healpy-data").absolute())
+
+    # Define a finalizer function for teardown
+    def finalizer():
+      """Deletes the pulled healpy_datapath directory"""
+      subprocess.run(["rm","-rf",healpy_datapath])
+
+    # Register the finalizer to ensure cleanup
+    request.addfinalizer(finalizer)
+
+    return healpy_datapath
+   
+
+@pytest.fixture(scope="function")
+def add_healpy_datapath_to_env(request: pytest.FixtureRequest, healpy_datapath: str) -> None:
+    """
+    Adds the path to the healpy into the environment.
+
+    Also removes the new env var when finalising.
+    """
+    # Set path to healpy data in environment
+    os.environ["HEALPY_DATAPATH"] = healpy_datapath
+
+    # Define a finalizer function for teardown
+    def finalizer():
+      """Removes healpy_datapath from the env"""
+      os.environ.pop("HEALPY_DATAPATH")
+
+    # Register the finalizer to ensure cleanup
+    request.addfinalizer(finalizer)

--- a/tests/fixtures/healpy_data.py
+++ b/tests/fixtures/healpy_data.py
@@ -1,55 +1,57 @@
-"""Fixtures for handling healpy data within tests"""
+"""Fixtures for handling healpy data within tests."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+from typing import TYPE_CHECKING
 
 import pytest
-import subprocess
-import pathlib
-import os
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 @pytest.fixture(scope="session")
-def healpy_datapath(request: pytest.FixtureRequest) -> str:
+def healpy_datapath() -> Generator[str]:
     """
-    Pulls the healpy data and returns the path to the new folder.
+    Pull the healpy data and returns the path to the new folder.
 
     Also performs cleanup by removing the cloned dir.
     """
-    subprocess.run(
+    subprocess.run(  # noqa: S602
         """
         git clone --depth 1 https://github.com/healpy/healpy-data;
         cd healpy-data;
         bash download_weights_8192.sh;
-        """
-        ,
+        """,  # noqa: S607
         shell=True,
         check=True,
         capture_output=True,
     )
     healpy_datapath = str(pathlib.Path("healpy-data").absolute())
 
-    # Define a finalizer function for teardown
-    def finalizer():
-      """Deletes the pulled healpy_datapath directory"""
-      subprocess.run(["rm","-rf",healpy_datapath])
+    yield healpy_datapath
 
-    # Register the finalizer to ensure cleanup
-    request.addfinalizer(finalizer)
+    # Teardown
+    subprocess.run(  # noqa: S603
+        ["rm", "-rf", healpy_datapath],  # noqa: S607
+        check=True,
+    )
 
-    return healpy_datapath
-   
 
-@pytest.fixture(scope="function")
-def add_healpy_datapath_to_env(request: pytest.FixtureRequest, healpy_datapath: str) -> None:
+@pytest.fixture
+def add_healpy_datapath_to_env(healpy_datapath: str) -> Generator:
     """
-    Adds the path to the healpy into the environment.
+    Add the path to the healpy into the environment.
 
     Also removes the new env var when finalising.
     """
     # Set path to healpy data in environment
     os.environ["HEALPY_DATAPATH"] = healpy_datapath
 
-    # Define a finalizer function for teardown
-    def finalizer():
-      """Removes healpy_datapath from the env"""
-      os.environ.pop("HEALPY_DATAPATH")
+    yield
 
-    # Register the finalizer to ensure cleanup
-    request.addfinalizer(finalizer)
+    # Teardown
+    os.environ.pop("HEALPY_DATAPATH")

--- a/tests/fixtures/healpy_data.py
+++ b/tests/fixtures/healpy_data.py
@@ -44,7 +44,7 @@ def healpy_datapath() -> Generator[str]:
 @pytest.fixture
 def add_healpy_datapath_to_env(healpy_datapath: str) -> Generator:
     """
-    Add the path to the healpy into the environment.
+    Add the path to the healpy data into the environment.
 
     Also removes the new env var when finalising.
     """
@@ -52,6 +52,23 @@ def add_healpy_datapath_to_env(healpy_datapath: str) -> Generator:
     os.environ["HEALPY_DATAPATH"] = healpy_datapath
 
     yield
+
+    # Teardown
+    os.environ.pop("HEALPY_DATAPATH")
+
+
+@pytest.fixture
+def invalid_healpy_datapath() -> Generator[str]:
+    """
+    Add an invalid path to the healpy data into the environment.
+
+    Also removes the new env var when finalising.
+    """
+    # Set path to healpy data in environment
+    fake_datapath = "/does/not/exist"
+    os.environ["HEALPY_DATAPATH"] = fake_datapath
+
+    yield fake_datapath
 
     # Teardown
     os.environ.pop("HEALPY_DATAPATH")

--- a/tests/fixtures/healpy_data.py
+++ b/tests/fixtures/healpy_data.py
@@ -24,7 +24,6 @@ def healpy_datapath() -> Generator[str]:
         """
         git clone --depth 1 https://github.com/healpy/healpy-data;
         cd healpy-data;
-        bash download_weights_8192.sh;
         """,  # noqa: S607
         shell=True,
         check=True,

--- a/tests/fixtures/healpy_data.py
+++ b/tests/fixtures/healpy_data.py
@@ -41,7 +41,7 @@ def healpy_datapath() -> Generator[str]:
 
 
 @pytest.fixture
-def add_healpy_datapath_to_env(healpy_datapath: str) -> Generator:
+def _add_healpy_datapath_to_env(healpy_datapath: str) -> Generator:
     """
     Add the path to the healpy data into the environment.
 

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -110,7 +110,7 @@ def test_cls2cov(
     xpx.testing.assert_equal(cov[:, 2], xpb.asarray(0.0), check_shape=False)
 
 
-@pytest.mark.stable
+@pytest.mark.unstable
 @pytest.mark.parametrize("use_rng", [False, True])
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate_grf(  # noqa: PLR0913

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -137,10 +137,7 @@ def test_generate_grf(  # noqa: PLR0913
             rng=urngb if use_rng else None,
             ncorr=ncorr,
         )
-        return generator_consumer.consume(
-            generator,
-            valid_exception="covariance matrix is not positive definite",
-        )
+        return generator_consumer.consume(generator)
 
     gaussian_fields = benchmark(function_to_benchmark)
 

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -147,7 +147,7 @@ def test_generate_grf(  # noqa: PLR0913
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
 
-@pytest.mark.stable
+@pytest.mark.unstable
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -137,7 +137,10 @@ def test_generate_grf(  # noqa: PLR0913
             rng=urngb if use_rng else None,
             ncorr=ncorr,
         )
-        return generator_consumer.consume(generator)
+        return generator_consumer.consume(
+            generator,
+            valid_exception="covariance matrix is not positive definite",
+        )
 
     gaussian_fields = benchmark(function_to_benchmark)
 

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -110,7 +110,7 @@ def test_cls2cov(
     xpx.testing.assert_equal(cov[:, 2], xpb.asarray(0.0), check_shape=False)
 
 
-@pytest.mark.unstable
+@pytest.mark.stable
 @pytest.mark.parametrize("use_rng", [False, True])
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate_grf(  # noqa: PLR0913
@@ -147,7 +147,7 @@ def test_generate_grf(  # noqa: PLR0913
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
 
-@pytest.mark.unstable
+@pytest.mark.stable
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -59,8 +59,8 @@ def test_ellipticity_intnorm(
     xpb: ModuleType,
 ) -> None:
     """Regression test for glass.ellipticity_intnorm."""
-    array_length = 10
-    n = 1_000_000
+    array_length = 20
+    n = 100_000
     count = xpb.full(array_length, fill_value=n)
     sigma = xpb.full(array_length, fill_value=0.256)
 


### PR DESCRIPTION
# Description

Removes the requirement for glass to be ran with internet access by allowing a local path to healpy datafile to be specified through an environment variable

Fixes: #1124 

## Changelog entry

Fixed: An internet connection is no longer required to run glass.

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
