### PR TITLE
gh-1172: Test to see regression tests run from a fork

### DIFF
--- a/tests/regression/test_galaxies.py
+++ b/tests/regression/test_galaxies.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.stable
-def test_redshifts(
+def test_redshifts_demo(
     benchmark: BenchmarkFixture,
     urng: UnifiedGenerator,
     xp: ModuleType,


### PR DESCRIPTION
This is a temporary PR to check that the regression tests can now be run by a fork.