### PR TITLE
gh-1145: Default to wrapping rng if backend is not known

### DIFF
--- a/glass/_types.py
+++ b/glass/_types.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     FloatArray: TypeAlias = np.typing.NDArray[np.float64] | jaxtyping.Array | Array
     IntArray: TypeAlias = np.typing.NDArray[np.int64] | jaxtyping.Array | Array
     UnifiedGenerator: TypeAlias = (
-        np.random.Generator | glass.jax.Generator | glass.rng.SupportsGlassRNG
+        np.random.Generator | glass.jax.Generator | glass.rng.Generator
     )
 
     AngularPowerSpectra: TypeAlias = Sequence[AnyArray]

--- a/glass/_types.py
+++ b/glass/_types.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from array_api_strict._array_object import Array
     from array_api_strict._dtypes import DType
 
+    import glass.jax
+    import glass.rng
+
     P = typing.ParamSpec("P")
     R = typing.TypeVar("R")
     T = typing.TypeVar("T")
@@ -20,6 +23,9 @@ if TYPE_CHECKING:
     DTypeLike: TypeAlias = np.typing.DTypeLike | jaxtyping.DTypeLike | DType
     FloatArray: TypeAlias = np.typing.NDArray[np.float64] | jaxtyping.Array | Array
     IntArray: TypeAlias = np.typing.NDArray[np.int64] | jaxtyping.Array | Array
+    UnifiedGenerator: TypeAlias = (
+        np.random.Generator | glass.jax.Generator | glass.rng.Generator
+    )
 
     AngularPowerSpectra: TypeAlias = Sequence[AnyArray]
 else:
@@ -30,18 +36,17 @@ else:
     DTypeLike = Any
     FloatArray = Any
     IntArray = Any
+    UnifiedGenerator = Any
 
     AngularPowerSpectra = Any
 
 
-class UnifiedGenerator(Protocol):
+class SupportsGlassRNG(Protocol):
     """Defines the methods required for an RNG to be used within glass."""
 
     def random(
         self,
         size: int | tuple[int, ...] | None = None,
-        dtype: DTypeLike | None = None,
-        out: FloatArray | None = None,
     ) -> FloatArray:
         """
         Return random floats in the half-open interval [0.0, 1.0).
@@ -108,8 +113,6 @@ class UnifiedGenerator(Protocol):
     def standard_normal(
         self,
         size: int | tuple[int, ...] | None = None,
-        dtype: DTypeLike | None = None,
-        out: FloatArray | None = None,
     ) -> FloatArray:
         """
         Draw samples from a standard Normal distribution (mean=0, stdev=1).

--- a/glass/_types.py
+++ b/glass/_types.py
@@ -1,5 +1,5 @@
 import typing
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -11,9 +11,6 @@ if TYPE_CHECKING:
     from array_api_strict._array_object import Array
     from array_api_strict._dtypes import DType
 
-    import glass.jax
-    import glass.rng
-
     P = typing.ParamSpec("P")
     R = typing.TypeVar("R")
     T = typing.TypeVar("T")
@@ -23,9 +20,6 @@ if TYPE_CHECKING:
     DTypeLike: TypeAlias = np.typing.DTypeLike | jaxtyping.DTypeLike | DType
     FloatArray: TypeAlias = np.typing.NDArray[np.float64] | jaxtyping.Array | Array
     IntArray: TypeAlias = np.typing.NDArray[np.int64] | jaxtyping.Array | Array
-    UnifiedGenerator: TypeAlias = (
-        np.random.Generator | glass.jax.Generator | glass.rng.Generator
-    )
 
     AngularPowerSpectra: TypeAlias = Sequence[AnyArray]
 else:
@@ -36,6 +30,149 @@ else:
     DTypeLike = Any
     FloatArray = Any
     IntArray = Any
-    UnifiedGenerator = Any
 
     AngularPowerSpectra = Any
+
+
+class UnifiedGenerator(Protocol):
+    """Defines the methods required for an RNG to be used within glass."""
+
+    def random(
+        self,
+        size: int | tuple[int, ...] | None = None,
+        dtype: DTypeLike | None = None,
+        out: FloatArray | None = None,
+    ) -> FloatArray:
+        """
+        Return random floats in the half-open interval [0.0, 1.0).
+
+        Parameters
+        ----------
+        size
+            Output shape.
+        dtype
+            Desired data type.
+        out
+            Optional output array.
+
+        Returns
+        -------
+            Array of random floats.
+        """
+
+    def normal(
+        self,
+        loc: float | FloatArray = 0.0,
+        scale: float | FloatArray = 1.0,
+        size: int | tuple[int, ...] | None = None,
+    ) -> FloatArray:
+        """
+        Draw samples from a Normal distribution (mean=loc, stdev=scale).
+
+        Parameters
+        ----------
+        loc
+            Mean of the distribution.
+        scale
+            Standard deviation of the distribution.
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the normal distribution.
+
+        """
+
+    def poisson(
+        self,
+        lam: float | FloatArray,
+        size: int | tuple[int, ...] | None = None,
+    ) -> IntArray:
+        """
+        Draw samples from a Poisson distribution.
+
+        Parameters
+        ----------
+        lam
+            Expected number of events.
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the Poisson distribution.
+
+        """
+
+    def standard_normal(
+        self,
+        size: int | tuple[int, ...] | None = None,
+        dtype: DTypeLike | None = None,
+        out: FloatArray | None = None,
+    ) -> FloatArray:
+        """
+        Draw samples from a standard Normal distribution (mean=0, stdev=1).
+
+        Parameters
+        ----------
+        size
+            Output shape.
+        dtype
+            Desired data type.
+        out
+            Optional output array.
+
+        Returns
+        -------
+            Array of samples from the standard normal distribution.
+
+        """
+
+    def uniform(
+        self,
+        low: float | FloatArray = 0.0,
+        high: float | FloatArray = 1.0,
+        size: int | tuple[int, ...] | None = None,
+    ) -> FloatArray:
+        """
+        Draw samples from a Uniform distribution.
+
+        Parameters
+        ----------
+        low
+            Lower bound of the distribution.
+        high
+            Upper bound of the distribution.
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the uniform distribution.
+
+        """
+
+    def multinomial(
+        self,
+        n: int | IntArray,
+        pvals: FloatArray,
+        size: int | tuple[int, ...] | None = None,
+    ) -> IntArray:
+        """
+        Draw samples from a multinomial distribution.
+
+        Parameters
+        ----------
+        n
+            Number of experiments.
+        pvals
+            Probabilities of each of the p different outcomes.
+        size
+            Output shape.
+
+        Returns
+        -------
+            The drawn sample.
+
+        """

--- a/glass/_types.py
+++ b/glass/_types.py
@@ -1,5 +1,5 @@
 import typing
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     FloatArray: TypeAlias = np.typing.NDArray[np.float64] | jaxtyping.Array | Array
     IntArray: TypeAlias = np.typing.NDArray[np.int64] | jaxtyping.Array | Array
     UnifiedGenerator: TypeAlias = (
-        np.random.Generator | glass.jax.Generator | glass.rng.Generator
+        np.random.Generator | glass.jax.Generator | glass.rng.SupportsGlassRNG
     )
 
     AngularPowerSpectra: TypeAlias = Sequence[AnyArray]
@@ -39,143 +39,3 @@ else:
     UnifiedGenerator = Any
 
     AngularPowerSpectra = Any
