### PR TITLE
gh-930: Make the regressions pass if func is missing on `main`

### DIFF
--- a/tests/regression/test_arraytools.py
+++ b/tests/regression/test_arraytools.py
@@ -6,12 +6,15 @@ import pytest
 
 import array_api_extra as xpx
 
-import glass.arraytools
-
 if TYPE_CHECKING:
     from types import ModuleType
 
     from pytest_benchmark.fixture import BenchmarkFixture
+
+glass_arraytools = pytest.importorskip(
+    "glass.arraytools",
+    reason="tests require glass.arraytools",
+)
 
 
 @pytest.mark.unstable
@@ -28,7 +31,7 @@ def test_broadcast_leading_axes(
     c_in = xp.zeros(c_shape)
 
     dims, *rest = benchmark(
-        glass.arraytools.broadcast_leading_axes,
+        glass_arraytools.broadcast_leading_axes,
         (a_in, 0),
         (b_in, 1),
         (c_in, 2),
@@ -52,7 +55,7 @@ def test_cumulative_trapezoid_1d(
     f = xp.arange(scaled_length + 1)[1:]  # [1, 2, 3, 4,...]
     x = xp.arange(scaled_length)  # [0, 1, 2, 3,...]
 
-    ct = benchmark(glass.arraytools.cumulative_trapezoid, f, x)
+    ct = benchmark(glass_arraytools.cumulative_trapezoid, f, x)
 
     # Compare to int64 as old versions of glass round to int64 if `dtype` is not passed.
     xpx.testing.assert_equal(
@@ -78,7 +81,7 @@ def test_cumulative_trapezoid_2d(
     )
     x = xp.arange(scaled_length)  # [0, 1, 2, 3,...]
 
-    ct = benchmark(glass.arraytools.cumulative_trapezoid, f, x)
+    ct = benchmark(glass_arraytools.cumulative_trapezoid, f, x)
 
     expected_first_4_out = xp.asarray([0, 1, 4, 7])
 

--- a/tests/regression/test_arraytools.py
+++ b/tests/regression/test_arraytools.py
@@ -17,6 +17,10 @@ glass_arraytools = pytest.importorskip(
 )
 
 
+@pytest.mark.skipif(
+    not hasattr(glass_arraytools, "broadcast_leading_axes"),
+    reason="glass.arraytools.broadcast_leading_axes not implemented",
+)
 @pytest.mark.unstable
 def test_broadcast_leading_axes(
     benchmark: BenchmarkFixture,
@@ -44,6 +48,10 @@ def test_broadcast_leading_axes(
     assert c_out.shape == (c_shape[0], b_shape[0], c_shape[2], c_shape[3])
 
 
+@pytest.mark.skipif(
+    not hasattr(glass_arraytools, "cumulative_trapezoid"),
+    reason="glass.arraytools.cumulative_trapezoid not implemented",
+)
 @pytest.mark.unstable
 def test_cumulative_trapezoid_1d(
     benchmark: BenchmarkFixture,
@@ -65,6 +73,10 @@ def test_cumulative_trapezoid_1d(
     assert ct.shape == (scaled_length,)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass_arraytools, "cumulative_trapezoid"),
+    reason="glass.arraytools.cumulative_trapezoid not implemented",
+)
 @pytest.mark.unstable
 def test_cumulative_trapezoid_2d(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -26,6 +26,10 @@ glass_fields = pytest.importorskip(
 )
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "iternorm"),
+    reason="glass.iternorm not implemented",
+)
 @pytest.mark.stable
 def test_iternorm_no_size(
     benchmark: BenchmarkFixture,
@@ -44,6 +48,10 @@ def test_iternorm_no_size(
     assert len(result) == len(array_in)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "iternorm"),
+    reason="glass.iternorm not implemented",
+)
 @pytest.mark.stable
 @pytest.mark.parametrize("num_dimensions", [1, 2])
 def test_iternorm_specify_size(
@@ -67,6 +75,10 @@ def test_iternorm_specify_size(
     assert len(result) == len(array_in)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "iternorm"),
+    reason="glass.iternorm not implemented",
+)
 @pytest.mark.stable
 def test_iternorm_k_0(
     benchmark: BenchmarkFixture,
@@ -85,6 +97,10 @@ def test_iternorm_k_0(
     assert len(result) == len(array_in)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "cls2cov"),
+    reason="glass.cls2cov not implemented",
+)
 @pytest.mark.stable
 def test_cls2cov(
     benchmark: BenchmarkFixture,
@@ -115,6 +131,10 @@ def test_cls2cov(
     xpx.testing.assert_equal(cov[:, 2], xp.asarray(0.0), check_shape=False)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass_fields, "_generate_grf"),
+    reason="glass.fields._generate_grf not implemented",
+)
 @pytest.mark.stable
 @pytest.mark.parametrize("use_rng", [False, True])
 @pytest.mark.parametrize("ncorr", [None, 1])
@@ -149,6 +169,10 @@ def test_generate_grf(  # noqa: PLR0913
     assert gaussian_fields[0].shape == (hp.nside2npix(nside),)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "generate"),
+    reason="glass.generate not implemented",
+)
 @pytest.mark.stable
 @pytest.mark.parametrize("ncorr", [None, 1])
 def test_generate(
@@ -183,6 +207,10 @@ def test_generate(
         assert field.shape == (hp.nside2npix(nside),)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "getcl"),
+    reason="glass.getcl not implemented",
+)
 @pytest.mark.unstable
 def test_getcl_lmax_0(
     benchmark: BenchmarkFixture,
@@ -213,6 +241,10 @@ def test_getcl_lmax_0(
     xpx.testing.assert_equal(result, expected)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "getcl"),
+    reason="glass.getcl not implemented",
+)
 @pytest.mark.unstable
 def test_getcl_lmax_larger_than_cls(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -8,7 +8,6 @@ import pytest
 import array_api_extra as xpx
 
 import glass
-import glass.fields
 import glass.healpix as hp
 
 if TYPE_CHECKING:

--- a/tests/regression/test_fields.py
+++ b/tests/regression/test_fields.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
     from glass._types import AngularPowerSpectra, UnifiedGenerator
     from tests.fixtures.helper_classes import GeneratorConsumer
 
+glass_fields = pytest.importorskip(
+    "glass.fields",
+    reason="tests require glass.fields",
+)
+
 
 @pytest.mark.stable
 def test_iternorm_no_size(
@@ -131,7 +136,7 @@ def test_generate_grf(  # noqa: PLR0913
     nside = 32
 
     def function_to_benchmark() -> list[Any]:
-        generator = glass.fields._generate_grf(
+        generator = glass_fields._generate_grf(
             gls,
             nside,
             rng=urng if use_rng else None,

--- a/tests/regression/test_galaxies.py
+++ b/tests/regression/test_galaxies.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from glass._types import UnifiedGenerator
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "redshifts"),
+    reason="glass.redshifts not implemented",
+)
 @pytest.mark.stable
 def test_redshifts(
     benchmark: BenchmarkFixture,
@@ -34,6 +38,10 @@ def test_redshifts(
     assert xp.max(z) <= 1.0
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "redshifts_from_bins"),
+    reason="glass.redshifts_from_bins not implemented",
+)
 @pytest.mark.stable
 def test_redshifts_from_bins(
     benchmark: BenchmarkFixture,
@@ -65,6 +73,10 @@ def test_redshifts_from_bins(
     assert redshifts.shape == bins.shape
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "redshifts_from_nz"),
+    reason="glass.redshifts_from_nz not implemented",
+)
 @pytest.mark.stable
 def test_redshifts_from_nz(
     benchmark: BenchmarkFixture,
@@ -92,6 +104,10 @@ def test_redshifts_from_nz(
     assert xp.all((redshifts >= 0) & (redshifts <= 1))
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "galaxy_shear"),
+    reason="glass.galaxy_shear not implemented",
+)
 @pytest.mark.unstable
 @pytest.mark.parametrize("reduced_shear", [True, False])
 def test_galaxy_shear(
@@ -124,6 +140,10 @@ def test_galaxy_shear(
     assert shear.shape == gal_size
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "gaussian_phz"),
+    reason="glass.gaussian_phz not implemented",
+)
 @pytest.mark.stable
 def test_gaussian_phz(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_harmonics.py
+++ b/tests/regression/test_harmonics.py
@@ -17,6 +17,10 @@ glass_harmonics = pytest.importorskip(
 )
 
 
+@pytest.mark.skipif(
+    not hasattr(glass_harmonics, "multalm"),
+    reason="glass.harmonics.multalm not implemented",
+)
 @pytest.mark.unstable
 def test_multalm(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_harmonics.py
+++ b/tests/regression/test_harmonics.py
@@ -6,16 +6,15 @@ import pytest
 
 import array_api_extra as xpx
 
-glass_harmonics = pytest.importorskip(
-    "glass.harmonics",
-    reason="tests require glass.harmonics",
-)
-
-
 if TYPE_CHECKING:
     from types import ModuleType
 
     from pytest_benchmark.fixture import BenchmarkFixture
+
+glass_harmonics = pytest.importorskip(
+    "glass.harmonics",
+    reason="tests require glass.harmonics",
+)
 
 
 @pytest.mark.unstable

--- a/tests/regression/test_lensing.py
+++ b/tests/regression/test_lensing.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
     from glass.cosmology import Cosmology
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "multi_plane_matrix"),
+    reason="glass.multi_plane_matrix not implemented",
+)
 @pytest.mark.stable
 def test_multi_plane_matrix(
     benchmark: BenchmarkFixture,
@@ -76,6 +80,10 @@ def test_multi_plane_matrix(
         assert x is not None
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "multi_plane_weights"),
+    reason="glass.multi_plane_weights not implemented",
+)
 @pytest.mark.stable
 def test_multi_plane_weights(
     benchmark: BenchmarkFixture,

--- a/tests/regression/test_points.py
+++ b/tests/regression/test_points.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
     )
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "positions_from_delta"),
+    reason="glass.positions_from_delta not implemented",
+)
 @pytest.mark.stable
 @pytest.mark.parametrize(
     ("bias", "bias_model"),
@@ -68,6 +72,10 @@ def test_positions_from_delta(  # noqa: PLR0913
     assert lat.shape == (xp.sum(count),)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "uniform_positions"),
+    reason="glass.uniform_positions not implemented",
+)
 @pytest.mark.stable
 def test_uniform_positions(
     benchmark: BenchmarkFixture,
@@ -75,7 +83,7 @@ def test_uniform_positions(
     generator_consumer: type[GeneratorConsumer],
     xp: ModuleType,
 ) -> None:
-    """Regression tests for glass.uniform_positionsuniform_positions."""
+    """Regression tests for glass.uniform_positions."""
     scaling_factor = 12
     shape_ngal = (int(scaling_factor / 2), 2)
 
@@ -97,6 +105,10 @@ def test_uniform_positions(
     assert lon.shape == lat.shape == (xp.sum(count),)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "displace"),
+    reason="glass.displace not implemented",
+)
 @pytest.mark.parametrize(
     ("r_to_alpha"),
     [
@@ -105,10 +117,6 @@ def test_uniform_positions(
         # Real
         (lambda r: [r, 0]),
     ],
-)
-@pytest.mark.skipif(
-    not hasattr(glass, "displace"),
-    reason="test requires glass.displace",
 )
 def test_displace(
     benchmark: BenchmarkFixture,
@@ -136,11 +144,11 @@ def test_displace(
     assert lat.shape == (scale_length,)
 
 
-@pytest.mark.stable
 @pytest.mark.skipif(
     not hasattr(glass, "displacement"),
-    reason="test requires glass.displacement",
+    reason="glass.displacement not implemented",
 )
+@pytest.mark.stable
 def test_displacement(
     benchmark: BenchmarkFixture,
     urng: UnifiedGenerator,

--- a/tests/regression/test_shapes.py
+++ b/tests/regression/test_shapes.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from glass._types import UnifiedGenerator
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "ellipticity_ryden04"),
+    reason="glass.ellipticity_ryden04 not implemented",
+)
 @pytest.mark.stable
 def test_ellipticity_ryden04(
     benchmark: BenchmarkFixture,
@@ -33,6 +37,10 @@ def test_ellipticity_ryden04(
     assert e.shape == size
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "ellipticity_gaussian"),
+    reason="glass.ellipticity_gaussian not implemented",
+)
 @pytest.mark.stable
 def test_ellipticity_gaussian(
     benchmark: BenchmarkFixture,
@@ -53,6 +61,10 @@ def test_ellipticity_gaussian(
     assert eps.shape == (n * array_length,)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "ellipticity_intnorm"),
+    reason="glass.ellipticity_intnorm not implemented",
+)
 @pytest.mark.stable
 def test_ellipticity_intnorm(
     benchmark: BenchmarkFixture,
@@ -73,6 +85,10 @@ def test_ellipticity_intnorm(
     assert eps.shape == (n * array_length,)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "resample_shapes"),
+    reason="glass.resample_shapes not implemented",
+)
 @pytest.mark.stable
 @pytest.mark.parametrize(
     ("varg", "vargamma"),

--- a/tests/regression/test_shells.py
+++ b/tests/regression/test_shells.py
@@ -14,12 +14,16 @@ if TYPE_CHECKING:
     from pytest_benchmark.fixture import BenchmarkFixture
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "RadialWindow"),
+    reason="glass.RadialWindow not implemented",
+)
 @pytest.mark.unstable
 def test_radialwindow(
     benchmark: BenchmarkFixture,
     xp: ModuleType,
 ) -> None:
-    """Regression test for shells.RadialWindow."""
+    """Regression test for glass.RadialWindow."""
     # check zeff is computed when not provided
     arr_length = 100_000
     expected_zeff = xp.asarray(66_666.0)
@@ -32,11 +36,15 @@ def test_radialwindow(
     xpx.testing.assert_close(w.zeff, expected_zeff)
 
 
+@pytest.mark.skipif(
+    not hasattr(glass, "distribute"),
+    reason="glass.distribute not implemented",
+)
 def test_distribute(
     benchmark: BenchmarkFixture,
     xp: ModuleType,
 ) -> None:
-    """Regression test for distribute() over a moderately-sized catalogue."""
+    """Regression test for glass.distribute over a moderately-sized catalogue."""
     # use N shells; tens is a good number
     shells = glass.linear_windows(xp.linspace(0.0, 3.0, 52))
     assert len(shells) == 50


### PR DESCRIPTION
# Description

When a new function is added with a regression test, i.e. https://github.com/glass-dev/glass/pull/1138, the regression test will always fail in that PR. This isn't particularly helpful and could hide a real failure caused by the PR if people don't look. The idea behind this PR is to make sure that all regression tests are skipped if a given function/module doesn't exist. All future regression tests should follow the same format.

<!-- for user facing bugs -->
Fixes: #930

<!-- for other issues -->
<!-- Closes: # (issue) -->

<!-- referring some issue -->
<!-- Refs: # (issue) -->

## Changelog entry

Fixed: Regression tests will no longer fail when a new function is added

## Checks

- [x] Is your code passing linting?
- [x] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [x] Have you added a one-liner changelog entry above (if required)?
