### PR TITLE
gh-1165: fix `dataclass` docstrings in `shells.py`

### DIFF
--- a/glass/shells.py
+++ b/glass/shells.py
@@ -86,7 +86,7 @@ class DistanceWeight:
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
-        Uniform weight in comoving distance.
+        Uniform weight function in comoving distance.
 
         Parameters
         ----------
@@ -117,7 +117,7 @@ class VolumeWeight:
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
-        Uniform weight in comoving distance.
+        Uniform weight function in comoving volume.
 
         Parameters
         ----------
@@ -150,7 +150,7 @@ class DensityWeight:
 
     def __call__(self, z: FloatArray) -> FloatArray:
         """
-        Uniform weight in comoving distance.
+        Uniform weight function in matter density.
 
         Parameters
         ----------


### PR DESCRIPTION
# Description

Corrects the docstrings for the distance `dataclasses`.

<!-- for user facing bugs -->
Fixes: #1165

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: The `dataclasses` for distance have had their docstrings fixed.

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [X] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
