### PR TITLE
gh-1173: Rename `default_rng` tests

### DIFF
--- a/tests/core/test_array_api_utils.py
+++ b/tests/core/test_array_api_utils.py
@@ -15,13 +15,13 @@ HAVE_ARRAY_API_STRICT = importlib.util.find_spec("array_api_strict") is not None
 HAVE_JAX = importlib.util.find_spec("jax") is not None
 
 
-def test_rng_dispatcher_numpy() -> None:
+def test_default_rng_numpy() -> None:
     rng = glass.rng.default_rng(xp=np)
     assert isinstance(rng, np.random.Generator)
 
 
 @pytest.mark.skipif(not HAVE_JAX, reason="test requires jax")
-def test_rng_dispatcher_jax() -> None:
+def test_default_rng_jax() -> None:
     import jax.numpy as jnp
 
     rng = glass.rng.default_rng(xp=jnp)
@@ -29,7 +29,7 @@ def test_rng_dispatcher_jax() -> None:
 
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT, reason="test requires array_api_strict")
-def test_rng_dispatcher_array_api_strict() -> None:
+def test_default_rng_array_api_strict() -> None:
     import array_api_strict
 
     rng = glass.rng.default_rng(xp=array_api_strict)


### PR DESCRIPTION
# Description

Spotted that the test names hadn't been changed to reflect that change with `default_rng` function.

<!-- for user facing bugs -->
<!-- Fixes: # (issue) -->

<!-- for other issues -->
Closes: #1173

<!-- referring some issue -->
<!-- Refs: # (issue) -->

<!-- add a one liner changelog entry here if this PR makes any user-facing change
## Changelog entry

Added: Some new feature
Changed: Some change in existing functionality
Deprecated: Some soon-to-be removed feature
Removed: Some now removed feature
Fixed: Some bug fix
Security: Some vulnerability was fixed
-->

## Checks

- [X] Is your code passing linting?
- [X] Is your code passing tests?
- [ ] Have you added additional tests (if required)?
- [ ] Have you modified/extended the documentation (if required)?
- [ ] Have you added a one-liner changelog entry above (if required)?
