### PR TITLE
gh-1127: `broadcast_shapes` part of Array API + bump `ty`

### DIFF
--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -97,7 +97,7 @@ def broadcast_leading_axes(
         i = len(s) - n
         shapes.append(s[:i])
         trails.append(s[i:])
-    dims = xpx.broadcast_shapes(*shapes)
+    dims = xp.broadcast_shapes(*shapes)
     arrs = (
         xp.broadcast_to(xp.asarray(a), dims + t)
         for (a, _), t in zip(args, trails, strict=False)

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -102,7 +102,7 @@ def broadcast_leading_axes(
         xp.broadcast_to(xp.asarray(a), dims + t)
         for (a, _), t in zip(args, trails, strict=False)
     )
-    return (dims, *arrs)  # ty: ignore[invalid-return-type]
+    return (dims, *arrs)
 
 
 def ndinterp(  # noqa: PLR0913

--- a/glass/ext/__init__.py
+++ b/glass/ext/__init__.py
@@ -28,7 +28,7 @@ def _extend_path(path: list[str], name: str) -> list[str]:
     """
     _pkg, _, _mod = name.partition(".")
 
-    return list(  # ty: ignore[invalid-return-type]
+    return list(
         filter(
             os.path.isdir,
             (os.path.join(p, _mod) for p in pkgutil.extend_path(path, _pkg)),  # noqa: PTH118

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ doctest = [
 ]
 lint = [
     "prek",
-    "ty==0.0.35",
+    "ty==0.0.46",
 ]
 test = [
     "cosmology-api",

--- a/tests/core/test_galaxies.py
+++ b/tests/core/test_galaxies.py
@@ -134,7 +134,7 @@ def test_redshifts_from_nz(
     z = xp.linspace(0, 1, 100)
     nz = xp.stack([z * (1 - z), (z - 0.5) ** 2])
 
-    with pytest.raises(ValueError, match="Incompatible shapes for broadcasting"):
+    with pytest.raises(ValueError, match=r"shape mismatch|Incompatible shapes"):
         glass.redshifts_from_nz(count, z, nz, warn=False)
 
     with pytest.warns(UserWarning, match="when sampling galaxies"):

--- a/tests/core/test_galaxies.py
+++ b/tests/core/test_galaxies.py
@@ -134,7 +134,7 @@ def test_redshifts_from_nz(
     z = xp.linspace(0, 1, 100)
     nz = xp.stack([z * (1 - z), (z - 0.5) ** 2])
 
-    with pytest.raises(ValueError, match="shape mismatch"):
+    with pytest.raises(ValueError, match="Incompatible shapes for broadcasting"):
         glass.redshifts_from_nz(count, z, nz, warn=False)
 
     with pytest.warns(UserWarning, match="when sampling galaxies"):


### PR DESCRIPTION
# Description

Noticed from https://github.com/data-apis/array-api-extra/releases/tag/v0.11.0 that `broadcast_shapes` is part of the standard so we can remove the `xpx` call. Also bumped `ty`.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1127

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
