### PR TITLE
gh-1122: Document cprofile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,7 +290,7 @@ benchmark tests. To run the profiler pass the additional flag
 want to limit the number of regression tests you profile by filtering with
 `-k <test_name>`. Read the
 [pytest-benchmark docs](https://pytest-benchmark.readthedocs.io/en/latest/usage.html)
-ffor more details.
+for more details.
 
 ## Failure of the `Regression tests / Regression test` Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,11 +284,11 @@ uv run nox -s regression-tests -- <initial-state-revision> \
 
 #### Profiling regression tests
 
-pytest-benchmark comes with a cprofile integration making it easy to profile
-benchmark tests. To run the profiler pass the additional flag
-`--benchmark-cprofile` to pytest. To ensure the output is readable you'll likely
-want to limit the number of regression tests you profile by filtering with
-`-k <test_name>`. Read the
+pytest-benchmark comes with a cProfile integration making it easy to profile
+benchmark tests. To run the profiler, pass the additional flag
+`--benchmark-cprofile` to pytest. To ensure the output is readable, you'll
+likely want to limit the number of regression tests you profile by filtering
+with `-k <test_name>`. See the
 [pytest-benchmark docs](https://pytest-benchmark.readthedocs.io/en/latest/usage.html)
 for more details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,6 +282,16 @@ uv run nox -s regression-tests -- <initial-state-revision> \
 > [01e6e4c](https://github.com/glass-dev/glass/pull/911/changes/01e6e4c248e96e4683ca651edffa2fd4d845502f)
 > for an example.
 
+#### Profiling regression tests
+
+pytest-benchmark comes with a cprofile integration making it easy to profile
+benchmark tests. To run the profiler pass the additional flag
+`--benchmark-cprofile` to pytest. To ensure the output is readable you'll likely
+want to limit the number of regression tests you profile by filtering with
+`-k <test_name>`. Read the
+[pytest-benchmark docs](https://pytest-benchmark.readthedocs.io/en/latest/usage.html)
+ffor more details.
+
 ## Failure of the `Regression tests / Regression test` Workflow
 
 <!-- prettier-ignore -->

--- a/noxfile.py
+++ b/noxfile.py
@@ -133,6 +133,7 @@ def coverage_regression(session: nox.Session) -> None:
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs,
         env=os.environ,
+        success_codes=[0,5],
     )
 
 
@@ -280,6 +281,7 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare-fail=mean:5%",
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs[2:],
+        success_codes=[0,5],
     )
 
     session.log("Running unstable regression tests")
@@ -293,4 +295,5 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare-fail=mean:0.0005",
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs[2:],
+        success_codes=[0,5],
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -269,6 +269,9 @@ def regression_tests(session: nox.Session) -> None:
         *session.posargs[2:],
     )
 
+    # Allow no tests to have been found if the tests have been filtered by the user
+    success_codes = [0, 5] if "-k" in session.posargs[2:] else [0]
+
     session.log(f"Comparing {before_revision} benchmark to revision {after_revision}")
     session.install(f"git+{GLASS_REPO_URL}@{after_revision}")
     session.log("Running stable regression tests")
@@ -281,7 +284,7 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare-fail=mean:5%",
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs[2:],
-        success_codes=[0, 5],
+        success_codes=success_codes,
     )
 
     session.log("Running unstable regression tests")
@@ -295,5 +298,5 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare-fail=mean:0.0005",
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs[2:],
-        success_codes=[0, 5],
+        success_codes=success_codes,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -133,7 +133,7 @@ def coverage_regression(session: nox.Session) -> None:
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs,
         env=os.environ,
-        success_codes=[0,5],
+        success_codes=[0, 5],
     )
 
 
@@ -281,7 +281,7 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare-fail=mean:5%",
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs[2:],
-        success_codes=[0,5],
+        success_codes=[0, 5],
     )
 
     session.log("Running unstable regression tests")
@@ -295,5 +295,5 @@ def regression_tests(session: nox.Session) -> None:
         "--benchmark-compare-fail=mean:0.0005",
         *SHARED_PYTEST_BENCHMARK_FLAGS,
         *session.posargs[2:],
-        success_codes=[0,5],
+        success_codes=[0, 5],
     )


### PR DESCRIPTION
# Description

- Adds some documentation on how to run cprofile via pytest-benchmark.
- Allows running the cprofile via the nox regression tests.

Closes: #1122

## Changelog entry

Added: Ability to run the pytest-benchmark cprofiler via nox regression tests

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
