### PR TITLE
gh-1144: Alias xbp and urngb to xp and urng in regression tests

### DIFF
--- a/tests/fixtures/array_backends.py
+++ b/tests/fixtures/array_backends.py
@@ -108,6 +108,34 @@ def xp(request: pytest.FixtureRequest) -> ModuleType:
 
 
 @pytest.fixture(
+    params=[
+        xp
+        for name, xp in xp_available_backends.items()
+        if name not in {"array_api_strict", "jax.numpy"}
+    ],
+    scope="session",
+)
+def xpb(request: pytest.FixtureRequest) -> ModuleType:
+    """
+    Fixture for array backend to be used in regression tests.
+
+    Access array library functions using `xpb.` in tests.
+
+    We are excluding array-api-strict and jax for two reasons
+    1. Our use of array-api-strict is not for its performance but
+       for checking our interface with array libraries. Additionally,
+       users are unlikely to use array-api-strict with glass.
+       Therefore, it is not worth regression testing with array-api-strict.
+    2. We did not previously support jax, therefore it does
+       not _yet_ make sense to regression test jax as there is
+       nothing to compare against, since jax is not supported by
+       the older versions of glass.
+
+    """
+    return request.param
+
+
+@pytest.fixture(
     params=[xp for name, xp in xp_available_backends.items() if name != "jax.numpy"],
     scope="session",
 )

--- a/tests/fixtures/array_backends.py
+++ b/tests/fixtures/array_backends.py
@@ -108,34 +108,6 @@ def xp(request: pytest.FixtureRequest) -> ModuleType:
 
 
 @pytest.fixture(
-    params=[
-        xp
-        for name, xp in xp_available_backends.items()
-        if name not in {"array_api_strict", "jax.numpy"}
-    ],
-    scope="session",
-)
-def xpb(request: pytest.FixtureRequest) -> ModuleType:
-    """
-    Fixture for array backend to be used in regression tests.
-
-    Access array library functions using `xpb.` in tests.
-
-    We are excluding array-api-strict and jax for two reasons
-    1. Our use of array-api-strict is not for its performance but
-       for checking our interface with array libraries. Additionally,
-       users are unlikely to use array-api-strict with glass.
-       Therefore, it is not worth regression testing with array-api-strict.
-    2. We did not previously support jax, therefore it does
-       not _yet_ make sense to regression test jax as there is
-       nothing to compare against, since jax is not supported by
-       the older versions of glass.
-
-    """
-    return request.param
-
-
-@pytest.fixture(
     params=[xp for name, xp in xp_available_backends.items() if name != "jax.numpy"],
     scope="session",
 )

--- a/tests/fixtures/generators.py
+++ b/tests/fixtures/generators.py
@@ -37,16 +37,3 @@ def urng(xp: ModuleType) -> UnifiedGenerator:
 
     """
     return _rng.rng_dispatcher(xp=xp)
-
-
-@pytest.fixture
-def urngb(xpb: ModuleType) -> UnifiedGenerator:
-    """
-    Fixture for a unified RNG interface to be used in regression tests.
-
-    Access the relevant RNG using `urngb.` in tests.
-
-    Must be used with the `xpb` fixture.
-
-    """
-    return _rng.rng_dispatcher(xp=xpb)

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -19,7 +19,7 @@ def xp(xpb: ModuleType) -> ModuleType:
 
 
 @pytest.fixture
-def urngb(xpb: ModuleType) -> UnifiedGenerator:
+def urng(xpb: ModuleType) -> UnifiedGenerator:
     """
     Fixture for a unified RNG interface to be used in regression tests.
 

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -4,11 +4,28 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from glass import _rng
+
 if TYPE_CHECKING:
     from types import ModuleType
+
+    from glass._types import UnifiedGenerator
 
 
 @pytest.fixture
 def xp(xpb: ModuleType) -> ModuleType:
     """Alias of Fixture for array backend to be used in regression tests."""
     return xpb
+
+
+@pytest.fixture
+def urngb(xpb: ModuleType) -> UnifiedGenerator:
+    """
+    Fixture for a unified RNG interface to be used in regression tests.
+
+    Access the relevant RNG using `urngb.` in tests.
+
+    Must be used with the `xpb` fixture.
+
+    """
+    return _rng.rng_dispatcher(xp=xpb)

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from glass import _rng
+from tests.fixtures.array_backends import xp_available_backends
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -12,20 +13,42 @@ if TYPE_CHECKING:
     from glass._types import UnifiedGenerator
 
 
-@pytest.fixture
-def xp(xpb: ModuleType) -> ModuleType:
-    """Alias of Fixture for array backend to be used in regression tests."""
-    return xpb
+@pytest.fixture(
+    params=[
+        xp
+        for name, xp in xp_available_backends.items()
+        if name not in {"array_api_strict", "jax.numpy"}
+    ],
+    scope="session",
+)
+def xp(request: pytest.FixtureRequest) -> ModuleType:
+    """
+    Fixture for array backend to be used in regression tests.
+
+    Access array library functions using `xp.` in tests.
+
+    We are excluding array-api-strict and jax for two reasons
+    1. Our use of array-api-strict is not for its performance but
+       for checking our interface with array libraries. Additionally,
+       users are unlikely to use array-api-strict with glass.
+       Therefore, it is not worth regression testing with array-api-strict.
+    2. We did not previously support jax, therefore it does
+       not _yet_ make sense to regression test jax as there is
+       nothing to compare against, since jax is not supported by
+       the older versions of glass.
+
+    """
+    return request.param
 
 
 @pytest.fixture
