### PR TITLE
gh-1172: Allow regression tests to be run from forks

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -26,6 +26,7 @@ on:
       - pyproject.toml
     branches:
       - main
+      - paddy/issue-1172
     types:
       - opened
       - ready_for_review

--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -47,8 +47,8 @@ jobs:
           persist-credentials: false
           ref: >-
             ${{ github.event_name == 'pull_request' &&
-            format('refs/pull/{0}/head', github.event.pull_request.number) ||
-            (inputs.head_ref || github.ref) }}
+            github.event.pull_request.head.sha || (inputs.head_ref ||
+            github.ref) }}
 
       - name: Set up uv
         # yamllint disable-line rule:line-length

--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -26,7 +26,6 @@ on:
       - pyproject.toml
     branches:
       - main
-      - paddy/issue-1172
     types:
       - opened
       - ready_for_review

--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -45,6 +45,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: >-
+            ${{ github.event_name == 'pull_request' &&
+            format('refs/pull/{0}/head', github.event.pull_request.number) ||
+            (inputs.head_ref || github.ref) }}
 
       - name: Set up uv
         # yamllint disable-line rule:line-length
@@ -68,5 +72,7 @@ jobs:
         env:
           ARRAY_BACKEND: all
           BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-          HEAD_REF: ${{ inputs.head_ref || github.event.pull_request.head.ref }}
+          HEAD_REF: >-
+            ${{ github.event_name == 'pull_request' && 'local' ||
+            inputs.head_ref }}
           FORCE_COLOR: 1

--- a/noxfile.py
+++ b/noxfile.py
@@ -269,7 +269,12 @@ def regression_tests(session: nox.Session) -> None:
     )
 
     session.log(f"Comparing {before_revision} benchmark to revision {after_revision}")
-    session.install(f"git+{GLASS_REPO_URL}@{after_revision}")
+    if after_revision == "local":
+        session.log("Installing after-revision from local checkout")
+        session.install(".")
+    else:
+        session.install(f"git+{GLASS_REPO_URL}@{after_revision}")
+
     session.log("Running stable regression tests")
     session.run(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -271,9 +271,9 @@ def regression_tests(session: nox.Session) -> None:
     session.log(f"Comparing {before_revision} benchmark to revision {after_revision}")
     if after_revision == "local":
         session.log("Installing after-revision from local checkout")
-        session.install(".")
+        session.install("--force-reinstall", ".")
     else:
-        session.install(f"git+{GLASS_REPO_URL}@{after_revision}")
+        session.install("--force-reinstall", f"git+{GLASS_REPO_URL}@{after_revision}")
 
     session.log("Running stable regression tests")
     session.run(


### PR DESCRIPTION
# Description

I noticed in #1021 that the regression tests couldn't be run from forks. This PR attempts to address that by using the `refs` syntax that the GitHub CLI uses, e.g. `gh pr checkout`.

Tested from a fork https://github.com/glass-dev/glass/pull/1179.

<!-- for user facing bugs -->
Fixes: #1172

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: The regression tests are now run from forks

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [X] Have you added a one-liner changelog entry above (if required)?
