### PR TITLE
gh-1167: Prepare for lazy imports in `3.15`

### DIFF
--- a/glass/_array_api_utils.py
+++ b/glass/_array_api_utils.py
@@ -16,6 +16,10 @@ integration, interpolation, and linear algebra.
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+]
+
 import functools
 from typing import TYPE_CHECKING
 

--- a/glass/algorithm.py
+++ b/glass/algorithm.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+]
+
 import typing
 import warnings
 from typing import TYPE_CHECKING

--- a/glass/arraytools.py
+++ b/glass/arraytools.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+]
+
 import typing
 from typing import TYPE_CHECKING
 

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+    "transformcl",
+]
+
 import collections
 import itertools
 import math

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -20,6 +20,11 @@ Functions
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+]
+
 import math
 import typing
 import warnings

--- a/glass/grf/_core.py
+++ b/glass/grf/_core.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "transformcl",
+]
+
 import typing
 from typing import TYPE_CHECKING
 

--- a/glass/grf/_solver.py
+++ b/glass/grf/_solver.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "numpy",
+    "transformcl",
+]
+
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/glass/harmonics.py
+++ b/glass/harmonics.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+]
+
 from typing import TYPE_CHECKING
 
 import array_api_compat

--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "healpix",
+    "healpy",
+    "numpy",
+]
+
 import os
 import pathlib
 from collections.abc import Sequence

--- a/glass/jax.py
+++ b/glass/jax.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "jax",
+]
+
 import math
 import threading
 from typing import TYPE_CHECKING

--- a/glass/lensing.py
+++ b/glass/lensing.py
@@ -31,6 +31,12 @@ Applying lensing
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+    "numpy",
+]
+
 import typing
 from typing import TYPE_CHECKING, Literal
 

--- a/glass/observations.py
+++ b/glass/observations.py
@@ -27,6 +27,10 @@ Visibility
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+]
+
 import itertools
 import math
 from typing import TYPE_CHECKING

--- a/glass/points.py
+++ b/glass/points.py
@@ -38,6 +38,11 @@ Displacing points
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+]
+
 import itertools
 import math
 from typing import TYPE_CHECKING

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -24,6 +24,11 @@ Utilities
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+]
+
 import math
 import typing
 from typing import TYPE_CHECKING
@@ -420,7 +425,7 @@ def resample_shapes(
                 xp.sqrt(((1 - 2 * varg) * vare) ** 2 + 4 * varg * eve4 * (vare - varg))
                 - (1 - 2 * varg) * vare
             )
-            / (2 * varg * eve4)
+            / (2 * varg * eve4),
         )
 
     # assign random orientations to shapes

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -46,6 +46,11 @@ Weight functions
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "array_api_compat",
+    "array_api_extra",
+]
+
 import dataclasses
 import itertools
 import math

--- a/glass/user.py
+++ b/glass/user.py
@@ -19,6 +19,10 @@ Input and Output
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "numpy",
+]
+
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
# Description

Uses the `__lazy_modules__` in the `glass/glass` module to speed up use elsewhere once Python `3.15` is released.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1167

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
