### PR TITLE
gh-1153: Add temporary fix for NumPy in examples

### DIFF
--- a/.github/workflows/test-examples-on-push.yaml
+++ b/.github/workflows/test-examples-on-push.yaml
@@ -13,6 +13,7 @@ on:
       - .github/workflows/run-examples.yaml
       - examples/**
       - glass/**
+      - pyproject.toml
     types:
       - opened
       - ready_for_review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ optional-dependencies = {examples = [
     "glass-ext-camb",
     "jupyter",
     "matplotlib",
+    "numpy<2.4", # TODO: remove when cmbant/CAMB#203 is fixed
 ]}
 requires-python = ">=3.11"
 


### PR DESCRIPTION
# Description

The examples are currently failing as they rely on CAMB which experiencing this bug cmbant/CAMB#203. By putting an upper bound on NumPy for the examples we should be able to minimise disruption until this is fixed.

<!-- for user facing bugs -->
Fixes: #1153

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: The examples that run with CAMB no longer have a NumPy version bug

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
