### PR TITLE
gh-1155: Pin `array-api-strict` for `2025.12` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
     {include-group = "lint"},
 ]
 docs = [
-    "array-api-strict",
+    "array-api-strict>=2.5",
     "cosmology-api",
     "furo",
     "ipython",
@@ -54,7 +54,7 @@ test = [
     "scipy",
 ]
 typechecking = [
-    "array-api-strict",
+    "array-api-strict>=2.5",
     "cosmology-api",
     "fitsio",
     "jax",


### PR DESCRIPTION
# Description

#1128 introduced a new function which relies on a more recent version of `array-api-strict`, therefore we should pin it to make sure users environments are up-to-date.

<!-- for user facing bugs -->
Fixes: #1155

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: `array-api-strict` is pinned to `2.5` to fix issues running GLASS

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
