### PR TITLE
gh-1116: add resample_shapes()

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -62,6 +62,7 @@ __all__ = [
     "redshifts",
     "redshifts_from_nz",
     "regularized_spectra",
+    "resample_shapes",
     "restrict",
     "save_cls",
     "shear_from_convergence",
@@ -142,6 +143,7 @@ from glass.shapes import (
     ellipticity_gaussian,
     ellipticity_intnorm,
     ellipticity_ryden04,
+    resample_shapes,
     triaxial_axis_ratio,
 )
 from glass.shells import (

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -13,7 +13,7 @@ Ellipticity
 .. autofunction:: ellipticity_gaussian
 .. autofunction:: ellipticity_intnorm
 .. autofunction:: ellipticity_ryden04
-
+.. autofunction:: resample_shapes
 
 Utilities
 ---------
@@ -363,3 +363,65 @@ def ellipticity_intnorm(
         i += count_broadcasted[k]
 
     return typing.cast("ComplexArray", eps)
+
+
+def resample_shapes(
+    epsilon: ComplexArray,
+    *,
+    varg: float | None = None,
+    vargamma: float | None = None,
+    rng: UnifiedGenerator | None = None,
+) -> ComplexArray:
+    """Resample galaxy shapes with random orientations.
+
+    Return the galaxy shapes *epsilon* resampled with random orientations.
+    If *varg* or *vargamma* are provided, the ellipticities are rescaled to
+    compensate for the intrinsic variance of the reduced shear (*varg*) or
+    shear (*vargamma*). Only one of *varg* or *vargamma* can be provided.
+
+    Parameters
+    ----------
+    epsilon
+        Complex-valued array of input ellipticity.
+    varg, vargamma
+        Intrinsic variance of the reduced shear or shear field.
+    rng
+        Random number generator. If not given, a default RNG is used.
+
+    Returns
+    -------
+        Complex-valued array of resampled :term:`ellipticity` values.
+
+    """
+    if varg is not None and vargamma is not None:
+        raise ValueError("only one of varg or vargamma can be given")
+
+    xp = epsilon.__array_namespace__()
+
+    if rng is None:
+        rng = _rng.rng_dispatcher(xp=xp)
+
+    # get absolute value of epsilon
+    r = xp.hypot(xp.real(epsilon), xp.imag(epsilon))
+
+    # compensate for variance of intrinsic field if given
+    if vargamma is not None:
+        vare = xp.mean(r**2)
+        if vargamma > vare:
+            raise ValueError("vargamma too large for epsilon")
+        r *= xp.sqrt(1 - vargamma / vare)
+    elif varg is not None:
+        vare = xp.mean(r**2)
+        if varg > vare:
+            raise ValueError("varg too large for epsilon")
+        eve4 = xp.mean(r**4)
+        r *= xp.sqrt(
+            (
+                xp.sqrt(((1 - 2 * varg) * vare) ** 2 + 4 * varg * eve4 * (vare - varg))
+                - (1 - 2 * varg) * vare
+            )
+            / (2 * varg * eve4)
+        )
+
+    # assign random orientations to shapes
+    return r * xp.exp(1j * rng.uniform(0, 2 * xp.pi, size=r.shape))

--- a/tests/core/test_shapes.py
+++ b/tests/core/test_shapes.py
@@ -11,7 +11,7 @@ import glass
 if TYPE_CHECKING:
     from types import ModuleType
 
-    from glass._types import UnifiedGenerator
+    from glass._types import ComplexArray, UnifiedGenerator
 
 
 def test_triaxial_axis_ratio(
@@ -252,23 +252,30 @@ def test_ellipticity_intnorm(
         glass.ellipticity_intnorm(1, 0.71, xp=xp)
 
 
-def test_resample_shapes(
+@pytest.fixture
+def epsilon(
     urng: UnifiedGenerator,
     xp: ModuleType,
-) -> None:
-    """Test for resample_shapes() without compensation."""
-    # generate an array of random ellipticities
-    n = 1000
+) -> ComplexArray:
+    """Generate uniform random epsilon ellipticities."""
+    n = 1_000_000
     r = xp.sqrt(urng.uniform(0.0, 1.0, n))
     phi = urng.uniform(0.0, 2 * xp.pi, n)
-    epsilon = r * xp.exp(1j * phi)
+    return r * xp.exp(1j * phi)
 
+
+def test_resample_shapes(
+    epsilon: ComplexArray,
+    urng: UnifiedGenerator,
+) -> None:
+    """Test for resample_shapes() without compensation."""
     # resulting absolute values should match identically
     result = glass.resample_shapes(epsilon, rng=urng)
     xpx.testing.assert_close(abs(result), abs(epsilon), rtol=1e-10)
 
 
 def test_resample_shapes_varg(
+    epsilon: ComplexArray,
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
@@ -276,19 +283,13 @@ def test_resample_shapes_varg(
     # variance to compensate
     varg = 0.1
 
-    # generate an array of random ellipticities
-    n = 1000
-    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
-    phi = urng.uniform(0.0, 2 * xp.pi, n)
-    epsilon = r * xp.exp(1j * phi)
-
     # compute compensated result
     result = glass.resample_shapes(epsilon, varg=varg, rng=urng)
 
     # sample g with given variance
     g = urng.normal(
         scale=xp.sqrt(xp.asarray(varg / 2)),
-        size=(n, 2),
+        size=(*epsilon.shape, 2),
     ) @ xp.asarray([1, 1j])
 
     # apply g to result
@@ -303,6 +304,7 @@ def test_resample_shapes_varg(
 
 
 def test_resample_shapes_vargamma(
+    epsilon: ComplexArray,
     urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
@@ -310,19 +312,13 @@ def test_resample_shapes_vargamma(
     # variance to compensate
     vargamma = 0.1
 
-    # generate an array of random ellipticities
-    n = 1000
-    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
-    phi = urng.uniform(0.0, 2 * xp.pi, n)
-    epsilon = r * xp.exp(1j * phi)
-
     # compute compensated result
     result = glass.resample_shapes(epsilon, vargamma=vargamma, rng=urng)
 
     # sample gamma with given variance
     gamma = urng.normal(
         scale=xp.sqrt(xp.asarray(vargamma / 2)),
-        size=(n, 2),
+        size=(*epsilon.shape, 2),
     ) @ xp.asarray([1, 1j])
 
     # apply gamma to result

--- a/tests/core/test_shapes.py
+++ b/tests/core/test_shapes.py
@@ -250,3 +250,87 @@ def test_ellipticity_intnorm(
 
     with pytest.raises(ValueError, match="sigma must be between"):
         glass.ellipticity_intnorm(1, 0.71, xp=xp)
+
+
+def test_resample_shapes(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
+    """Test for resample_shapes() without compensation."""
+    # generate an array of random ellipticities
+    n = 1000
+    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
+    phi = urng.uniform(0.0, 2 * xp.pi, n)
+    epsilon = r * xp.exp(1j * phi)
+
+    # resulting absolute values should match identically
+    result = glass.resample_shapes(epsilon, rng=urng)
+    xpx.testing.assert_close(abs(result), abs(epsilon), rtol=1e-10)
+
+
+def test_resample_shapes_varg(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
+    """Test for resample_shapes() with varg compensation."""
+    # variance to compensate
+    varg = 0.1
+
+    # generate an array of random ellipticities
+    n = 1000
+    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
+    phi = urng.uniform(0.0, 2 * xp.pi, n)
+    epsilon = r * xp.exp(1j * phi)
+
+    # compute compensated result
+    result = glass.resample_shapes(epsilon, varg=varg, rng=urng)
+
+    # sample g with given variance
+    g = urng.normal(
+        scale=xp.sqrt(xp.asarray(varg / 2)),
+        size=(n, 2),
+    ) @ xp.asarray([1, 1j])
+
+    # apply g to result
+    result = (result + g) / (1 + result * xp.conj(g))
+
+    # check variance is close to input
+    xpx.testing.assert_close(
+        xp.var(xp.real(result)) + xp.var(xp.imag(result)),
+        xp.var(xp.real(epsilon)) + xp.var(xp.imag(epsilon)),
+        atol=1e-2,
+    )
+
+
+def test_resample_shapes_vargamma(
+    urng: UnifiedGenerator,
+    xp: ModuleType,
+) -> None:
+    """Test for resample_shapes() with vargamma compensation."""
+    # variance to compensate
+    vargamma = 0.1
+
+    # generate an array of random ellipticities
+    n = 1000
+    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
+    phi = urng.uniform(0.0, 2 * xp.pi, n)
+    epsilon = r * xp.exp(1j * phi)
+
+    # compute compensated result
+    result = glass.resample_shapes(epsilon, vargamma=vargamma, rng=urng)
+
+    # sample gamma with given variance
+    gamma = urng.normal(
+        scale=xp.sqrt(xp.asarray(vargamma / 2)),
+        size=(n, 2),
+    ) @ xp.asarray([1, 1j])
+
+    # apply gamma to result
+    result = result + gamma
+
+    # check variance is close to input
+    xpx.testing.assert_close(
+        xp.var(xp.real(result)) + xp.var(xp.imag(result)),
+        xp.var(xp.real(epsilon)) + xp.var(xp.imag(epsilon)),
+        atol=1e-2,
+    )

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -71,3 +71,34 @@ def test_ellipticity_intnorm(
     )
 
     assert eps.shape == (n * array_length,)
+
+
+@pytest.mark.stable
+@pytest.mark.parametrize(
+    ("varg", "vargamma"),
+    [(None, None), (0.1, None), (None, 0.1)],
+    ids=["novar", "varg", "vargamma"],
+)
+def test_resample_shapes(
+    varg: float | None,
+    vargamma: float | None,
+    benchmark: BenchmarkFixture,
+    xpb: ModuleType,
+    urngb: UnifiedGenerator,
+) -> None:
+    """Regression test for :func:`glass.resample_shapes`."""
+    n = 1_000_000
+
+    r = xpb.sqrt(urngb.uniform(0.0, 1.0, n))
+    phi = urngb.uniform(0.0, 2 * xpb.pi, n)
+    epsilon = r * xpb.exp(1j * phi)
+
+    result = benchmark(
+        glass.resample_shapes,
+        epsilon,
+        varg=varg,
+        vargamma=vargamma,
+        rng=urngb,
+    )
+
+    assert result.shape == epsilon.shape


### PR DESCRIPTION
# Description

Adds a new function `glass.resample_shapes()` that takes an array of ellipticity and randomises them. The function can optionally compensate for the intrinsic variance `varg` or `vargamma` of the (reduced) shear field (i.e., the variance of the ellipticities will be equal to the input array after applying a (reduced) shear).

Closes: #1116

## Changelog entry

Added: A new function `glass.resample_shapes()` for resampling an existing catalogue of ellipticities.

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