-def urng(xpb: ModuleType) -> UnifiedGenerator:
+def urng(xp: ModuleType) -> UnifiedGenerator:
     """
     Fixture for a unified RNG interface to be used in regression tests.
 
-    Access the relevant RNG using `urngb.` in tests.
+    Access the relevant RNG using `urng.` in tests.
 
-    Must be used with the `xpb` fixture.
+    Must be used with the `xp` fixture.
 
     """
-    return _rng.rng_dispatcher(xp=xpb)
+    return _rng.rng_dispatcher(xp=xp)

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+@pytest.fixture
+def xp(xpb: ModuleType) -> ModuleType:
+    """Alias of Fixture for array backend to be used in regression tests."""
+    return xpb

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from glass import _rng
-from tests.fixtures.array_backends import xp_available_backends
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -13,42 +12,20 @@ if TYPE_CHECKING:
     from glass._types import UnifiedGenerator
 
 
-@pytest.fixture(
-    params=[
-        xp
-        for name, xp in xp_available_backends.items()
-        if name not in {"array_api_strict", "jax.numpy"}
-    ],
-    scope="session",
-)
-def xp(request: pytest.FixtureRequest) -> ModuleType:
-    """
-    Fixture for array backend to be used in regression tests.
-
-    Access array library functions using `xp.` in tests.
-
-    We are excluding array-api-strict and jax for two reasons
-    1. Our use of array-api-strict is not for its performance but
-       for checking our interface with array libraries. Additionally,
-       users are unlikely to use array-api-strict with glass.
-       Therefore, it is not worth regression testing with array-api-strict.
-    2. We did not previously support jax, therefore it does
-       not _yet_ make sense to regression test jax as there is
-       nothing to compare against, since jax is not supported by
-       the older versions of glass.
-
-    """
-    return request.param
+@pytest.fixture
+def xp(xpb: ModuleType) -> ModuleType:
+    """Alias of Fixture for array backend to be used in regression tests."""
+    return xpb
 
 
 @pytest.fixture
-def urng(xp: ModuleType) -> UnifiedGenerator:
+def urng(xpb: ModuleType) -> UnifiedGenerator:
     """
     Fixture for a unified RNG interface to be used in regression tests.
 
-    Access the relevant RNG using `urng.` in tests.
+    Access the relevant RNG using `urngb.` in tests.
 
-    Must be used with the `xp` fixture.
+    Must be used with the `xpb` fixture.
 
     """
-    return _rng.rng_dispatcher(xp=xp)
+    return _rng.rng_dispatcher(xp=xpb)

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -23,9 +23,9 @@ def urng(xpb: ModuleType) -> UnifiedGenerator:
     """
     Fixture for a unified RNG interface to be used in regression tests.
 
-    Access the relevant RNG using `urngb.` in tests.
+    Access the relevant RNG using `urng.` in tests.
 
-    Must be used with the `xpb` fixture.
+    Must be used with the `xp` fixture.
 
     """
     return _rng.rng_dispatcher(xp=xpb)