-
-
-class SupportsGlassRNG(Protocol):
-    """Defines the methods required for an RNG to be used within glass."""
-
-    def random(
-        self,
-        size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
-        """
-        Return random floats in the half-open interval [0.0, 1.0).
-
-        Parameters
-        ----------
-        size
-            Output shape.
-        dtype
-            Desired data type.
-        out
-            Optional output array.
-
-        Returns
-        -------
-            Array of random floats.
-        """
-
-    def normal(
-        self,
-        loc: float | FloatArray = 0.0,
-        scale: float | FloatArray = 1.0,
-        size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
-        """
-        Draw samples from a Normal distribution (mean=loc, stdev=scale).
-
-        Parameters
-        ----------
-        loc
-            Mean of the distribution.
-        scale
-            Standard deviation of the distribution.
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the normal distribution.
-
-        """
-
-    def poisson(
-        self,
-        lam: float | FloatArray,
-        size: int | tuple[int, ...] | None = None,
-    ) -> IntArray:
-        """
-        Draw samples from a Poisson distribution.
-
-        Parameters
-        ----------
-        lam
-            Expected number of events.
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the Poisson distribution.
-
-        """
-
-    def standard_normal(
-        self,
-        size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
-        """
-        Draw samples from a standard Normal distribution (mean=0, stdev=1).
-
-        Parameters
-        ----------
-        size
-            Output shape.
-        dtype
-            Desired data type.
-        out
-            Optional output array.
-
-        Returns
-        -------
-            Array of samples from the standard normal distribution.
-
-        """
-
-    def uniform(
-        self,
-        low: float | FloatArray = 0.0,
-        high: float | FloatArray = 1.0,
-        size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
-        """
-        Draw samples from a Uniform distribution.
-
-        Parameters
-        ----------
-        low
-            Lower bound of the distribution.
-        high
-            Upper bound of the distribution.
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the uniform distribution.
-
-        """
-
-    def multinomial(
-        self,
-        n: int | IntArray,
-        pvals: FloatArray,
-        size: int | tuple[int, ...] | None = None,
-    ) -> IntArray:
-        """
-        Draw samples from a multinomial distribution.
-
-        Parameters
-        ----------
-        n
-            Number of experiments.
-        pvals
-            Probabilities of each of the p different outcomes.
-        size
-            Output shape.
-
-        Returns
-        -------
-            The drawn sample.
-
-        """

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -376,8 +376,7 @@ def _generate_grf(
     """
     xp = array_api_compat.array_namespace(*gls, use_compat=False)
 
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # number of gls and number of fields
     ngrf = nfields_from_nspectra(len(gls))

--- a/glass/fields.py
+++ b/glass/fields.py
@@ -376,7 +376,7 @@ def _generate_grf(
     """
     xp = array_api_compat.array_namespace(*gls, use_compat=False)
 
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # number of gls and number of fields
     ngrf = nfields_from_nspectra(len(gls))
@@ -404,7 +404,7 @@ def _generate_grf(
     for w in iternorm(cov):
         # standard normal random variates for alm
         # sample real and imaginary parts, then combine into complex number
-        z = rng.standard_normal((z_size, 2)) @ xp.asarray([1, 1j])
+        z = xrng.standard_normal((z_size, 2)) @ xp.asarray([1, 1j])
 
         # append to stack of standard normals
         y.append(z)

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -74,6 +74,9 @@ def _draw_nz(
         Redshifts sampled from the given source distribution.
 
     """
+    xp = array_api_compat.array_namespace(count, z, nz, use_compat=False)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
+
     # compute the CDF
     cdf = glass.arraytools.cumulative_trapezoid(nz, z)
     cdf /= cdf[-1]
@@ -157,8 +160,7 @@ def redshifts_from_bins(
     xp = array_api_compat.array_namespace(bins, z, *nz_values, use_compat=False)
 
     # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # tally the bins
     bin_label, _, bin_index, bin_count = xp.unique_all(bins)
@@ -234,9 +236,7 @@ def redshifts_from_nz(
             stacklevel=2,
         )
 
-    # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # bring inputs' leading axes into common shape
     dims, *rest = glass.arraytools.broadcast_leading_axes((count, 0), (z, 1), (nz, 1))
@@ -420,8 +420,7 @@ def gaussian_phz(  # noqa: PLR0913
     sigma_0_arr = xp.asarray(sigma_0)
 
     # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # Ensure lower and upper are arrays that have the same shape and type
     lower_arr = xp.asarray(0.0 if lower is None else lower, dtype=xp.float64)

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -159,7 +159,6 @@ def redshifts_from_bins(
 
     xp = array_api_compat.array_namespace(bins, z, *nz_values, use_compat=False)
 
-    # get default RNG if not given
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # tally the bins
@@ -419,7 +418,6 @@ def gaussian_phz(  # noqa: PLR0913
     z_arr = xp.asarray(z)
     sigma_0_arr = xp.asarray(sigma_0)
 
-    # get default RNG if not given
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # Ensure lower and upper are arrays that have the same shape and type

--- a/glass/galaxies.py
+++ b/glass/galaxies.py
@@ -75,7 +75,7 @@ def _draw_nz(
 
     """
     xp = array_api_compat.array_namespace(count, z, nz, use_compat=False)
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # compute the CDF
     cdf = glass.arraytools.cumulative_trapezoid(nz, z)
@@ -83,7 +83,7 @@ def _draw_nz(
 
     # sample redshifts and return result
     return uxpx.interp(
-        rng.uniform(0.0, 1.0, size=count),
+        xrng.uniform(0.0, 1.0, size=count),
         cdf,
         z,
     )
@@ -160,7 +160,7 @@ def redshifts_from_bins(
     xp = array_api_compat.array_namespace(bins, z, *nz_values, use_compat=False)
 
     # get default RNG if not given
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # tally the bins
     bin_label, _, bin_index, bin_count = xp.unique_all(bins)
@@ -168,7 +168,7 @@ def redshifts_from_bins(
     # sample the redshifts from each nz
     # concatenate into runs of redshifts for each bin
     redshifts = xp.concat([
-        _draw_nz(int(k), z, nz_values[nz_keys.index(x)], rng=rng)
+        _draw_nz(int(k), z, nz_values[nz_keys.index(x)], rng=xrng)
         for x, k in zip(bin_label, bin_count, strict=True)
     ])
 
@@ -236,7 +236,7 @@ def redshifts_from_nz(
             stacklevel=2,
         )
 
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # bring inputs' leading axes into common shape
     dims, *rest = glass.arraytools.broadcast_leading_axes((count, 0), (z, 1), (nz, 1))
@@ -259,7 +259,7 @@ def redshifts_from_nz(
                 int(count_out[k]),
                 z_out_slice,
                 nz_out_slice,
-                rng=rng,
+                rng=xrng,
             ),
         )
         total += count_out[k]
@@ -420,7 +420,7 @@ def gaussian_phz(  # noqa: PLR0913
     sigma_0_arr = xp.asarray(sigma_0)
 
     # get default RNG if not given
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # Ensure lower and upper are arrays that have the same shape and type
     lower_arr = xp.asarray(0.0 if lower is None else lower, dtype=xp.float64)
@@ -432,7 +432,7 @@ def gaussian_phz(  # noqa: PLR0913
 
     sigma = xp.add(1, z_arr) * sigma_0_arr
     dims = sigma.shape
-    zphot = xp.asarray(rng.normal(z_arr, sigma))
+    zphot = xp.asarray(xrng.normal(z_arr, sigma))
 
     # Check for valid user input
     if (lower_arr.ndim == upper_arr.ndim != 0) and not (
@@ -446,12 +446,12 @@ def gaussian_phz(  # noqa: PLR0913
 
     if not dims:
         while zphot < lower_arr or zphot > upper_arr:
-            zphot = xp.asarray(rng.normal(z_arr, sigma))
+            zphot = xp.asarray(xrng.normal(z_arr, sigma))
     else:
         z_arr = xp.broadcast_to(z_arr, dims)
         trunc = (zphot < lower_arr) | (zphot > upper_arr)
         while xp.count_nonzero(trunc) > 0:
-            zphot = xp.where(trunc, rng.normal(z_arr, sigma), zphot)
+            zphot = xp.where(trunc, xrng.normal(z_arr, sigma), zphot)
             trunc = (zphot < lower_arr) | (zphot > upper_arr)
 
     return zphot

--- a/glass/healpix.py
+++ b/glass/healpix.py
@@ -464,7 +464,7 @@ def randang(
         nside,
         np.asarray(ipix),
         lonlat=lonlat,
-        rng=glass.rng.rng_dispatcher(xp=np),
+        rng=glass.rng.default_rng(xp=np),
     )
     return xp.asarray(theta), xp.asarray(phi)
 

--- a/glass/jax.py
+++ b/glass/jax.py
@@ -185,6 +185,10 @@ class Generator:
         dtype: DTypeLike = float,
     ) -> FloatArray:
         """Draw samples from a Uniform distribution."""
+        # Ensure arrays are jax arrays
+        low = jnp.asarray(low)
+        high = jnp.asarray(high)
+
         return jax.random.uniform(
             self.__key,
             _shape(size, low, high),
@@ -201,6 +205,10 @@ class Generator:
         dtype: DTypeLike = int,
     ) -> IntArray:
         """Draw samples from a multinomial distribution."""
+        # Ensure arrays are jax arrays
+        n = jnp.asarray(n)
+        pvals = jnp.asarray(pvals)
+
         # JAX's shape parameter is the full shape of pvals including the
         # categories axis, so infer only the batch dimensions here.
         batch_shape = _shape(size, n, pvals[..., 0])

--- a/glass/points.py
+++ b/glass/points.py
@@ -340,8 +340,7 @@ def _sample_number_galaxies(
     xp = n.__array_namespace__()
 
     # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # clip number density at zero
     n = xp.clip(n, min=0.0)
@@ -522,8 +521,7 @@ def positions_from_delta(  # noqa: PLR0913
     xp = array_api_compat.array_namespace(ngal, delta, bias, vis, use_compat=False)
 
     # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # ensure bias_model is a function
     if not callable(bias_model):
@@ -585,13 +583,12 @@ def uniform_positions(
         xp = array_api_compat.array_namespace(ngal, use_compat=False)
 
     # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     ngal = xp.asarray(ngal)
 
     # sample number of galaxies
-    ngal_sphere = xp.asarray(rng.poisson(xp.multiply(ARCMIN2_SPHERE, ngal)))
+    ngal_sphere = rng.poisson(xp.multiply(ARCMIN2_SPHERE, ngal))
 
     # extra dimensions of the output
     dims = ngal_sphere.shape

--- a/glass/points.py
+++ b/glass/points.py
@@ -339,7 +339,6 @@ def _sample_number_galaxies(
     """
     xp = n.__array_namespace__()
 
-    # get default RNG if not given
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # clip number density at zero
@@ -520,7 +519,6 @@ def positions_from_delta(  # noqa: PLR0913
     """
     xp = array_api_compat.array_namespace(ngal, delta, bias, vis, use_compat=False)
 
-    # get default RNG if not given
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # ensure bias_model is a function
@@ -582,7 +580,6 @@ def uniform_positions(
     if xp is None:
         xp = array_api_compat.array_namespace(ngal, use_compat=False)
 
-    # get default RNG if not given
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     ngal = xp.asarray(ngal)

--- a/glass/points.py
+++ b/glass/points.py
@@ -340,13 +340,13 @@ def _sample_number_galaxies(
     xp = n.__array_namespace__()
 
     # get default RNG if not given
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # clip number density at zero
     n = xp.clip(n, min=0.0)
 
     # sample actual number in each pixel
-    return rng.poisson(n)
+    return xrng.poisson(n)
 
 
 def _sample_galaxies_per_pixel(
@@ -521,7 +521,7 @@ def positions_from_delta(  # noqa: PLR0913
     xp = array_api_compat.array_namespace(ngal, delta, bias, vis, use_compat=False)
 
     # get default RNG if not given
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # ensure bias_model is a function
     if not callable(bias_model):
@@ -537,7 +537,7 @@ def positions_from_delta(  # noqa: PLR0913
 
         n = _apply_visibility(k, n, vis)
 
-        n = _sample_number_galaxies(n, rng=rng)
+        n = _sample_number_galaxies(n, rng=xrng)
 
         yield from _sample_galaxies_per_pixel(batch, dims, k, n)
 
@@ -583,12 +583,12 @@ def uniform_positions(
         xp = array_api_compat.array_namespace(ngal, use_compat=False)
 
     # get default RNG if not given
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     ngal = xp.asarray(ngal)
 
     # sample number of galaxies
-    ngal_sphere = rng.poisson(xp.multiply(ARCMIN2_SPHERE, ngal))
+    ngal_sphere = xrng.poisson(xp.multiply(ARCMIN2_SPHERE, ngal))
 
     # extra dimensions of the output
     dims = ngal_sphere.shape
@@ -597,8 +597,8 @@ def uniform_positions(
     for k in uxpx.ndindex(dims, xp=xp):
         size = (ngal_sphere[k],)
         # sample uniformly over the sphere
-        lon = rng.uniform(-180, 180, size=size)
-        lat = uxpx.degrees(xp.asin(rng.uniform(-1, 1, size=size)))
+        lon = xrng.uniform(-180, 180, size=size)
+        lat = uxpx.degrees(xp.asin(xrng.uniform(-1, 1, size=size)))
 
         # report count
         if dims:

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -19,18 +19,7 @@ class SupportsGlassRNG(Protocol):
     """Defines the methods required for an RNG to be used within glass."""
 
     def random(self, size: int | tuple[int, ...] | None = None) -> FloatArray:
-        """
-        Return random floats in the half-open interval [0.0, 1.0).
-
-        Parameters
-        ----------
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of random floats.
-        """
+        """Return random floats in the half-open interval [0.0, 1.0)."""
 
     def normal(
         self,
@@ -38,57 +27,15 @@ class SupportsGlassRNG(Protocol):
         scale: float | FloatArray = 1.0,
         size: int | tuple[int, ...] | None = None,
     ) -> FloatArray:
-        """
-        Draw samples from a Normal distribution (mean=loc, stdev=scale).
-
-        Parameters
-        ----------
-        loc
-            Mean of the distribution.
-        scale
-            Standard deviation of the distribution.
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the normal distribution.
-
-        """
+        """Draw samples from a Normal distribution (mean=loc, stdev=scale)."""
 
     def poisson(
         self, lam: float | FloatArray, size: int | tuple[int, ...] | None = None
     ) -> IntArray:
-        """
-        Draw samples from a Poisson distribution.
-
-        Parameters
-        ----------
-        lam
-            Expected number of events.
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the Poisson distribution.
-
-        """
+        """Draw samples from a Poisson distribution."""
 
     def standard_normal(self, size: int | tuple[int, ...] | None = None) -> FloatArray:
-        """
-        Draw samples from a standard Normal distribution (mean=0, stdev=1).
-
-        Parameters
-        ----------
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the standard normal distribution.
-
-        """
+        """Draw samples from a standard Normal distribution (mean=0, stdev=1)."""
 
     def uniform(
         self,
@@ -96,23 +43,7 @@ class SupportsGlassRNG(Protocol):
         high: float | FloatArray = 1.0,
         size: int | tuple[int, ...] | None = None,
     ) -> FloatArray:
-        """
-        Draw samples from a Uniform distribution.
-
-        Parameters
-        ----------
-        low
-            Lower bound of the distribution.
-        high
-            Upper bound of the distribution.
-        size
-            Output shape.
-
-        Returns
-        -------
-            Array of samples from the uniform distribution.
-
-        """
+        """Draw samples from a Uniform distribution."""
 
     def multinomial(
         self,
@@ -120,23 +51,7 @@ class SupportsGlassRNG(Protocol):
         pvals: FloatArray,
         size: int | tuple[int, ...] | None = None,
     ) -> IntArray:
-        """
-        Draw samples from a multinomial distribution.
-
-        Parameters
-        ----------
-        n
-            Number of experiments.
-        pvals
-            Probabilities of each of the p different outcomes.
-        size
-            Output shape.
-
-        Returns
-        -------
-            The drawn sample.
-
-        """
+        """Draw samples from a multinomial distribution."""
 
 
 SEED = 42

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -13,45 +13,6 @@ if TYPE_CHECKING:
         IntArray,
         UnifiedGenerator,
     )
-
-
-class SupportsGlassRNG(Protocol):
-    """Defines the methods required for an RNG to be used within glass."""
-
-    def random(self, size: int | tuple[int, ...] | None = None) -> FloatArray:
-        """Return random floats in the half-open interval [0.0, 1.0)."""
-
-    def normal(
-        self,
-        loc: float | FloatArray = 0.0,
-        scale: float | FloatArray = 1.0,
-        size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
-        """Draw samples from a Normal distribution (mean=loc, stdev=scale)."""
-
-    def poisson(
-        self, lam: float | FloatArray, size: int | tuple[int, ...] | None = None
-    ) -> IntArray:
-        """Draw samples from a Poisson distribution."""
-
-    def standard_normal(self, size: int | tuple[int, ...] | None = None) -> FloatArray:
-        """Draw samples from a standard Normal distribution (mean=0, stdev=1)."""
-
-    def uniform(
-        self,
-        low: float | FloatArray = 0.0,
-        high: float | FloatArray = 1.0,
-        size: int | tuple[int, ...] | None = None,
-    ) -> FloatArray:
-        """Draw samples from a Uniform distribution."""
-
-    def multinomial(
-        self,
-        n: int | IntArray,
-        pvals: FloatArray,
-        size: int | tuple[int, ...] | None = None,
-    ) -> IntArray:
-        """Draw samples from a multinomial distribution."""
 
 
 SEED = 42
@@ -127,7 +88,7 @@ class Generator:
     def __init__(
         self,
         *,
-        rng: SupportsGlassRNG | None = None,
+        rng: UnifiedGenerator | None = None,
         seed: int | IntArray = SEED,
         xp: ModuleType,
     ) -> None:

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -20,11 +20,13 @@ SEED = 42
 
 def default_rng(
     *,
-    seed: int | IntArray | None = None,
+    seed: int | IntArray = SEED,
     xp: ModuleType,
 ) -> UnifiedGenerator:
     """
     Dispatch a random number generator for the array backend for a given seed.
+
+    Defaults to the GLASS default seed.
 
     Parameters
     ----------
@@ -51,23 +53,6 @@ def default_rng(
         return rng
 
     return Generator(rng=rng, xp=xp)
-
-
-def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
-    """
-    Dispatch a random number generator for the array backend for the GLASS default seed.
-
-    Parameters
-    ----------
-    xp
-        The array library backend to use for array operations.
-
-    Returns
-    -------
-        The appropriate random number generator for the array's backend.
-
-    """
-    return default_rng(seed=SEED, xp=xp)
 
 
 class Generator:

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -122,6 +122,8 @@ class Generator:
     rng: UnifiedGenerator
     xp: ModuleType
 
+    __slots__ = ("default_dtype", "rng", "xp")
+
     def __init__(
         self,
         *,
@@ -148,7 +150,6 @@ class Generator:
                 import glass.jax  # noqa: PLC0415
 
                 self.rng = glass.jax.Generator(seed=seed)
-
             else:
                 import numpy as np  # noqa: PLC0415
 

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -33,21 +33,16 @@ def default_rng(
         The appropriate random number generator for the array's backend.
 
     """
-    
     if xp.__name__ == "jax.numpy":
         import glass.jax  # noqa: PLC0415
 
         return glass.jax.Generator(seed=seed)
-    else:
-        import numpy as np
-        rng: UnifiedGenerator = np.random.default_rng(seed=seed)
-        
-        if xp.__name__ == "numpy":
-            return rng
-        
-        return Generator(rng=rng, xp=xp)
-            
 
+    import numpy as np  # noqa: PLC0415
+
+    rng = np.random.default_rng(seed=seed)
+
+    return rng if xp.__name__ == "numpy" else Generator(rng=rng, xp=xp)
 
 
 def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
@@ -96,15 +91,12 @@ class Generator:
             Seed for the random number generator.
 
         """
-        import numpy  # noqa: ICN001, PLC0415
-
         self.xp = xp
         self.default_dtype = xp.float64
         if rng is None:
             self.rng = default_rng(seed=seed, xp=xp)
         else:
             self.rng = rng
-            
 
     def random(
         self,

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from types import ModuleType
 
-    from glass._types import DTypeLike, FloatArray, IntArray, UnifiedGenerator
+    from glass._types import (
+        DTypeLike,
+        FloatArray,
+        IntArray,
+        SupportsGlassRNG,
+        UnifiedGenerator,
+    )
 
 
 SEED = 42
@@ -36,13 +42,16 @@ def default_rng(
     if xp.__name__ == "jax.numpy":
         import glass.jax  # noqa: PLC0415
 
-        return glass.jax.Generator(seed=seed)  # ty: ignore[invalid-return-type]
+        return glass.jax.Generator(seed=seed)
 
     import numpy as np  # noqa: PLC0415
 
     rng = np.random.default_rng(seed=seed)
 
-    return rng if xp.__name__ == "numpy" else Generator(rng=rng, xp=xp)  # ty: ignore[invalid-return-type]
+    if xp.__name__ == "numpy":
+        return rng
+
+    return Generator(rng=rng, xp=xp)
 
 
 def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
@@ -76,9 +85,9 @@ class Generator:
     def __init__(
         self,
         *,
-        xp: ModuleType,
-        rng: UnifiedGenerator | None = None,
+        rng: SupportsGlassRNG | None = None,
         seed: int | IntArray = SEED,
+        xp: ModuleType,
     ) -> None:
         """
         Initialize the Generator.
@@ -92,17 +101,13 @@ class Generator:
 
         """
         self.xp = xp
-        self.default_dtype = xp.float64
-        if rng is None:
-            self.rng = default_rng(seed=seed, xp=xp)
-        else:
-            self.rng = rng
+        self.default_dtype: DTypeLike = xp.float64
+        self.rng = default_rng(seed=seed, xp=xp) if rng is None else rng
 
     def random(
         self,
         size: int | tuple[int, ...] | None = None,
         dtype: DTypeLike | None = None,
-        out: FloatArray | None = None,
     ) -> FloatArray:
         """
         Return random floats in the half-open interval [0.0, 1.0).
@@ -122,7 +127,7 @@ class Generator:
 
         """
         dtype = dtype if dtype is not None else self.default_dtype
-        return self.xp.asarray(self.rng.random(size, out), dtype=dtype)
+        return self.xp.asarray(self.rng.random(size), dtype=dtype)
 
     def normal(
         self,
@@ -175,7 +180,6 @@ class Generator:
         self,
         size: int | tuple[int, ...] | None = None,
         dtype: DTypeLike | None = None,
-        out: FloatArray | None = None,
     ) -> FloatArray:
         """
         Draw samples from a standard Normal distribution (mean=0, stdev=1).
@@ -195,7 +199,7 @@ class Generator:
 
         """
         dtype = dtype if dtype is not None else self.default_dtype
-        return self.xp.asarray(self.rng.standard_normal(size, out), dtype=dtype)
+        return self.xp.asarray(self.rng.standard_normal(size), dtype=dtype)
 
     def uniform(
         self,

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -36,13 +36,13 @@ def default_rng(
     if xp.__name__ == "jax.numpy":
         import glass.jax  # noqa: PLC0415
 
-        return glass.jax.Generator(seed=seed)
+        return glass.jax.Generator(seed=seed)  # ty: ignore[invalid-return-type]
 
     import numpy as np  # noqa: PLC0415
 
     rng = np.random.default_rng(seed=seed)
 
-    return rng if xp.__name__ == "numpy" else Generator(rng=rng, xp=xp)
+    return rng if xp.__name__ == "numpy" else Generator(rng=rng, xp=xp)  # ty: ignore[invalid-return-type]
 
 
 def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
@@ -64,10 +64,10 @@ def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
 
 class Generator:
     """
-    NumPy random number generator returning Arrays of the given backend.
+    Wrapper for a random number generator returning Arrays of the given backend.
 
-    This class wraps NumPy's random number generator and returns arrays compatible
-    with the provided backend.
+    This class wraps random number generators which match the glass UnifiedGenerator
+    protocol and returns arrays compatible with the provided backend.
 
     """
 
@@ -122,7 +122,7 @@ class Generator:
 
         """
         dtype = dtype if dtype is not None else self.default_dtype
-        return self.xp.asarray(self.rng.random(size, out), dtype=dtype)  # ty: ignore[no-matching-overload]
+        return self.xp.asarray(self.rng.random(size, out), dtype=dtype)
 
     def normal(
         self,
@@ -195,7 +195,7 @@ class Generator:
 
         """
         dtype = dtype if dtype is not None else self.default_dtype
-        return self.xp.asarray(self.rng.standard_normal(size, out), dtype=dtype)  # ty: ignore[no-matching-overload]
+        return self.xp.asarray(self.rng.standard_normal(size, out), dtype=dtype)
 
     def uniform(
         self,

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -33,15 +33,21 @@ def default_rng(
         The appropriate random number generator for the array's backend.
 
     """
+    
     if xp.__name__ == "jax.numpy":
         import glass.jax  # noqa: PLC0415
 
         return glass.jax.Generator(seed=seed)
+    else:
+        import numpy as np
+        rng: UnifiedGenerator = np.random.default_rng(seed=seed)
+        
+        if xp.__name__ == "numpy":
+            return rng
+        
+        return Generator(rng=rng, xp=xp)
+            
 
-    if xp.__name__ == "numpy":
-        return xp.random.default_rng(seed=seed)
-
-    return Generator(xp=xp, seed=seed)
 
 
 def rng_dispatcher(*, xp: ModuleType) -> UnifiedGenerator:
@@ -70,11 +76,13 @@ class Generator:
 
     """
 
-    __slots__ = ("np", "rng", "xp")
+    __slots__ = ("default_dtype", "rng", "xp")
 
     def __init__(
         self,
+        *,
         xp: ModuleType,
+        rng: UnifiedGenerator | None = None,
         seed: int | IntArray = SEED,
     ) -> None:
         """
@@ -91,8 +99,12 @@ class Generator:
         import numpy  # noqa: ICN001, PLC0415
 
         self.xp = xp
-        self.np = numpy
-        self.rng = self.np.random.default_rng(seed=seed)
+        self.default_dtype = xp.float64
+        if rng is None:
+            self.rng = default_rng(seed=seed, xp=xp)
+        else:
+            self.rng = rng
+            
 
     def random(
         self,
@@ -117,8 +129,8 @@ class Generator:
             Array of random floats.
 
         """
-        dtype = dtype if dtype is not None else self.np.float64
-        return self.xp.asarray(self.rng.random(size, dtype, out))  # ty: ignore[no-matching-overload]
+        dtype = dtype if dtype is not None else self.default_dtype
+        return self.xp.asarray(self.rng.random(size, out), dtype=dtype)  # ty: ignore[no-matching-overload]
 
     def normal(
         self,
@@ -190,8 +202,8 @@ class Generator:
             Array of samples from the standard normal distribution.
 
         """
-        dtype = dtype if dtype is not None else self.np.float64
-        return self.xp.asarray(self.rng.standard_normal(size, dtype, out))  # ty: ignore[no-matching-overload]
+        dtype = dtype if dtype is not None else self.default_dtype
+        return self.xp.asarray(self.rng.standard_normal(size, out), dtype=dtype)  # ty: ignore[no-matching-overload]
 
     def uniform(
         self,

--- a/glass/rng.py
+++ b/glass/rng.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -11,9 +11,132 @@ if TYPE_CHECKING:
         DTypeLike,
         FloatArray,
         IntArray,
-        SupportsGlassRNG,
         UnifiedGenerator,
     )
+
+
+class SupportsGlassRNG(Protocol):
+    """Defines the methods required for an RNG to be used within glass."""
+
+    def random(self, size: int | tuple[int, ...] | None = None) -> FloatArray:
+        """
+        Return random floats in the half-open interval [0.0, 1.0).
+
+        Parameters
+        ----------
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of random floats.
+        """
+
+    def normal(
+        self,
+        loc: float | FloatArray = 0.0,
+        scale: float | FloatArray = 1.0,
+        size: int | tuple[int, ...] | None = None,
+    ) -> FloatArray:
+        """
+        Draw samples from a Normal distribution (mean=loc, stdev=scale).
+
+        Parameters
+        ----------
+        loc
+            Mean of the distribution.
+        scale
+            Standard deviation of the distribution.
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the normal distribution.
+
+        """
+
+    def poisson(
+        self, lam: float | FloatArray, size: int | tuple[int, ...] | None = None
+    ) -> IntArray:
+        """
+        Draw samples from a Poisson distribution.
+
+        Parameters
+        ----------
+        lam
+            Expected number of events.
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the Poisson distribution.
+
+        """
+
+    def standard_normal(self, size: int | tuple[int, ...] | None = None) -> FloatArray:
+        """
+        Draw samples from a standard Normal distribution (mean=0, stdev=1).
+
+        Parameters
+        ----------
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the standard normal distribution.
+
+        """
+
+    def uniform(
+        self,
+        low: float | FloatArray = 0.0,
+        high: float | FloatArray = 1.0,
+        size: int | tuple[int, ...] | None = None,
+    ) -> FloatArray:
+        """
+        Draw samples from a Uniform distribution.
+
+        Parameters
+        ----------
+        low
+            Lower bound of the distribution.
+        high
+            Upper bound of the distribution.
+        size
+            Output shape.
+
+        Returns
+        -------
+            Array of samples from the uniform distribution.
+
+        """
+
+    def multinomial(
+        self,
+        n: int | IntArray,
+        pvals: FloatArray,
+        size: int | tuple[int, ...] | None = None,
+    ) -> IntArray:
+        """
+        Draw samples from a multinomial distribution.
+
+        Parameters
+        ----------
+        n
+            Number of experiments.
+        pvals
+            Probabilities of each of the p different outcomes.
+        size
+            Output shape.
+
+        Returns
+        -------
+            The drawn sample.
+
+        """
 
 
 SEED = 42
@@ -76,11 +199,13 @@ class Generator:
     Wrapper for a random number generator returning Arrays of the given backend.
 
     This class wraps random number generators which match the glass UnifiedGenerator
-    protocol and returns arrays compatible with the provided backend.
+    type and returns arrays compatible with the provided backend.
 
     """
 
-    __slots__ = ("default_dtype", "rng", "xp")
+    default_dtype: DTypeLike
+    rng: UnifiedGenerator
+    xp: ModuleType
 
     def __init__(
         self,
@@ -101,8 +226,20 @@ class Generator:
 
         """
         self.xp = xp
-        self.default_dtype: DTypeLike = xp.float64
-        self.rng = default_rng(seed=seed, xp=xp) if rng is None else rng
+        self.default_dtype = xp.float64
+
+        if rng is None:
+            if xp.__name__ == "jax.numpy":
+                import glass.jax  # noqa: PLC0415
+
+                self.rng = glass.jax.Generator(seed=seed)
+
+            else:
+                import numpy as np  # noqa: PLC0415
+
+                self.rng = np.random.default_rng(seed=seed)
+        else:
+            self.rng = rng
 
     def random(
         self,
@@ -118,8 +255,6 @@ class Generator:
             Output shape.
         dtype
             Desired data type.
-        out
-            Optional output array.
 
         Returns
         -------
@@ -190,8 +325,6 @@ class Generator:
             Output shape.
         dtype
             Desired data type.
-        out
-            Optional output array.
 
         Returns
         -------

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -97,8 +97,7 @@ def triaxial_axis_ratio(
     xi = xp.asarray(xi)
 
     # default RNG if not provided
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # get size from inputs if not explicitly provided
     if size is None:
@@ -186,6 +185,7 @@ def ellipticity_ryden04(  # noqa: PLR0913
     sigma_gamma = xp.asarray(sigma_gamma)
 
     # default RNG if not provided
+    rng = glass.rng.Generator(rng=rng, xp=xp)
     if rng is None:
         rng = glass.rng.rng_dispatcher(xp=xp)
 
@@ -266,8 +266,7 @@ def ellipticity_gaussian(
     )
 
     # default RNG if not provided
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # allocate flattened output array
     eps = xp.empty(xp.sum(count_broadcasted), dtype=xp.complex128)
@@ -329,8 +328,7 @@ def ellipticity_intnorm(
     if xp is None:
         xp = array_api_compat.array_namespace(count, sigma, use_compat=False)
     # default RNG if not provided
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # bring inputs into common shape
     count_broadcasted, sigma_broadcasted = xp.broadcast_arrays(
@@ -403,8 +401,7 @@ def resample_shapes(
 
     xp = epsilon.__array_namespace__()
 
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # get absolute value of epsilon
     r = xp.hypot(xp.real(epsilon), xp.imag(epsilon))

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -96,7 +96,6 @@ def triaxial_axis_ratio(
     zeta = xp.asarray(zeta)
     xi = xp.asarray(xi)
 
-    # default RNG if not provided
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # get size from inputs if not explicitly provided
@@ -184,7 +183,6 @@ def ellipticity_ryden04(  # noqa: PLR0913
     gamma = xp.asarray(gamma)
     sigma_gamma = xp.asarray(sigma_gamma)
 
-    # default RNG if not provided
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # default size if not given
@@ -263,7 +261,6 @@ def ellipticity_gaussian(
         xp.asarray(sigma),
     )
 
-    # default RNG if not provided
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # allocate flattened output array
@@ -325,7 +322,6 @@ def ellipticity_intnorm(
     """
     if xp is None:
         xp = array_api_compat.array_namespace(count, sigma, use_compat=False)
-    # default RNG if not provided
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # bring inputs into common shape

--- a/glass/shapes.py
+++ b/glass/shapes.py
@@ -97,17 +97,17 @@ def triaxial_axis_ratio(
     xi = xp.asarray(xi)
 
     # default RNG if not provided
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # get size from inputs if not explicitly provided
     if size is None:
         size = xp.broadcast_arrays(zeta, xi)[0].shape
 
     # draw random viewing angle (theta, phi)
-    cos2_theta = rng.uniform(low=-1.0, high=1.0, size=size)
+    cos2_theta = xrng.uniform(low=-1.0, high=1.0, size=size)
     cos2_theta *= cos2_theta
     sin2_theta = 1 - cos2_theta
-    cos2_phi = xp.cos(rng.uniform(low=0.0, high=2 * math.pi, size=size))
+    cos2_phi = xp.cos(xrng.uniform(low=0.0, high=2 * math.pi, size=size))
     cos2_phi *= cos2_phi
     sin2_phi = 1 - cos2_phi
 
@@ -185,9 +185,7 @@ def ellipticity_ryden04(  # noqa: PLR0913
     sigma_gamma = xp.asarray(sigma_gamma)
 
     # default RNG if not provided
-    rng = glass.rng.Generator(rng=rng, xp=xp)
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # default size if not given
     if size is None:
@@ -202,22 +200,22 @@ def ellipticity_ryden04(  # noqa: PLR0913
 
     # draw gamma and epsilon from truncated normal -- eq.s (10)-(11)
     # first sample unbounded normal, then rejection sample truncation
-    eps = rng.normal(mu, sigma, size=size)
+    eps = xrng.normal(mu, sigma, size=size)
     while xp.any(bad := eps > 0):
-        eps = xpx.at(eps)[bad].set(rng.normal(mu[bad], sigma[bad]))
-    gam = rng.normal(gamma, sigma_gamma, size=size)
+        eps = xpx.at(eps)[bad].set(xrng.normal(mu[bad], sigma[bad]))
+    gam = xrng.normal(gamma, sigma_gamma, size=size)
     while xp.any(bad := (gam < 0) | (gam > 1)):
-        gam = xpx.at(gam)[bad].set(rng.normal(gamma[bad], sigma_gamma[bad]))
+        gam = xpx.at(gam)[bad].set(xrng.normal(gamma[bad], sigma_gamma[bad]))
 
     # compute triaxial axis ratios zeta = B/A, xi = C/A
     zeta = -xp.expm1(eps)
     xi = (1 - gam) * zeta
 
     # random projection of random triaxial ellipsoid
-    q = triaxial_axis_ratio(zeta, xi, rng=rng)
+    q = triaxial_axis_ratio(zeta, xi, rng=xrng)
 
     # assemble ellipticity with random complex phase
-    e = xp.exp(1j * rng.uniform(0, 2 * math.pi, size=q.shape))
+    e = xp.exp(1j * xrng.uniform(0, 2 * math.pi, size=q.shape))
     e *= (1 - q) / (1 + q)
 
     # return the ellipticity
@@ -266,7 +264,7 @@ def ellipticity_gaussian(
     )
 
     # default RNG if not provided
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # allocate flattened output array
     eps = xp.empty(xp.sum(count_broadcasted), dtype=xp.complex128)
@@ -275,12 +273,12 @@ def ellipticity_gaussian(
     # reject those where abs(e) > 0
     i = 0
     for k in uxpx.ndindex(count_broadcasted.shape, xp=xp):
-        e = _populate_random_complex_array(count_broadcasted[k], rng=rng)
+        e = _populate_random_complex_array(count_broadcasted[k], rng=xrng)
         e *= sigma_broadcasted[k]
         r = xp.abs(e) > 1
         while xp.count_nonzero(r) > 0:
             e = xpx.at(e)[r].set(
-                _populate_random_complex_array(xp.count_nonzero(r), rng=rng),
+                _populate_random_complex_array(xp.count_nonzero(r), rng=xrng),
             )
             e = xpx.at(e)[r].multiply(sigma_broadcasted[k])
             r = xp.abs(e) > 1
@@ -328,7 +326,7 @@ def ellipticity_intnorm(
     if xp is None:
         xp = array_api_compat.array_namespace(count, sigma, use_compat=False)
     # default RNG if not provided
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # bring inputs into common shape
     count_broadcasted, sigma_broadcasted = xp.broadcast_arrays(
@@ -353,7 +351,7 @@ def ellipticity_intnorm(
     # sample complex ellipticities
     i = 0
     for k in uxpx.ndindex(count_broadcasted.shape, xp=xp):
-        e = _populate_random_complex_array(count_broadcasted[k], rng=rng)
+        e = _populate_random_complex_array(count_broadcasted[k], rng=xrng)
         e *= sigma_eta[k]
         r = xp.hypot(xp.real(e), xp.imag(e))
         e *= xp.where(
@@ -401,7 +399,7 @@ def resample_shapes(
 
     xp = epsilon.__array_namespace__()
 
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # get absolute value of epsilon
     r = xp.hypot(xp.real(epsilon), xp.imag(epsilon))
@@ -426,4 +424,4 @@ def resample_shapes(
         )
 
     # assign random orientations to shapes
-    return r * xp.exp(1j * rng.uniform(0, 2 * xp.pi, size=r.shape))
+    return r * xp.exp(1j * xrng.uniform(0, 2 * xp.pi, size=r.shape))

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -1043,7 +1043,7 @@ def distribute(
     xp = redshifts.__array_namespace__()
 
     # get default RNG if not given
-    rng = glass.rng.Generator(rng=rng, xp=xp)
+    xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # flatten redshifts but store shape
     shape = redshifts.shape
@@ -1087,7 +1087,7 @@ def distribute(
         # simulate a draw from a categorial distribution by
         # drawing a single event from a multinomial distribution
         # and finding the bin in which the event landed
-        index = xp.argmax(rng.multinomial(1, weights), axis=1)
+        index = xp.argmax(xrng.multinomial(1, weights), axis=1)
 
         # subtract 1 so that the "outside" shell is -1
         index -= 1

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -1042,7 +1042,6 @@ def distribute(
     """
     xp = redshifts.__array_namespace__()
 
-    # get default RNG if not given
     xrng = glass.rng.Generator(rng=rng, xp=xp)
 
     # flatten redshifts but store shape

--- a/glass/shells.py
+++ b/glass/shells.py
@@ -1043,8 +1043,7 @@ def distribute(
     xp = redshifts.__array_namespace__()
 
     # get default RNG if not given
-    if rng is None:
-        rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.Generator(rng=rng, xp=xp)
 
     # flatten redshifts but store shape
     shape = redshifts.shape

--- a/tests/core/test_array_api_utils.py
+++ b/tests/core/test_array_api_utils.py
@@ -45,6 +45,14 @@ def test_init() -> None:
 
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
+def test_init_mix_of_backends() -> None:
+    import array_api_strict
+
+    rng = glass.rng.Generator(rng=np.random.default_rng(), xp=array_api_strict)
+    assert isinstance(rng, glass.rng.Generator)
+
+
+@pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
 def test_random() -> None:
     import array_api_strict
 

--- a/tests/core/test_array_api_utils.py
+++ b/tests/core/test_array_api_utils.py
@@ -16,7 +16,7 @@ HAVE_JAX = importlib.util.find_spec("jax") is not None
 
 
 def test_rng_dispatcher_numpy() -> None:
-    rng = glass.rng.rng_dispatcher(xp=np)
+    rng = glass.rng.default_rng(xp=np)
     assert isinstance(rng, np.random.Generator)
 
 
@@ -24,7 +24,7 @@ def test_rng_dispatcher_numpy() -> None:
 def test_rng_dispatcher_jax() -> None:
     import jax.numpy as jnp
 
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     assert isinstance(rng, glass.jax.Generator)
 
 
@@ -32,7 +32,7 @@ def test_rng_dispatcher_jax() -> None:
 def test_rng_dispatcher_array_api_strict() -> None:
     import array_api_strict
 
-    rng = glass.rng.rng_dispatcher(xp=array_api_strict)
+    rng = glass.rng.default_rng(xp=array_api_strict)
     assert isinstance(rng, glass.rng.Generator)
 
 
@@ -73,7 +73,7 @@ def test_init_mix_of_backends_jax_np() -> None:
 def test_random() -> None:
     import array_api_strict
 
-    rng = glass.rng.rng_dispatcher(xp=array_api_strict)
+    rng = glass.rng.default_rng(xp=array_api_strict)
     rvs = rng.random(size=10_000)
     assert rvs.shape == (10_000,)
     assert array_api_strict.min(rvs) >= 0.0
@@ -85,7 +85,7 @@ def test_random() -> None:
 def test_normal() -> None:
     import array_api_strict
 
-    rng = glass.rng.rng_dispatcher(xp=array_api_strict)
+    rng = glass.rng.default_rng(xp=array_api_strict)
     rvs = rng.normal(1, 2, size=10_000)
     assert rvs.shape == (10_000,)
     assert isinstance(rvs, array_api_strict._array_object.Array)
@@ -95,7 +95,7 @@ def test_normal() -> None:
 def test_standard_normal() -> None:
     import array_api_strict
 
-    rng = glass.rng.rng_dispatcher(xp=array_api_strict)
+    rng = glass.rng.default_rng(xp=array_api_strict)
     rvs = rng.standard_normal(size=10_000)
     assert rvs.shape == (10_000,)
     assert isinstance(rvs, array_api_strict._array_object.Array)
@@ -105,7 +105,7 @@ def test_standard_normal() -> None:
 def test_poisson() -> None:
     import array_api_strict
 
-    rng = glass.rng.rng_dispatcher(xp=array_api_strict)
+    rng = glass.rng.default_rng(xp=array_api_strict)
     rvs = rng.poisson(lam=1, size=10_000)
     assert rvs.shape == (10_000,)
     assert isinstance(rvs, array_api_strict._array_object.Array)
@@ -115,7 +115,7 @@ def test_poisson() -> None:
 def test_uniform() -> None:
     import array_api_strict
 
-    rng = glass.rng.rng_dispatcher(xp=array_api_strict)
+    rng = glass.rng.default_rng(xp=array_api_strict)
     rvs = rng.uniform(size=10_000)
     assert rvs.shape == (10_000,)
     assert array_api_strict.min(rvs) >= 0.0

--- a/tests/core/test_array_api_utils.py
+++ b/tests/core/test_array_api_utils.py
@@ -45,11 +45,28 @@ def test_init() -> None:
 
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
-def test_init_mix_of_backends() -> None:
-    import array_api_strict
+def test_init_mix_of_backends_np_array_api_strict() -> None:
+    import array_api_strict as xp
 
-    rng = glass.rng.Generator(rng=np.random.default_rng(), xp=array_api_strict)
-    assert isinstance(rng, glass.rng.Generator)
+    rng = glass.rng.Generator(rng=np.random.default_rng(), xp=xp)
+    assert rng.random(1).__array_namespace__().__name__ == "array_api_strict"
+    assert rng.poisson(1).__array_namespace__().__name__ == "array_api_strict"
+    assert rng.standard_normal(1).__array_namespace__().__name__ == "array_api_strict"
+    assert rng.uniform().__array_namespace__().__name__ == "array_api_strict"
+    assert (
+        rng.multinomial(1, xp.ones(2)).__array_namespace__().__name__
+        == "array_api_strict"
+    )
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="test requires jax")
+def test_init_mix_of_backends_jax_np() -> None:
+    rng = glass.rng.Generator(rng=glass.jax.Generator(42), xp=np)
+    assert rng.random(1).__array_namespace__().__name__ == "numpy"
+    assert rng.poisson(1).__array_namespace__().__name__ == "numpy"
+    assert rng.standard_normal(1).__array_namespace__().__name__ == "numpy"
+    assert rng.uniform().__array_namespace__().__name__ == "numpy"
+    assert rng.multinomial(1, np.ones(2)).__array_namespace__().__name__ == "numpy"
 
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -369,13 +369,13 @@ def test_generate_grf(xp: ModuleType) -> None:
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
     # requires resetting the RNG for reproducibility
-    rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.default_rng(xp=xp)
     gaussian_fields = list(glass.fields._generate_grf(gls, nside, rng=rng))
 
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
     # requires resetting the RNG for reproducibility
-    rng = glass.rng.rng_dispatcher(xp=xp)
+    rng = glass.rng.default_rng(xp=xp)
     new_gaussian_fields = list(
         glass.fields._generate_grf(gls, nside, ncorr=ncorr, rng=rng),
     )

--- a/tests/core/test_healpix.py
+++ b/tests/core/test_healpix.py
@@ -409,7 +409,7 @@ def test_randang(
         healpix_inputs.nside,
         ipix,
         lonlat=lonlat,
-        rng=glass.rng.rng_dispatcher(xp=np),
+        rng=glass.rng.default_rng(xp=np),
     )
     new = hp.randang(
         healpix_inputs.nside,

--- a/tests/core/test_jax.py
+++ b/tests/core/test_jax.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def test_init() -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     assert isinstance(rng, Generator)
     assert isinstance(rng.key, jax.Array)
     assert jax.dtypes.issubdtype(rng.key.dtype, jax.dtypes.prng_key)
@@ -37,7 +37,7 @@ def test_from_key() -> None:
 
 
 def test_key() -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     rngkey, outkey = jax.random.split(rng.key, 2)  # ty: ignore[unresolved-attribute]
     key = rng.split()  # ty: ignore[unresolved-attribute]
     assert jnp.all(rng.key == rngkey)  # ty: ignore[unresolved-attribute]
@@ -45,7 +45,7 @@ def test_key() -> None:
 
 
 def test_spawn() -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key, *subkeys = jax.random.split(rng.key, 4)  # ty: ignore[unresolved-attribute]
     subrngs = rng.spawn(3)  # ty: ignore[unresolved-attribute]
     assert rng.key == key  # ty: ignore[unresolved-attribute]
@@ -73,7 +73,7 @@ def test_random(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
 ) -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.random(size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
@@ -110,7 +110,7 @@ def test_normal(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
 ) -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.normal(loc=loc, scale=scale, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
@@ -120,7 +120,7 @@ def test_normal(
 
 def test_normal_shape_mismatch_explicit() -> None:
     """Explicit size incompatible with input broadcast shape."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="is incompatible with input shapes that broadcast to",
@@ -130,7 +130,7 @@ def test_normal_shape_mismatch_explicit() -> None:
 
 def test_normal_shape_mismatch_broadcast() -> None:
     """Input shapes that cannot be broadcast together."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="Incompatible shapes for broadcasting",
@@ -155,7 +155,7 @@ def test_standard_normal(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
 ) -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.standard_normal(size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
@@ -185,7 +185,7 @@ def test_poisson(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
 ) -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.poisson(lam=lam, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
@@ -195,7 +195,7 @@ def test_poisson(
 
 def test_poisson_shape_mismatch_explicit() -> None:
     """Explicit size incompatible with input broadcast shape."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="is incompatible with input shapes that broadcast to",
@@ -232,7 +232,7 @@ def test_uniform(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
 ) -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.uniform(low=low, high=high, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
@@ -244,7 +244,7 @@ def test_uniform(
 
 def test_uniform_shape_mismatch_explicit() -> None:
     """Explicit size incompatible with input broadcast shape."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="is incompatible with input shapes that broadcast to",
@@ -254,7 +254,7 @@ def test_uniform_shape_mismatch_explicit() -> None:
 
 def test_uniform_shape_mismatch_broadcast() -> None:
     """Input shapes that cannot be broadcast together."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="Incompatible shapes for broadcasting",
@@ -285,7 +285,7 @@ def test_multinomial(
     size_input: int | tuple[int, ...] | None,
     shape_output: tuple[int, ...],
 ) -> None:
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     key = rng.key  # ty: ignore[unresolved-attribute]
     rvs = rng.multinomial(n, pvals, size=size_input)
     assert rng.key != key  # ty: ignore[unresolved-attribute]
@@ -297,7 +297,7 @@ def test_multinomial(
 
 def test_multinomial_shape_mismatch_explicit() -> None:
     """Explicit size incompatible with input broadcast shape."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="is incompatible with input shapes that broadcast to",
@@ -307,7 +307,7 @@ def test_multinomial_shape_mismatch_explicit() -> None:
 
 def test_multinomial_shape_mismatch_broadcast() -> None:
     """Input shapes that cannot be broadcast together."""
-    rng = glass.rng.rng_dispatcher(xp=jnp)
+    rng = glass.rng.default_rng(xp=jnp)
     with pytest.raises(
         ValueError,
         match="Incompatible shapes for broadcasting",

--- a/tests/fixtures/generators.py
+++ b/tests/fixtures/generators.py
@@ -36,4 +36,4 @@ def urng(xp: ModuleType) -> UnifiedGenerator:
     Must be used with the `xp` fixture. Use `rng` for non array API tests.
 
     """
-    return glass.rng.rng_dispatcher(xp=xp)
+    return glass.rng.default_rng(xp=xp)

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -28,4 +28,4 @@ def urng(xpb: ModuleType) -> UnifiedGenerator:
     Must be used with the `xp` fixture.
 
     """
-    return glass.rng.rng_dispatcher(xp=xpb)
+    return glass.rng.default_rng(xp=xpb)


### PR DESCRIPTION
# Description

- Alters the existing `glass.rng.Generator` to allow it to wrap more than just NumPy RNGs.
- Adds a new RNG protocol to ensure the wrapped rng in `glass.rng.Generator` defines the required methods.
- Updates how rngs are handles within functions to ensure they always return the required array backend.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1145 

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Changed: `glass.rng.Generator` class now wraps returned values ensuring all methods return the correct array backend.

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [x] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
