### PR TITLE
gh-1159: Add `CosmologyWithOmegaM` protocol

### DIFF
--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -16,8 +16,15 @@ class Cosmology(
     cosmology.api.HasInverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasLittleH[AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasOmegaM0[AnyArray],  # ty: ignore[invalid-type-arguments]
-    cosmology.api.HasOmegaM[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasTransverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     typing.Protocol,
 ):
     """Cosmology protocol for GLASS."""
+
+
+class CosmologyWithOmegaM(
+    Cosmology,
+    cosmology.api.HasOmegaM[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
+    typing.Protocol,
+):
+    """Cosmology protocol for GLASS with OmegaM."""

--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -28,10 +28,10 @@ class CosmologyWithGrowthFactor(
 ):
     """Cosmology protocol for GLASS with growth factor."""
 
+
 class CosmologyWithOmegaM(
     Cosmology,
     cosmology.api.HasOmegaM[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     typing.Protocol,
 ):
     """Cosmology protocol for GLASS with OmegaM."""
-

--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -25,6 +25,5 @@ class Cosmology(
 class CosmologyWithOmegaM(
     Cosmology,
     cosmology.api.HasOmegaM[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
-    typing.Protocol,
 ):
     """Cosmology protocol for GLASS with OmegaM."""

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -141,12 +141,12 @@ class DensityWeight:
 
     Attributes
     ----------
-    cosmo
+    cosmo_omega_m
         Cosmology instance with OmegaM.
 
     """
 
-    cosmo: CosmologyWithOmegaM
+    cosmo_omega_m: CosmologyWithOmegaM
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
@@ -163,11 +163,14 @@ class DensityWeight:
 
         """
         return (
-            self.cosmo.critical_density0
-            * self.cosmo.Omega_m(z)
-            * (self.cosmo.transverse_comoving_distance(z) / self.cosmo.hubble_distance)
+            self.cosmo_omega_m.critical_density0
+            * self.cosmo_omega_m.Omega_m(z)
+            * (
+                self.cosmo_omega_m.transverse_comoving_distance(z)
+                / self.cosmo_omega_m.hubble_distance
+            )
             ** 2
-            / self.cosmo.H_over_H0(z)
+            / self.cosmo_omega_m.H_over_H0(z)
         )
 
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -146,7 +146,7 @@ class DensityWeight:
 
     """
 
-    cosmo_omega_m: CosmologyWithOmegaM
+    cosmo: CosmologyWithOmegaM
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
@@ -163,14 +163,11 @@ class DensityWeight:
 
         """
         return (
-            self.cosmo_omega_m.critical_density0
-            * self.cosmo_omega_m.Omega_m(z)
-            * (
-                self.cosmo_omega_m.transverse_comoving_distance(z)
-                / self.cosmo_omega_m.hubble_distance
-            )
+            self.cosmo.critical_density0
+            * self.cosmo.Omega_m(z)
+            * (self.cosmo.transverse_comoving_distance(z) / self.cosmo.hubble_distance)
             ** 2
-            / self.cosmo_omega_m.H_over_H0(z)
+            / self.cosmo.H_over_H0(z)
         )
 
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -141,7 +141,7 @@ class DensityWeight:
 
     Attributes
     ----------
-    cosmo_omega_m
+    cosmo
         Cosmology instance with OmegaM.
 
     """

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import FloatArray, IntArray, UnifiedGenerator
-    from glass.cosmology import Cosmology
+    from glass.cosmology import Cosmology, CosmologyWithOmegaM
 
 
 @dataclasses.dataclass
@@ -142,11 +142,11 @@ class DensityWeight:
     Attributes
     ----------
     cosmo
-        Cosmology instance.
+        Cosmology instance with OmegaM.
 
     """
 
-    cosmo: Cosmology
+    cosmo: CosmologyWithOmegaM
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import UnifiedGenerator
-    from glass.cosmology import Cosmology, CosmologyWithOmegaM
+    from glass.cosmology import Cosmology
 
 
 @pytest.fixture(scope="session")
@@ -103,13 +103,13 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo_omega_m: CosmologyWithOmegaM) -> None:
+def test_density_weight(cosmo: Cosmology) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.DensityWeight(cosmo_omega_m)(z)
+    w = glass.DensityWeight(cosmo)(z)
     assert w.shape == z.shape
 
     # check first value is 0

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import UnifiedGenerator
-    from glass.cosmology import Cosmology
+    from glass.cosmology import Cosmology, CosmologyWithOmegaM
 
 
 @pytest.fixture(scope="session")
@@ -103,7 +103,7 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo: Cosmology) -> None:
+def test_density_weight(cosmo: CosmologyWithOmegaM) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -103,13 +103,13 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo: CosmologyWithOmegaM) -> None:
+def test_density_weight(cosmo_omega_m: CosmologyWithOmegaM) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.DensityWeight(cosmo)(z)
+    w = glass.DensityWeight(cosmo_omega_m)(z)
     assert w.shape == z.shape
 
     # check first value is 0

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -103,13 +103,13 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo: CosmologyWithOmegaM) -> None:
+def test_density_weight(cosmo_with_omega_m: CosmologyWithOmegaM) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.DensityWeight(cosmo)(z)
+    w = glass.DensityWeight(cosmo_with_omega_m)(z)
     assert w.shape == z.shape
 
     # check first value is 0

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -86,10 +86,6 @@ class MockCosmology:
         """Inverse function for the comoving distance in Mpc."""
         return 1_000 * (1 / (dc + np.finfo(float).eps))
 
-    def Omega_m(self, z: FloatArray) -> FloatArray:  # noqa: N802
-        """Matter density parameter at redshift z."""
-        return self.rho_m_z(z) / self.critical_density0
-
     def transverse_comoving_distance(
         self,
         z: FloatArray,

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -21,6 +21,12 @@ def cosmo() -> MockCosmology:
     return MockCosmology()
 
 
+@pytest.fixture(scope="session")
+def cosmo_with_omega_m() -> MockCosmologyWithOmegaM:
+    """Mock cosmology with OmegaM to use for core tests."""
+    return MockCosmologyWithOmegaM()
+
+
 class MockCosmology:
     """
     A mock class to represent Cosmology in tests.
@@ -91,6 +97,14 @@ class MockCosmology:
     ) -> FloatArray:
         """Transverse comoving distance :math:`d_M(z)` in Mpc."""
         return self.hubble_distance * self.xm(z, z2)
+
+
+class MockCosmologyWithOmegaM(MockCosmology):
+    """A mock class to represent Cosmology with OmegaM in tests."""
+
+    def Omega_m(self, z: FloatArray) -> FloatArray:  # noqa: N802
+        """Matter density parameter at redshift z."""
+        return self.rho_m_z(z) / self.critical_density0
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Description

Adds a `CosmologyWithOmegaM` protocol as `OmegaM` isn't used that often.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1159

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Added: A `CosmologyWithOmegaM` protocol

## Checks

- [X] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
