### PR TITLE
gh-1134: Remove unused exception check

### DIFF
--- a/tests/fixtures/helper_classes.py
+++ b/tests/fixtures/helper_classes.py
@@ -72,23 +72,9 @@ class GeneratorConsumer:
     @staticmethod
     def consume(
         generator: Generator[Any],
-        *,
-        valid_exception: str = "",
     ) -> list[Any]:
-        """
-        Generate and consume a generator returned by a given functions.
-
-        The resulting generator will be consumed an any ValueError
-        exceptions swallowed.
-
-        """
-        output: list[Any] = []
-        try:
-            # Consume in a loop, as we expect users to
-            output.extend(iter(generator))
-        except ValueError as e:
-            assert str(e) == valid_exception  # noqa: PT017
-        return output
+        """Generate and consume a generator returned by a given functions."""
+        return list(generator)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Description

Removes the check of the exception in consume as...

- This is now not used
- This likely impacts the benchmark performance.

Closes: #1134

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
