### PR TITLE
gh-1078: Add running on gpu page to docs

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -6,6 +6,7 @@ User guide
    :maxdepth: 2
 
    how-glass-works
+   running-on-gpu
    publications
    bibliography
    definitions

--- a/docs/user/running-on-gpu.rst
+++ b/docs/user/running-on-gpu.rst
@@ -1,0 +1,21 @@
+==============
+Running on GPU
+==============
+
+GLASS is fully [Python Array API](https://data-apis.org/array-api/latest/)
+compatible as of version
+[v2026.2](https://github.com/glass-dev/glass/releases/tag/v2026.2). Thus, it is
+possible to pass arrays from any Array API compatible backends. Therefore,
+running GLASS on GPU is as simple as selecting an array backend which is both
+Array API compatible and GPU enabled. For example, by if JAX is installed with
+the relevant optional dependencies it will by default utilise any GPU devices
+it has available.
+
+Unfortunately, we have found that this does not necessarily mean running GLASS
+with GPU enabled JAX will give an immediate performance boost. The performance
+gains, or as is often the case, degradations of runnign GLASS on GPU depends on
+many factors including the size of the problem and the accelerator architecture
+available.
+
+For examples of running GLASS on GPU, check out our
+[benchmarks](https://github.com/glass-dev/glass/tree/main/benchmarks).

--- a/docs/user/running-on-gpu.rst
+++ b/docs/user/running-on-gpu.rst
@@ -2,9 +2,9 @@
 Running on GPU
 ==============
 
-GLASS is fully [Python Array API](https://data-apis.org/array-api/latest/)
+GLASS is fully `Python Array API <https://data-apis.org/array-api/latest/>`_
 compatible as of version
-[v2026.2](https://github.com/glass-dev/glass/releases/tag/v2026.2). Thus, it is
+`v2026.2 <https://github.com/glass-dev/glass/releases/tag/v2026.2>`_. Thus, it is
 possible to pass arrays from any Array API compatible backends. Therefore,
 running GLASS on GPU is as simple as selecting an array backend which is both
 Array API compatible and GPU enabled. For example, by if JAX is installed with
@@ -13,9 +13,9 @@ it has available.
 
 Unfortunately, we have found that this does not necessarily mean running GLASS
 with GPU enabled JAX will give an immediate performance boost. The performance
-gains, or as is often the case, degradations of runnign GLASS on GPU depends on
+gains, or as is often the case, degradations of running GLASS on GPU depends on
 many factors including the size of the problem and the accelerator architecture
 available.
 
 For examples of running GLASS on GPU, check out our
-[benchmarks](https://github.com/glass-dev/glass/tree/main/benchmarks).
+`benchmarks <https://github.com/glass-dev/glass/tree/main/benchmarks>`_.

--- a/docs/user/running-on-gpu.rst
+++ b/docs/user/running-on-gpu.rst
@@ -7,7 +7,7 @@ compatible as of version
 `v2026.2 <https://github.com/glass-dev/glass/releases/tag/v2026.2>`_. Thus, it is
 possible to pass arrays from any Array API compatible backends. Therefore,
 running GLASS on GPU is as simple as selecting an array backend which is both
-Array API compatible and GPU enabled. For example, by if JAX is installed with
+Array API compatible and GPU enabled. For example, if JAX is installed with
 the relevant optional dependencies it will by default utilise any GPU devices
 it has available.
 


### PR DESCRIPTION
# Description

- Adds a page to the docs about running glass on GPU

Closes: #1078 

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [x] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
