### PR TITLE
gh-1158: Add `CosmologyWithGrowthFactor` protocol

### DIFF
--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -10,7 +10,6 @@ from glass._types import AnyArray
 class Cosmology(
     cosmology.api.HasComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasCriticalDensity0[AnyArray],  # ty: ignore[invalid-type-arguments]
-    cosmology.api.HasGrowthFactor[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasHoverH0[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasHubbleDistance[AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasInverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
@@ -21,3 +20,10 @@ class Cosmology(
     typing.Protocol,
 ):
     """Cosmology protocol for GLASS."""
+
+
+class CosmologyWithGrowthFactor(
+    Cosmology,
+    cosmology.api.HasGrowthFactor[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
+):
+    """Cosmology protocol for GLASS with growth factor."""

--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -25,5 +25,6 @@ class Cosmology(
 class CosmologyWithGrowthFactor(
     Cosmology,
     cosmology.api.HasGrowthFactor[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
+    typing.Protocol,
 ):
     """Cosmology protocol for GLASS with growth factor."""

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from glass._types import AnyArray, FloatArray, IntArray, UnifiedGenerator
-    from glass.cosmology import Cosmology
+    from glass.cosmology import CosmologyWithGrowthFactor
 
 
 def _draw_nz(
@@ -457,7 +457,7 @@ def _kappa_ia_nla(  # noqa: PLR0913
     delta: FloatArray,
     zeff: float,
     a_ia: float,
-    cosmo: Cosmology,
+    cosmo: CosmologyWithGrowthFactor,
     *,
     z0: float = 0.0,
     eta: float = 0.0,
@@ -477,7 +477,7 @@ def _kappa_ia_nla(  # noqa: PLR0913
     a_ia
         Intrinsic alignments amplitude.
     cosmo
-        Cosmology instance.
+        Cosmology instance with growth factor.
     z0
         Reference redshift for the redshift dependence.
     eta


### PR DESCRIPTION
# Description

Adds a `CosmologyWithGrowthFactor` protocol as `growth_factor` isn't used that often.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1158

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Added: A `CosmologyWithGrowthFactor` protocol

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
