### PR TITLE
gh-1111: add redshifts_from_bins()

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -60,6 +60,7 @@ __all__ = [
     "positions_from_delta",
     "redshift_grid",
     "redshifts",
+    "redshifts_from_bins",
     "redshifts_from_nz",
     "regularized_spectra",
     "restrict",
@@ -110,6 +111,7 @@ from glass.galaxies import (
     galaxy_shear,
     gaussian_phz,
     redshifts,
+    redshifts_from_bins,
     redshifts_from_nz,
 )
 from glass.lensing import (

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -11,6 +11,7 @@ Functions
 ---------
 
 .. autofunction:: redshifts
+.. autofunction:: redshifts_from_bins
 .. autofunction:: redshifts_from_nz
 .. autofunction:: galaxy_shear
 .. autofunction:: gaussian_phz
@@ -34,14 +35,54 @@ from glass import _rng
 from glass._array_api_utils import xp_additions as uxpx
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from types import ModuleType
+    from typing import Any
 
-    from glass._types import FloatArray, UnifiedGenerator
+    from glass._types import AnyArray, FloatArray, IntArray, UnifiedGenerator
     from glass.cosmology import Cosmology
 
 
+def _draw_nz(
+    count: int | FloatArray,
+    z: FloatArray,
+    nz: FloatArray,
+    *,
+    rng: UnifiedGenerator,
+) -> FloatArray:
+    """
+    Draw redshifts from a 1D source distribution.
+
+    Parameters
+    ----------
+    count
+        Number of redshifts to sample.
+    z
+        Source distribution. Must be 1D.
+    nz
+        Source distribution. Must be 1D.
+    rng
+        Random number generator.
+
+    Returns
+    -------
+        Redshifts sampled from the given source distribution.
+
+    """
+    # compute the CDF
+    cdf = glass.arraytools.cumulative_trapezoid(nz, z)
+    cdf /= cdf[-1]
+
+    # sample redshifts and return result
+    return uxpx.interp(
+        rng.uniform(0.0, 1.0, size=count),
+        cdf,
+        z,
+    )
+
+
 def redshifts(
-    n: int | FloatArray,
+    n: int | IntArray,
     w: glass.shells.RadialWindow,
     *,
     rng: UnifiedGenerator | None = None,
@@ -68,6 +109,74 @@ def redshifts(
 
     """
     return redshifts_from_nz(n, w.za, w.wa, rng=rng, warn=False)
+
+
+def redshifts_from_bins(
+    bins: AnyArray,
+    z: FloatArray,
+    nz_dict: Mapping[Any, FloatArray],
+    *,
+    rng: UnifiedGenerator | None = None,
+) -> FloatArray:
+    """Sample redshifts for a catalogue of redshift bins.
+
+    This function samples redshifts from a catalogue of tomographic redshift
+    bin labels *bins* according to a dictionary *nz_dict* of redshift
+    distributions :math:`n(z)`.
+
+    Parameters
+    ----------
+    bins
+        Array of tomographic bin labels. Each value must correspond to a
+        key in *nz_dict*.
+    z
+        Redshift values for the distributions in *nz_dict*.
+    nz_dict
+        Dictionary of redshift distribution values for each tomographic bin
+        label.
+    rng
+        Random number generator. If not given, a default RNG is used.
+
+    Returns
+    -------
+        Random redshifts following the given redshift distribution for each
+        tomographic bin label.
+
+    """
+    # array types are not guaranteed to be hashable
+    # will have to find bin labels in nz_dict keys by equality comparison
+    # split the array into ordered lists of keys and values
+    nz_keys = list(nz_dict.keys())
+    nz_values = list(nz_dict.values())
+
+    xp = array_api_compat.array_namespace(bins, z, *nz_values, use_compat=False)
+
+    # get default RNG if not given
+    if rng is None:
+        rng = _rng.rng_dispatcher(xp=xp)
+
+    # tally the bins
+    bin_label, _, bin_index, bin_count = xp.unique_all(bins)
+
+    # sample the redshifts from each nz
+    # concatenate into runs of redshifts for each bin
+    redshifts = xp.concat([
+        _draw_nz(int(k), z, nz_values[nz_keys.index(x)], rng=rng)
+        for x, k in zip(bin_label, bin_count, strict=True)
+    ])
+
+    # argsort the runs of redshifts into their intended positions
+    # argsort 1: sort bin_index into runs of the same bin
+    bin_index = xp.argsort(bin_index)
+    # argsort 2: invert the sort
+    bin_index = xp.argsort(bin_index)
+    # apply to runs of redshifts
+    redshifts = redshifts[bin_index]
+    # runs of redshifts are now sorted according to the original bin_index
+
+    # return the sampled redshifts for each bin
+    # reshape to match input shape
+    return xp.reshape(redshifts, bins.shape)
 
 
 def redshifts_from_nz(
@@ -139,16 +248,13 @@ def redshifts_from_nz(
         nz_out_slice = nz_out[(*k, ...)] if k != () else nz_out
         z_out_slice = z_out[(*k, ...)] if k != () else z_out
 
-        # compute the CDF of each galaxy population
-        cdf = glass.arraytools.cumulative_trapezoid(nz_out_slice, z_out_slice)
-        cdf /= cdf[-1]
-
         # sample redshifts and store result
         redshifts = xpx.at(redshifts)[total : total + count_out[k]].set(
-            uxpx.interp(
-                rng.uniform(0, 1, size=int(count_out[k])),
-                cdf,
+            _draw_nz(
+                int(count_out[k]),
                 z_out_slice,
+                nz_out_slice,
+                rng=rng,
             ),
         )
         total += count_out[k]

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 
 def _draw_nz(
-    count: int | FloatArray,
+    count: int | IntArray,
     z: FloatArray,
     nz: FloatArray,
     *,

--- a/tests/core/test_galaxies.py
+++ b/tests/core/test_galaxies.py
@@ -36,6 +36,33 @@ def test_redshifts(
     assert z.shape == (10,)
 
 
+def test_redshifts_from_bins(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
+    """Test that random redshifts can be sample for pre-assigned bins."""
+    # these are the bin labels
+    # not consecutive on purpose
+    bins = xp.asarray([5, 1, 4, 2])
+
+    # redshift array for distributions
+    z = xp.asarray([0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+
+    # tomographic redshift distributions
+    # each one has support over 1 redshift grid point
+    nz_dict = {
+        1: xp.asarray([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]),
+        2: xp.asarray([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        4: xp.asarray([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
+        5: xp.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+    }
+
+    # sample redshifts and check that each is in the limited range it was given
+    zout = glass.redshifts_from_bins(bins, z, nz_dict, rng=urng)
+    xpx.testing.assert_less(xp.asarray([0.3, 0.0, 0.2, 0.1]), zout)
+    xpx.testing.assert_less(zout, xp.asarray([0.5, 0.2, 0.4, 0.3]))
+
+
 def test_redshifts_from_nz(
     urng: UnifiedGenerator,
     xp: ModuleType,

--- a/tests/regression/test_galaxies.py
+++ b/tests/regression/test_galaxies.py
@@ -35,6 +35,37 @@ def test_redshifts(
 
 
 @pytest.mark.stable
+def test_redshifts_from_bins(
+    benchmark: BenchmarkFixture,
+    urngb: UnifiedGenerator,
+    xpb: ModuleType,
+) -> None:
+    """Regression test for galaxies.redshifts_from_bins."""
+    # sample N of redshifts from K bins
+    # good values are millions of redshifts, O(10) bins
+
+    # random bins
+    bins = xpb.astype(urngb.uniform(0.0, 10.0, size=1_000_000), int)
+
+    # generate a flat redshift distribution
+    # shape does not matter for performance
+    z = xpb.linspace(0.0, 3.0, 301)
+    nz_dict = {k: xpb.ones(z.shape) for k in range(10)}
+
+    # sample redshifts (scalar)
+    redshifts = benchmark(
+        glass.redshifts_from_bins,
+        bins,
+        z,
+        nz_dict,
+        rng=urngb,
+    )
+
+    # ensure that function has run on input size
+    assert redshifts.shape == bins.shape
+
+
+@pytest.mark.stable
 def test_redshifts_from_nz(
     benchmark: BenchmarkFixture,
     urngb: UnifiedGenerator,


### PR DESCRIPTION
# Description

Add a new function `glass.redshift_from_bins()` that allows sampling redshifts from existing tomographic bin labels and redshift distributions.

Closes: #1111

## Changelog entry

Added: A new function `glass.redshifts_from_bins()` to sample redshifts from existing tomographic bin labels and redshift distributions.

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