--- a/tests/regression/test_arraytools.py
+++ b/tests/regression/test_arraytools.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
 @pytest.mark.unstable
 def test_broadcast_leading_axes(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for glass.arraytools.broadcast_leading_axes."""
     # Ensure we don't use too much memory
     a_in = 0
     b_shape = (4, 10)
     c_shape = (30, 1, 5, 6)
-    b_in = xpb.zeros(b_shape)
-    c_in = xpb.zeros(c_shape)
+    b_in = xp.zeros(b_shape)
+    c_in = xp.zeros(c_shape)
 
     dims, *rest = benchmark(
         glass.arraytools.broadcast_leading_axes,
@@ -44,20 +44,20 @@ def test_broadcast_leading_axes(
 @pytest.mark.unstable
 def test_cumulative_trapezoid_1d(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for glass.arraytools.cumulative_trapezoid."""
     scaled_length = 10_000
 
-    f = xpb.arange(scaled_length + 1)[1:]  # [1, 2, 3, 4,...]
-    x = xpb.arange(scaled_length)  # [0, 1, 2, 3,...]
+    f = xp.arange(scaled_length + 1)[1:]  # [1, 2, 3, 4,...]
+    x = xp.arange(scaled_length)  # [0, 1, 2, 3,...]
 
     ct = benchmark(glass.arraytools.cumulative_trapezoid, f, x)
 
     # Compare to int64 as old versions of glass round to int64 if `dtype` is not passed.
     xpx.testing.assert_equal(
-        xpb.asarray(ct[:4], dtype=xpb.int64),
-        xpb.asarray([0, 1, 4, 7]),
+        xp.asarray(ct[:4], dtype=xp.int64),
+        xp.asarray([0, 1, 4, 7]),
     )
     assert ct.shape == (scaled_length,)
 
@@ -65,30 +65,30 @@ def test_cumulative_trapezoid_1d(
 @pytest.mark.unstable
 def test_cumulative_trapezoid_2d(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for glass.arraytools.cumulative_trapezoid."""
     scaled_length = 5_000
 
-    f = xpb.stack(
+    f = xp.stack(
         [  # [[1, 2, 3, 4,...], [1, 2, 3, 4,...]]
-            xpb.arange(scaled_length + 1)[1:],
-            xpb.arange(scaled_length + 1)[1:],
+            xp.arange(scaled_length + 1)[1:],
+            xp.arange(scaled_length + 1)[1:],
         ],
     )
-    x = xpb.arange(scaled_length)  # [0, 1, 2, 3,...]
+    x = xp.arange(scaled_length)  # [0, 1, 2, 3,...]
 
     ct = benchmark(glass.arraytools.cumulative_trapezoid, f, x)
 
-    expected_first_4_out = xpb.asarray([0, 1, 4, 7])
+    expected_first_4_out = xp.asarray([0, 1, 4, 7])
 
     # Compare to int64 as old versions of glass round to int64 if `dtype` is not passed.
     xpx.testing.assert_equal(
-        xpb.asarray(ct[0, :4], dtype=xpb.int64),
+        xp.asarray(ct[0, :4], dtype=xp.int64),
         expected_first_4_out,
     )
     xpx.testing.assert_equal(
-        xpb.asarray(ct[1, :4], dtype=xpb.int64),
+        xp.asarray(ct[1, :4], dtype=xp.int64),
         expected_first_4_out,
     )
 

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -25,10 +25,10 @@ if TYPE_CHECKING:
 def test_iternorm_no_size(
     benchmark: BenchmarkFixture,
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for glass.iternorm with k=2."""
-    array_in = [xpb.asarray([1.0, 0.5, 0.1])] * 10_000
+    array_in = [xp.asarray([1.0, 0.5, 0.1])] * 10_000
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(array_in)
@@ -44,14 +44,14 @@ def test_iternorm_no_size(
 def test_iternorm_specify_size(
     benchmark: BenchmarkFixture,
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
     num_dimensions: int,
 ) -> None:
     """Regression tests for glass.iternorm with k=2 and size=(3,)."""
     if num_dimensions == 1:
-        array_in = [xpb.asarray([1.0, 0.5, 0.1])] * 10_000
+        array_in = [xp.asarray([1.0, 0.5, 0.1])] * 10_000
     elif num_dimensions == 2:
-        array_in = [xpb.asarray([[1.0, 0.5, 0.1]] * 3)] * 10_000
+        array_in = [xp.asarray([[1.0, 0.5, 0.1]] * 3)] * 10_000
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(array_in)
@@ -66,10 +66,10 @@ def test_iternorm_specify_size(
 def test_iternorm_k_0(
     benchmark: BenchmarkFixture,
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests glass.iternorm with k set to 0."""
-    array_in = [xpb.asarray([x]) for x in xpb.ones(1_000, dtype=xpb.float64)]
+    array_in = [xp.asarray([x]) for x in xp.ones(1_000, dtype=xp.float64)]
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.iternorm(array_in)
@@ -84,11 +84,11 @@ def test_iternorm_k_0(
 def test_cls2cov(
     benchmark: BenchmarkFixture,
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for glass.cls2cov."""
     nl, nf, nc = 3, 2, 2
-    array_in = [xpb.arange(i + 1.0, i + 4.0) for i in range(1_000)]
+    array_in = [xp.arange(i + 1.0, i + 4.0) for i in range(1_000)]
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.cls2cov(
@@ -103,11 +103,11 @@ def test_cls2cov(
     cov = covs[0]
 
     assert cov.shape == (nl, nc + 1)
-    assert cov.dtype == xpb.float64
+    assert cov.dtype == xp.float64
 
-    xpx.testing.assert_equal(cov[:, 0], xpb.asarray([1.0, 1.5, 2.0]))
-    xpx.testing.assert_equal(cov[:, 1], xpb.asarray([1.5, 2.0, 2.5]))
-    xpx.testing.assert_equal(cov[:, 2], xpb.asarray(0.0), check_shape=False)
+    xpx.testing.assert_equal(cov[:, 0], xp.asarray([1.0, 1.5, 2.0]))
+    xpx.testing.assert_equal(cov[:, 1], xp.asarray([1.5, 2.0, 2.5]))
+    xpx.testing.assert_equal(cov[:, 2], xp.asarray(0.0), check_shape=False)
 
 
 @pytest.mark.stable
@@ -119,12 +119,12 @@ def test_generate_grf(  # noqa: PLR0913
     ncorr: int | None,
     urngb: UnifiedGenerator,
     use_rng: bool,  # noqa: FBT001
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests of glass.fields._generate_grf with positional arguments only."""
     n = 10
     gls: AngularPowerSpectra = [
-        xpb.ones(n) if i == j else xpb.zeros(n)
+        xp.ones(n) if i == j else xp.zeros(n)
         for i in range(n)
         for j in range(i, -1, -1)
     ]
@@ -149,7 +149,7 @@ def test_generate_grf(  # noqa: PLR0913
 def test_generate(
     benchmark: BenchmarkFixture,
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
     ncorr: int | None,
 ) -> None:
     """Regression tests for glass.generate."""
@@ -157,7 +157,7 @@ def test_generate(
     fields = [lambda x, var: x for _ in range(n)]  # noqa: ARG005
     fields[1] = lambda x, var: x**2  # noqa: ARG005
     gls: AngularPowerSpectra = [
-        xpb.ones(n) if i == j else xpb.zeros(n)
+        xp.ones(n) if i == j else xp.zeros(n)
         for i in range(n)
         for j in range(i, -1, -1)
     ]
@@ -181,13 +181,13 @@ def test_generate(
 @pytest.mark.unstable
 def test_getcl_lmax_0(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for glass.getcl with lmax of 0."""
     scale_factor = 1_000
     # make a mock Cls array with the index pairs as entries
     cls: AngularPowerSpectra = [
-        xpb.asarray([i, j], dtype=xpb.float64)
+        xp.asarray([i, j], dtype=xp.float64)
         for i in range(scale_factor)
         for j in range(i, -1, -1)
     ]
@@ -203,7 +203,7 @@ def test_getcl_lmax_0(
         random_j,
         lmax=0,
     )
-    expected = xpb.asarray([max(random_i, random_j)], dtype=xpb.float64)
+    expected = xp.asarray([max(random_i, random_j)], dtype=xp.float64)
     assert result.shape[0] == 1
     xpx.testing.assert_equal(result, expected)
 
@@ -211,13 +211,13 @@ def test_getcl_lmax_0(
 @pytest.mark.unstable
 def test_getcl_lmax_larger_than_cls(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for glass.getcl with lmax larger than the length of cl."""
     scale_factor = 1_000
     # make a mock Cls array with the index pairs as entries
     cls: AngularPowerSpectra = [
-        xpb.asarray([i, j], dtype=xpb.float64)
+        xp.asarray([i, j], dtype=xp.float64)
         for i in range(scale_factor)
         for j in range(i, -1, -1)
     ]
@@ -234,6 +234,6 @@ def test_getcl_lmax_larger_than_cls(
         random_j,
         lmax=lmax,
     )
-    expected = xpb.zeros((lmax - 1,), dtype=xpb.float64)
+    expected = xp.zeros((lmax - 1,), dtype=xp.float64)
     assert result.shape[0] == lmax + 1
     xpx.testing.assert_equal(result[2:], expected)

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -117,7 +117,7 @@ def test_generate_grf(  # noqa: PLR0913
     benchmark: BenchmarkFixture,
     generator_consumer: type[GeneratorConsumer],
     ncorr: int | None,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     use_rng: bool,  # noqa: FBT001
     xp: ModuleType,
 ) -> None:
@@ -134,7 +134,7 @@ def test_generate_grf(  # noqa: PLR0913
         generator = glass.fields._generate_grf(
             gls,
             nside,
-            rng=urngb if use_rng else None,
+            rng=urng if use_rng else None,
             ncorr=ncorr,
         )
         return generator_consumer.consume(generator)

--- a/tests/regression/test_galaxies.py
+++ b/tests/regression/test_galaxies.py
@@ -37,20 +37,20 @@ def test_redshifts(
 @pytest.mark.stable
 def test_redshifts_from_bins(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
-    xpb: ModuleType,
+    urng: UnifiedGenerator,
+    xp: ModuleType,
 ) -> None:
     """Regression test for galaxies.redshifts_from_bins."""
     # sample N of redshifts from K bins
     # good values are millions of redshifts, O(10) bins
 
     # random bins
-    bins = xpb.astype(urngb.uniform(0.0, 10.0, size=1_000_000), int)
+    bins = xp.astype(urng.uniform(0.0, 10.0, size=1_000_000), int)
 
     # generate a flat redshift distribution
     # shape does not matter for performance
-    z = xpb.linspace(0.0, 3.0, 301)
-    nz_dict = {k: xpb.ones(z.shape) for k in range(10)}
+    z = xp.linspace(0.0, 3.0, 301)
+    nz_dict = {k: xp.ones(z.shape) for k in range(10)}
 
     # sample redshifts (scalar)
     redshifts = benchmark(
@@ -58,7 +58,7 @@ def test_redshifts_from_bins(
         bins,
         z,
         nz_dict,
-        rng=urngb,
+        rng=urng,
     )
 
     # ensure that function has run on input size

--- a/tests/regression/test_galaxies.py
+++ b/tests/regression/test_galaxies.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 @pytest.mark.stable
 def test_redshifts(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
     """Regression test for galaxies.redshifts."""
@@ -28,7 +28,7 @@ def test_redshifts(
     w = glass.RadialWindow(za, wa)
 
     # sample redshifts (scalar)
-    z = benchmark(glass.redshifts, 13 * scale_factor, w, rng=urngb)
+    z = benchmark(glass.redshifts, 13 * scale_factor, w, rng=urng)
     assert z.shape == (13 * scale_factor,)
     assert xp.min(z) >= 0.0
     assert xp.max(z) <= 1.0
@@ -68,7 +68,7 @@ def test_redshifts_from_bins(
 @pytest.mark.stable
 def test_redshifts_from_nz(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
     """Regression test for galaxies.redshifts_from_nz."""
@@ -83,7 +83,7 @@ def test_redshifts_from_nz(
         13 * scale_factor,
         za,
         wa,
-        rng=urngb,
+        rng=urng,
         warn=False,
     )
     assert redshifts.shape == (13 * scale_factor,)
@@ -96,20 +96,20 @@ def test_redshifts_from_nz(
 @pytest.mark.parametrize("reduced_shear", [True, False])
 def test_galaxy_shear(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     reduced_shear: bool,  # noqa: FBT001
 ) -> None:
     """Regression test for galaxies.galaxy_shear."""
     scale_factor = 100
     size = (12 * scale_factor,)
-    kappa = urngb.normal(size=size)
-    gamma1 = urngb.normal(size=size)
-    gamma2 = urngb.normal(size=size)
+    kappa = urng.normal(size=size)
+    gamma1 = urng.normal(size=size)
+    gamma2 = urng.normal(size=size)
 
     gal_size = (512 * scale_factor,)
-    gal_lon = urngb.normal(size=gal_size)
-    gal_lat = urngb.normal(size=gal_size)
-    gal_eps = urngb.normal(size=gal_size)
+    gal_lon = urng.normal(size=gal_size)
+    gal_lat = urng.normal(size=gal_size)
+    gal_eps = urng.normal(size=gal_size)
 
     shear = benchmark(
         glass.galaxy_shear,
@@ -127,7 +127,7 @@ def test_galaxy_shear(
 @pytest.mark.stable
 def test_gaussian_phz(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
     """Regression tests for galaxies.gaussian_phz."""
@@ -142,7 +142,7 @@ def test_gaussian_phz(
         sigma_0,
         lower=0.5,
         upper=1.5,
-        rng=urngb,
+        rng=urng,
     )
 
     assert phz.shape == (scaled_length,)

--- a/tests/regression/test_galaxies.py
+++ b/tests/regression/test_galaxies.py
@@ -18,20 +18,20 @@ if TYPE_CHECKING:
 def test_redshifts(
     benchmark: BenchmarkFixture,
     urngb: UnifiedGenerator,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for galaxies.redshifts."""
     scale_factor = 1_000
     # create a mock radial window function
-    za = xpb.linspace(0.0, 1.0, 20 * scale_factor)
-    wa = xpb.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
+    za = xp.linspace(0.0, 1.0, 20 * scale_factor)
+    wa = xp.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
     w = glass.RadialWindow(za, wa)
 
     # sample redshifts (scalar)
     z = benchmark(glass.redshifts, 13 * scale_factor, w, rng=urngb)
     assert z.shape == (13 * scale_factor,)
-    assert xpb.min(z) >= 0.0
-    assert xpb.max(z) <= 1.0
+    assert xp.min(z) >= 0.0
+    assert xp.max(z) <= 1.0
 
 
 @pytest.mark.stable
@@ -69,13 +69,13 @@ def test_redshifts_from_bins(
 def test_redshifts_from_nz(
     benchmark: BenchmarkFixture,
     urngb: UnifiedGenerator,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for galaxies.redshifts_from_nz."""
     scale_factor = 1_000
     # create a mock radial window function
-    za = xpb.linspace(0.0, 1.0, 20 * scale_factor)
-    wa = xpb.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
+    za = xp.linspace(0.0, 1.0, 20 * scale_factor)
+    wa = xp.exp(-0.5 * (za - 0.5) ** 2 / 0.1**2)
 
     # sample redshifts (scalar)
     redshifts = benchmark(
@@ -87,9 +87,9 @@ def test_redshifts_from_nz(
         warn=False,
     )
     assert redshifts.shape == (13 * scale_factor,)
-    assert xpb.min(redshifts) >= 0.0
-    assert xpb.max(redshifts) <= 1.0
-    assert xpb.all((redshifts >= 0) & (redshifts <= 1))
+    assert xp.min(redshifts) >= 0.0
+    assert xp.max(redshifts) <= 1.0
+    assert xp.all((redshifts >= 0) & (redshifts <= 1))
 
 
 @pytest.mark.unstable
@@ -128,13 +128,13 @@ def test_galaxy_shear(
 def test_gaussian_phz(
     benchmark: BenchmarkFixture,
     urngb: UnifiedGenerator,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for galaxies.gaussian_phz."""
     scaled_length = 10_000
 
-    z = xpb.linspace(0, 1, scaled_length)
-    sigma_0 = xpb.ones(scaled_length)
+    z = xp.linspace(0, 1, scaled_length)
+    sigma_0 = xp.ones(scaled_length)
 
     phz = benchmark(
         glass.gaussian_phz,
@@ -146,5 +146,5 @@ def test_gaussian_phz(
     )
 
     assert phz.shape == (scaled_length,)
-    assert xpb.all(phz >= 0.5)
-    assert xpb.all(phz <= 1.5)
+    assert xp.all(phz >= 0.5)
+    assert xp.all(phz <= 1.5)

--- a/tests/regression/test_harmonics.py
+++ b/tests/regression/test_harmonics.py
@@ -21,17 +21,17 @@ if TYPE_CHECKING:
 @pytest.mark.unstable
 def test_multalm(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for glass.harmonics.multalm."""
     scale_factor = 100_000
 
-    alm = xpb.arange(scale_factor * 5, dtype=xpb.float64)
-    bl = xpb.asarray(scale_factor * 3, dtype=xpb.float64)
+    alm = xp.arange(scale_factor * 5, dtype=xp.float64)
+    bl = xp.asarray(scale_factor * 3, dtype=xp.float64)
 
     result = benchmark(glass_harmonics.multalm, alm, bl)
 
     xpx.testing.assert_equal(
         result[:5],
-        xpb.asarray([scale_factor * x for x in [0.0, 3.0, 6.0, 9.0, 12.0]]),
+        xp.asarray([scale_factor * x for x in [0.0, 3.0, 6.0, 9.0, 12.0]]),
     )

--- a/tests/regression/test_lensing.py
+++ b/tests/regression/test_lensing.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def test_multi_plane_matrix(
     benchmark: BenchmarkFixture,
     cosmo: Cosmology,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
     """Regression tests for add_window and add_plane with a multi_plane_matrix."""
@@ -36,7 +36,7 @@ def test_multi_plane_matrix(
         for i in range(1_000)
     ]
     mat = glass.multi_plane_matrix(shells, cosmo)
-    deltas = urngb.random((len(shells), 10))
+    deltas = urng.random((len(shells), 10))
 
     xpx.testing.assert_equal(mat, xp.tril(mat))
     xpx.testing.assert_equal(xp.triu(mat, k=1), xp.asarray(0.0), check_shape=False)
@@ -80,7 +80,7 @@ def test_multi_plane_matrix(
 def test_multi_plane_weights(
     benchmark: BenchmarkFixture,
     cosmo: Cosmology,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
     xp: ModuleType,
 ) -> None:
     """Regression tests for add_window and add_plane with a multi_plane_weights."""
@@ -94,8 +94,8 @@ def test_multi_plane_weights(
         for i in range(500)
     ]
     w_in = xp.eye(len(shells))
-    deltas = urngb.random((len(shells), 10))
-    weights = urngb.random((len(shells), 3))
+    deltas = urng.random((len(shells), 10))
+    weights = urng.random((len(shells), 3))
 
     w_out = glass.multi_plane_weights(w_in, shells, cosmo)
 

--- a/tests/regression/test_lensing.py
+++ b/tests/regression/test_lensing.py
@@ -23,14 +23,14 @@ def test_multi_plane_matrix(
     benchmark: BenchmarkFixture,
     cosmo: Cosmology,
     urngb: UnifiedGenerator,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for add_window and add_plane with a multi_plane_matrix."""
     # Use this over the fixture to allow us to add many more windows
     shells = [
         glass.RadialWindow(
-            xpb.arange(i, i + 3, dtype=xpb.float64),
-            xpb.asarray([0.0, 1.0, 0.0]),
+            xp.arange(i, i + 3, dtype=xp.float64),
+            xp.asarray([0.0, 1.0, 0.0]),
             float(i + 1),
         )
         for i in range(1_000)
@@ -38,8 +38,8 @@ def test_multi_plane_matrix(
     mat = glass.multi_plane_matrix(shells, cosmo)
     deltas = urngb.random((len(shells), 10))
 
-    xpx.testing.assert_equal(mat, xpb.tril(mat))
-    xpx.testing.assert_equal(xpb.triu(mat, k=1), xpb.asarray(0.0), check_shape=False)
+    xpx.testing.assert_equal(mat, xp.tril(mat))
+    xpx.testing.assert_equal(xp.triu(mat, k=1), xp.asarray(0.0), check_shape=False)
 
     def setup_shells_and_deltas() -> tuple[
         tuple[
@@ -81,26 +81,26 @@ def test_multi_plane_weights(
     benchmark: BenchmarkFixture,
     cosmo: Cosmology,
     urngb: UnifiedGenerator,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for add_window and add_plane with a multi_plane_weights."""
     # Use this over the fixture to allow us to add many more windows
     shells = [
         glass.RadialWindow(
-            xpb.arange(i, i + 3, dtype=xpb.float64),
-            xpb.asarray([0.0, 1.0, 0.0]),
+            xp.arange(i, i + 3, dtype=xp.float64),
+            xp.asarray([0.0, 1.0, 0.0]),
             float(i + 1),
         )
         for i in range(500)
     ]
-    w_in = xpb.eye(len(shells))
+    w_in = xp.eye(len(shells))
     deltas = urngb.random((len(shells), 10))
     weights = urngb.random((len(shells), 3))
 
     w_out = glass.multi_plane_weights(w_in, shells, cosmo)
 
-    xpx.testing.assert_equal(w_out, xpb.triu(w_out, 1))
-    xpx.testing.assert_equal(xpb.tril(w_out), xpb.asarray(0.0), check_shape=False)
+    xpx.testing.assert_equal(w_out, xp.triu(w_out, 1))
+    xpx.testing.assert_equal(xp.tril(w_out), xp.asarray(0.0), check_shape=False)
 
     def setup_shells_deltas_and_weights() -> tuple[
         tuple[

--- a/tests/regression/test_points.py
+++ b/tests/regression/test_points.py
@@ -34,7 +34,7 @@ def test_positions_from_delta(  # noqa: PLR0913
     benchmark: BenchmarkFixture,
     data_transformer: type[DataTransformer],
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
     bias: float,
     bias_model: Callable[[int], int],
     remove_monopole: bool,  # noqa: FBT001
@@ -43,9 +43,9 @@ def test_positions_from_delta(  # noqa: PLR0913
     nside = 48
     npix = 12 * nside * nside
 
-    ngal = xpb.asarray([i * 1e-3 for i in range(10)])
-    delta = xpb.zeros((9, 1, npix))
-    vis = xpb.ones(npix)
+    ngal = xp.asarray([i * 1e-3 for i in range(10)])
+    delta = xp.zeros((9, 1, npix))
+    vis = xp.ones(npix)
 
     def function_to_benchmark() -> list[Any]:
         generator = glass.positions_from_delta(
@@ -60,12 +60,12 @@ def test_positions_from_delta(  # noqa: PLR0913
 
     pos = benchmark(function_to_benchmark)
 
-    lon, lat, count = data_transformer.catpos(pos, xp=xpb)
+    lon, lat, count = data_transformer.catpos(pos, xp=xp)
 
-    assert isinstance(count, xpb.ndarray)
+    assert isinstance(count, xp.ndarray)
     assert count.shape == (9, 10)
-    assert lon.shape == (xpb.sum(count),)
-    assert lat.shape == (xpb.sum(count),)
+    assert lon.shape == (xp.sum(count),)
+    assert lat.shape == (xp.sum(count),)
 
 
 @pytest.mark.stable
@@ -73,15 +73,15 @@ def test_uniform_positions(
     benchmark: BenchmarkFixture,
     data_transformer: type[DataTransformer],
     generator_consumer: type[GeneratorConsumer],
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression tests for glass.uniform_positionsuniform_positions."""
     scaling_factor = 12
     shape_ngal = (int(scaling_factor / 2), 2)
 
-    ngal = xpb.asarray([[1e-3, 2e-3], [3e-3, 4e-3], [5e-3, 6e-3]])
-    ngal = xpb.reshape(
-        xpb.arange(1e-3, 1e-3 * scaling_factor + 1e-3, 1e-3),
+    ngal = xp.asarray([[1e-3, 2e-3], [3e-3, 4e-3], [5e-3, 6e-3]])
+    ngal = xp.reshape(
+        xp.arange(1e-3, 1e-3 * scaling_factor + 1e-3, 1e-3),
         shape=shape_ngal,
     )
 
@@ -91,10 +91,10 @@ def test_uniform_positions(
 
     pos = benchmark(function_to_benchmark)
 
-    lon, lat, count = data_transformer.catpos(pos, xp=xpb)
-    assert count.__array_namespace__() == xpb
+    lon, lat, count = data_transformer.catpos(pos, xp=xp)
+    assert count.__array_namespace__() == xp
     assert count.shape == shape_ngal
-    assert lon.shape == lat.shape == (xpb.sum(count),)
+    assert lon.shape == lat.shape == (xp.sum(count),)
 
 
 @pytest.mark.parametrize(
@@ -112,7 +112,7 @@ def test_uniform_positions(
 )
 def test_displace(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
     r_to_alpha: Callable[[float], complex | list[float]],
 ) -> None:
     """Regression test for glass.displace with complex values."""
@@ -122,9 +122,9 @@ def test_displace(
     r = d / 180 * math.pi
 
     # displace the origin so everything is easy
-    lon0 = xpb.asarray(xpb.zeros(scale_length, dtype=xpb.float64))
-    lat0 = xpb.asarray(xpb.zeros(scale_length, dtype=xpb.float64))
-    alpha = xpb.asarray(r_to_alpha(r))
+    lon0 = xp.asarray(xp.zeros(scale_length, dtype=xp.float64))
+    lat0 = xp.asarray(xp.zeros(scale_length, dtype=xp.float64))
+    alpha = xp.asarray(r_to_alpha(r))
 
     lon, lat = benchmark(
         glass.displace,

--- a/tests/regression/test_points.py
+++ b/tests/regression/test_points.py
@@ -143,16 +143,16 @@ def test_displace(
 )
 def test_displacement(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
 ) -> None:
     """Regression test for glass.displacement."""
     scale_factor = 100
 
     # test on an array
-    from_lon = urngb.uniform(-180.0, 180.0, size=(20 * scale_factor, 1))
-    from_lat = urngb.uniform(-90.0, 90.0, size=(20 * scale_factor, 1))
-    to_lon = urngb.uniform(-180.0, 180.0, size=5 * scale_factor)
-    to_lat = urngb.uniform(-90.0, 90.0, size=5 * scale_factor)
+    from_lon = urng.uniform(-180.0, 180.0, size=(20 * scale_factor, 1))
+    from_lat = urng.uniform(-90.0, 90.0, size=(20 * scale_factor, 1))
+    to_lon = urng.uniform(-180.0, 180.0, size=5 * scale_factor)
+    to_lat = urng.uniform(-90.0, 90.0, size=5 * scale_factor)
     alpha = benchmark(
         glass.displacement,
         from_lon,

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -83,22 +83,22 @@ def test_resample_shapes(
     varg: float | None,
     vargamma: float | None,
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
-    urngb: UnifiedGenerator,
+    xp: ModuleType,
+    urng: UnifiedGenerator,
 ) -> None:
     """Regression test for :func:`glass.resample_shapes`."""
     n = 1_000_000
 
-    r = xpb.sqrt(urngb.uniform(0.0, 1.0, n))
-    phi = urngb.uniform(0.0, 2 * xpb.pi, n)
-    epsilon = r * xpb.exp(1j * phi)
+    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
+    phi = urng.uniform(0.0, 2 * xp.pi, n)
+    epsilon = r * xp.exp(1j * phi)
 
     result = benchmark(
         glass.resample_shapes,
         epsilon,
         varg=varg,
         vargamma=vargamma,
-        rng=urngb,
+        rng=urng,
     )
 
     assert result.shape == epsilon.shape

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -17,17 +17,17 @@ if TYPE_CHECKING:
 @pytest.mark.stable
 def test_ellipticity_ryden04(
     benchmark: BenchmarkFixture,
-    urngb: UnifiedGenerator,
+    urng: UnifiedGenerator,
 ) -> None:
     """Regression test for glass.ellipticity_ryden04."""
     size = (1_000, 1_000)
 
     # single ellipticity
 
-    mu = urngb.random(size) * -1.0
-    sigma = urngb.random(size)
-    gamma = urngb.random(size)
-    sigma_gamma = urngb.random(size)
+    mu = urng.random(size) * -1.0
+    sigma = urng.random(size)
+    gamma = urng.random(size)
+    sigma_gamma = urng.random(size)
 
     e = benchmark(glass.ellipticity_ryden04, mu, sigma, gamma, sigma_gamma, size=size)
     assert e.shape == size

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -36,13 +36,13 @@ def test_ellipticity_ryden04(
 @pytest.mark.stable
 def test_ellipticity_gaussian(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for glass.ellipticity_gaussian."""
     array_length = 10
     n = 1_000_000
-    count = xpb.full(array_length, fill_value=n)
-    sigma = xpb.full(array_length, fill_value=0.256)
+    count = xp.full(array_length, fill_value=n)
+    sigma = xp.full(array_length, fill_value=0.256)
 
     eps = benchmark(
         glass.ellipticity_gaussian,
@@ -56,13 +56,13 @@ def test_ellipticity_gaussian(
 @pytest.mark.stable
 def test_ellipticity_intnorm(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for glass.ellipticity_intnorm."""
     array_length = 20
     n = 100_000
-    count = xpb.full(array_length, fill_value=n)
-    sigma = xpb.full(array_length, fill_value=0.256)
+    count = xp.full(array_length, fill_value=n)
+    sigma = xp.full(array_length, fill_value=0.256)
 
     eps = benchmark(
         glass.ellipticity_intnorm,

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -83,22 +83,22 @@ def test_resample_shapes(
     varg: float | None,
     vargamma: float | None,
     benchmark: BenchmarkFixture,
-    xp: ModuleType,
-    urng: UnifiedGenerator,
+    xpb: ModuleType,
+    urngb: UnifiedGenerator,
 ) -> None:
     """Regression test for :func:`glass.resample_shapes`."""
     n = 1_000_000
 
-    r = xp.sqrt(urng.uniform(0.0, 1.0, n))
-    phi = urng.uniform(0.0, 2 * xp.pi, n)
-    epsilon = r * xp.exp(1j * phi)
+    r = xpb.sqrt(urngb.uniform(0.0, 1.0, n))
+    phi = urngb.uniform(0.0, 2 * xpb.pi, n)
+    epsilon = r * xpb.exp(1j * phi)
 
     result = benchmark(
         glass.resample_shapes,
         epsilon,
         varg=varg,
         vargamma=vargamma,
-        rng=urng,
+        rng=urngb,
     )
 
     assert result.shape == epsilon.shape

--- a/tests/regression/test_shells.py
+++ b/tests/regression/test_shells.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
 @pytest.mark.unstable
 def test_radialwindow(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for shells.RadialWindow."""
     # check zeff is computed when not provided
     arr_length = 100_000
-    expected_zeff = xpb.asarray(66_666.0)
+    expected_zeff = xp.asarray(66_666.0)
 
-    wa = xpb.arange(arr_length)
-    za = xpb.arange(arr_length)
+    wa = xp.arange(arr_length)
+    za = xp.arange(arr_length)
 
     w = benchmark(glass.RadialWindow, za, wa)
 
@@ -34,14 +34,14 @@ def test_radialwindow(
 
 def test_distribute(
     benchmark: BenchmarkFixture,
-    xpb: ModuleType,
+    xp: ModuleType,
 ) -> None:
     """Regression test for distribute() over a moderately-sized catalogue."""
     # use N shells; tens is a good number
-    shells = glass.linear_windows(xpb.linspace(0.0, 3.0, 52))
+    shells = glass.linear_windows(xp.linspace(0.0, 3.0, 52))
     assert len(shells) == 50
     # use M redshifts; millions is a good number
-    redshifts = xpb.linspace(0.1, 2.9, 1_000_000)
+    redshifts = xp.linspace(0.1, 2.9, 1_000_000)
     # distribute redshifts over shells; problem size is N * M
     result = benchmark(glass.distribute, redshifts, shells)
     # make sure result was computed for each redshift


### PR DESCRIPTION
# Description

Changes `xpb` and `urngb` to `xp` and `urng` respectively in regression tests to reduce confusion when swapping between core and regression tests.

Closes: #1144 

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
