### PR TITLE
gh-1157: Add `CosmologyWithInverseComovingDistance` protocol

### DIFF
--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -25,5 +25,6 @@ class Cosmology(
 class CosmologyWithInverseComovingDistance(
     Cosmology,
     cosmology.api.HasInverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
+    typing.Protocol,
 ):
     """Cosmology protocol for GLASS with inverse comoving distance."""

--- a/glass/cosmology.py
+++ b/glass/cosmology.py
@@ -13,7 +13,6 @@ class Cosmology(
     cosmology.api.HasGrowthFactor[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasHoverH0[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasHubbleDistance[AnyArray],  # ty: ignore[invalid-type-arguments]
-    cosmology.api.HasInverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasLittleH[AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasOmegaM0[AnyArray],  # ty: ignore[invalid-type-arguments]
     cosmology.api.HasOmegaM[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
@@ -21,3 +20,10 @@ class Cosmology(
     typing.Protocol,
 ):
     """Cosmology protocol for GLASS."""
+
+
+class CosmologyWithInverseComovingDistance(
+    Cosmology,
+    cosmology.api.HasInverseComovingDistance[AnyArray, AnyArray],  # ty: ignore[invalid-type-arguments]
+):
+    """Cosmology protocol for GLASS with inverse comoving distance."""

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -141,12 +141,12 @@ class DensityWeight:
 
     Attributes
     ----------
-    comso
+    cosmo
         Cosmology instance with inverse comoving distance.
 
     """
 
-    comso: CosmologyWithInverseComovingDistance
+    cosmo: CosmologyWithInverseComovingDistance
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
@@ -163,11 +163,11 @@ class DensityWeight:
 
         """
         return (
-            self.comso.critical_density0
-            * self.comso.Omega_m(z)
-            * (self.comso.transverse_comoving_distance(z) / self.comso.hubble_distance)
+            self.cosmo.critical_density0
+            * self.cosmo.Omega_m(z)
+            * (self.cosmo.transverse_comoving_distance(z) / self.cosmo.hubble_distance)
             ** 2
-            / self.comso.H_over_H0(z)
+            / self.cosmo.H_over_H0(z)
         )
 
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -72,7 +72,11 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import FloatArray, IntArray, UnifiedGenerator
-    from glass.cosmology import Cosmology, CosmologyWithInverseComovingDistance, CosmologyWithOmegaM
+    from glass.cosmology import (
+        Cosmology,
+        CosmologyWithInverseComovingDistance,
+        CosmologyWithOmegaM,
+    )
 
 
 @dataclasses.dataclass

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -142,11 +142,11 @@ class DensityWeight:
     Attributes
     ----------
     cosmo
-        Cosmology instance with inverse comoving distance.
+        Cosmology instance.
 
     """
 
-    cosmo: CosmologyWithInverseComovingDistance
+    cosmo: Cosmology
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -141,12 +141,12 @@ class DensityWeight:
 
     Attributes
     ----------
-    cosmo_inv_co_dist
+    comso
         Cosmology instance with inverse comoving distance.
 
     """
 
-    cosmo_inv_co_dist: CosmologyWithInverseComovingDistance
+    comso: CosmologyWithInverseComovingDistance
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
@@ -163,14 +163,11 @@ class DensityWeight:
 
         """
         return (
-            self.cosmo_inv_co_dist.critical_density0
-            * self.cosmo_inv_co_dist.Omega_m(z)
-            * (
-                self.cosmo_inv_co_dist.transverse_comoving_distance(z)
-                / self.cosmo_inv_co_dist.hubble_distance
-            )
+            self.comso.critical_density0
+            * self.comso.Omega_m(z)
+            * (self.comso.transverse_comoving_distance(z) / self.comso.hubble_distance)
             ** 2
-            / self.cosmo_inv_co_dist.H_over_H0(z)
+            / self.comso.H_over_H0(z)
         )
 
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -146,7 +146,7 @@ class DensityWeight:
 
     """
 
-    cosmo_inv_co_dist: Cosmology
+    cosmo_inv_co_dist: CosmologyWithInverseComovingDistance
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -141,12 +141,12 @@ class DensityWeight:
 
     Attributes
     ----------
-    cosmo
-        Cosmology instance.
+    cosmo_inv_co_dist
+        Cosmology instance with inverse comoving distance.
 
     """
 
-    cosmo: Cosmology
+    cosmo_inv_co_dist: Cosmology
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
@@ -163,11 +163,14 @@ class DensityWeight:
 
         """
         return (
-            self.cosmo.critical_density0
-            * self.cosmo.Omega_m(z)
-            * (self.cosmo.transverse_comoving_distance(z) / self.cosmo.hubble_distance)
+            self.cosmo_inv_co_dist.critical_density0
+            * self.cosmo_inv_co_dist.Omega_m(z)
+            * (
+                self.cosmo_inv_co_dist.transverse_comoving_distance(z)
+                / self.cosmo_inv_co_dist.hubble_distance
+            )
             ** 2
-            / self.cosmo.H_over_H0(z)
+            / self.cosmo_inv_co_dist.H_over_H0(z)
         )
 
 

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import FloatArray, IntArray, UnifiedGenerator
-    from glass.cosmology import Cosmology
+    from glass.cosmology import Cosmology, CosmologyWithInverseComovingDistance
 
 
 @dataclasses.dataclass
@@ -908,7 +908,7 @@ def redshift_grid(
 
 
 def distance_grid(
-    cosmo: Cosmology,
+    cosmo: CosmologyWithInverseComovingDistance,
     zmin: float,
     zmax: float,
     *,
@@ -921,7 +921,7 @@ def distance_grid(
     Parameters
     ----------
     cosmo
-        Cosmology instance.
+        Cosmology instance with inverse comoving distance.
     zmin
         The minimum redshift.
     zmax

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import UnifiedGenerator
-    from glass.cosmology import Cosmology, CosmologyWithInverseComovingDistance, CosmologyWithOmegaM
+    from glass.cosmology import (
+        Cosmology,
+        CosmologyWithInverseComovingDistance,
+        CosmologyWithOmegaM,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -103,9 +103,7 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(
-    cosmo: Cosmology,
-) -> None:
+def test_density_weight(cosmo: Cosmology) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import UnifiedGenerator
-    from glass.cosmology import Cosmology, CosmologyWithInverseComovingDistance
+    from glass.cosmology import Cosmology
 
 
 @pytest.fixture(scope="session")
@@ -104,14 +104,14 @@ def test_volume_weight(
 
 
 def test_density_weight(
-    cosmo_inv_co_dist: CosmologyWithInverseComovingDistance,
+    cosmo: Cosmology,
 ) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.DensityWeight(cosmo_inv_co_dist)(z)
+    w = glass.DensityWeight(cosmo)(z)
     assert w.shape == z.shape
 
     # check first value is 0

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -103,13 +103,15 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo: CosmologyWithInverseComovingDistance) -> None:
+def test_density_weight(
+    cosmo_inv_co_dist: CosmologyWithInverseComovingDistance,
+) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 
     # check shape
 
-    w = glass.DensityWeight(cosmo)(z)
+    w = glass.DensityWeight(cosmo_inv_co_dist)(z)
     assert w.shape == z.shape
 
     # check first value is 0

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import UnifiedGenerator
-    from glass.cosmology import Cosmology
+    from glass.cosmology import Cosmology, CosmologyWithInverseComovingDistance
 
 
 @pytest.fixture(scope="session")
@@ -357,7 +357,9 @@ def test_redshift_grid(xp: ModuleType) -> None:
         glass.redshift_grid(zmin, zmax, dz=dz, num=num, xp=xp)
 
 
-def test_distance_grid(cosmo: Cosmology) -> None:
+def test_distance_grid(
+    cosmo_with_inverse_comoving_distance: CosmologyWithInverseComovingDistance,
+) -> None:
     """Add unit tests for :func:`glass.distance_grid`."""
     zmin = 0.0
     zmax = 1.0
@@ -365,18 +367,18 @@ def test_distance_grid(cosmo: Cosmology) -> None:
     # check num input
 
     num = 5
-    x = glass.distance_grid(cosmo, zmin, zmax, num=5)
+    x = glass.distance_grid(cosmo_with_inverse_comoving_distance, zmin, zmax, num=5)
     assert x.shape[0] == num + 1
 
     # check dz input
 
     dx = 0.2
-    x = glass.distance_grid(cosmo, zmin, zmax, dx=dx)
+    x = glass.distance_grid(cosmo_with_inverse_comoving_distance, zmin, zmax, dx=dx)
     assert x.shape[0] == math.ceil((zmax - zmin) / dx) + 1
 
     # check decrease in distance
 
-    x = glass.distance_grid(cosmo, zmin, zmax, dx=0.3)
+    x = glass.distance_grid(cosmo_with_inverse_comoving_distance, zmin, zmax, dx=0.3)
     xpx.testing.assert_less(x[1:], x[:-1])
 
     # check error raised
@@ -385,13 +387,15 @@ def test_distance_grid(cosmo: Cosmology) -> None:
         ValueError,
         match="exactly one of grid step size or number of steps must be given",
     ):
-        glass.distance_grid(cosmo, zmin, zmax)
+        glass.distance_grid(cosmo_with_inverse_comoving_distance, zmin, zmax)
 
     with pytest.raises(
         ValueError,
         match="exactly one of grid step size or number of steps must be given",
     ):
-        glass.distance_grid(cosmo, zmin, zmax, dx=dx, num=num)
+        glass.distance_grid(
+            cosmo_with_inverse_comoving_distance, zmin, zmax, dx=dx, num=num
+        )
 
 
 def test_combine(

--- a/tests/core/test_shells.py
+++ b/tests/core/test_shells.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from glass._types import UnifiedGenerator
-    from glass.cosmology import Cosmology
+    from glass.cosmology import Cosmology, CosmologyWithInverseComovingDistance
 
 
 @pytest.fixture(scope="session")
@@ -103,7 +103,7 @@ def test_volume_weight(
     xpx.testing.assert_less(w[:-1], w[1:])
 
 
-def test_density_weight(cosmo: Cosmology) -> None:
+def test_density_weight(cosmo: CosmologyWithInverseComovingDistance) -> None:
     """Add unit tests for :class:`glass.DensityWeight`."""
     z = np.linspace(0, 1, 6)
 

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -27,6 +27,7 @@ def cosmo_with_inverse_comoving_distance() -> MockCosmologyWithInverseComovingDi
     return MockCosmologyWithInverseComovingDistance()
 
 
+@pytest.fixture(scope="session")
 def cosmo_with_omega_m() -> MockCosmologyWithOmegaM:
     """Mock cosmology with OmegaM to use for core tests."""
     return MockCosmologyWithOmegaM()

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -21,6 +21,12 @@ def cosmo() -> MockCosmology:
     return MockCosmology()
 
 
+@pytest.fixture(scope="session")
+def cosmo_with_inverse_comoving_distance() -> MockCosmologyWithInverseComovingDistance:
+    """Mock cosmology with inverse comoving distance to use for core tests."""
+    return MockCosmologyWithInverseComovingDistance()
+
+
 class MockCosmology:
     """
     A mock class to represent Cosmology in tests.
@@ -76,10 +82,6 @@ class MockCosmology:
         """Comoving distance :math:`d_c(z)` in Mpc."""
         return np.divide(self.xm(z, z2), 1_000.0)
 
-    def inv_comoving_distance(self, dc: FloatArray) -> FloatArray:
-        """Inverse function for the comoving distance in Mpc."""
-        return 1_000 * (1 / (dc + np.finfo(float).eps))
-
     def Omega_m(self, z: FloatArray) -> FloatArray:  # noqa: N802
         """Matter density parameter at redshift z."""
         return self.rho_m_z(z) / self.critical_density0
@@ -91,6 +93,14 @@ class MockCosmology:
     ) -> FloatArray:
         """Transverse comoving distance :math:`d_M(z)` in Mpc."""
         return self.hubble_distance * self.xm(z, z2)
+
+
+class MockCosmologyWithInverseComovingDistance(MockCosmology):
+    """Mock cosmology with inverse comoving distance."""
+
+    def inv_comoving_distance(self, dc: FloatArray) -> FloatArray:
+        """Inverse function for the comoving distance in Mpc."""
+        return 1_000 * (1 / (dc + np.finfo(float).eps))
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Description

Adds a `CosmologyWithInverseComovingDistance` protocol as `inv_comoving_distance` isn't used that often.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1157

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Added: A `CosmologyWithInverseComovingDistance` protocol

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
