### PR TITLE
gh-1170: Increase timeout to `25` mins for examples

### DIFF
--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run examples
         run: uv run nox -s examples
-        timeout-minutes: 20
+        timeout-minutes: 25
         env:
           FORCE_COLOR: 1
 


### PR DESCRIPTION
# Description

The workflow is failing occasionally due to timeout issues so will try increasing from `20` to `25` minutes.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1170

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [ ] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
